### PR TITLE
fix: onRender wasn't fired right in unmount phase

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -615,9 +615,11 @@ export const createFiberVisitor = ({
     }
 
     const { prevFiber } = rootInstance;
-
     try {
-      if (prevFiber !== null) {
+      // if fiberNode don't have current instance, means it's been unmounted
+      if (!rootFiber) {
+        unmountFiber(onRender, root);
+      } else if (prevFiber !== null) {
         const wasMounted =
           prevFiber &&
           prevFiber.memoizedState != null &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -377,7 +377,7 @@ export const getRDTHook = () => {
       renderers.set(nextID, renderer);
       return nextID;
     },
-    instrumentation: 'bippy',
+    _instrumentationSource: 'bippy',
   };
   try {
     // sometimes this is a getter

--- a/src/index.ts
+++ b/src/index.ts
@@ -616,7 +616,7 @@ export const createFiberVisitor = ({
 
     const { prevFiber } = rootInstance;
     try {
-      // if fiberNode don't have current instance, means it's been unmounted
+      // if fiberRoot don't have current instance, means it's been unmounted
       if (!rootFiber) {
         unmountFiber(onRender, root);
       } else if (prevFiber !== null) {


### PR DESCRIPTION
The original code in `createFiberVisitor` access the `FirberRoot.current`
https://github.com/aidenybai/bippy/blob/8e9da0f0993dabbe31c0e3070cb6589c4b7dd38d/src/index.ts#L606
but the instance which `onCommitFiberUnmount` callback doesn't contain `.current` which means it's been unmounted


![image](https://github.com/user-attachments/assets/8bbc9be3-4618-4ae5-9e0e-7397699c3e42)

after change the logic, the `onRender` can log the unmount phase, use the code below:

```tsx
const visitor = createFiberVisitor({
  onRender(fiber, phase) {
    // the example code in README
    console.log(phase, render);
  }
});

export default function App() {
  const [count, setCount] = useState(0);
  const [show, setShow] = useState(true);
  const renderInfo = getRenderInfo(App);

  useEffect(() => {
    const timer = setTimeout(() => {
      setShow(false);
    }, 3000);
    return () => {
      clearTimeout(timer);
    };
  }, []);

  return (
    <Fragment>
      {show ? <Child /> : null}
    </Fragment>
  );
}
```

![image](https://github.com/user-attachments/assets/d19b29e9-3d88-4e62-9509-fa47272af74a)


