### PR TITLE
chore: union keys over entire object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 .env
 dist
+**/*.tgz

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,13 @@ export const traverseProps = (
   try {
     const nextProps = fiber.memoizedProps;
     const prevProps = fiber.alternate?.memoizedProps || {};
-    for (const propName in { ...prevProps, ...nextProps }) {
+
+    const allKeys = new Set([
+      ...Object.keys(prevProps),
+      ...Object.keys(nextProps),
+    ]);
+
+    for (const propName of allKeys) {
       const prevValue = prevProps?.[propName];
       const nextValue = nextProps?.[propName];
 


### PR DESCRIPTION
`Object.assign({}, prevProps, nextProps)`
vs
`{...prev1, prev2}`
vs
`new Set([
      ...Object.keys(prevProps),
      ...Object.keys(nextProps),
])`


So roughly 2x speed up


```
Size | Object.assign  | Spread          | Set of Keys
 -----------------------------------------------------
10    | 0.0003          | 0.0007          | 0.0009
100   | 0.0018          | 0.0051          | 0.0070
1000  | 0.0285          | 0.1048          | 0.0352
5000  | 0.9105          | 0.8052          | 0.3841
10000 | 2.6475          | 2.4428          | 1.1896
```