### PR TITLE
Fix `Fiber` type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -104,7 +104,7 @@ export type Fiber<T = any> = Omit<
 	| "updateQueue"
 > & {
 	stateNode: T;
-	dependencies: Dependencies;
+	dependencies: Dependencies | null;
 	child: Fiber | null;
 	sibling: Fiber | null;
 	return: Fiber | null;


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/54b615353ec7f8b50167859558a7d321dd8f7a37/types/react-reconciler/index.d.ts#L746

Currently we have `dependencies` as `Dependencies`