### PR TITLE
feat(core): enter & leave traverse handlers

### DIFF
--- a/setup-test.ts
+++ b/setup-test.ts
@@ -1,0 +1,1 @@
+import './src/rdt-hook';

--- a/src/core.test.tsx
+++ b/src/core.test.tsx
@@ -1,0 +1,49 @@
+import type React from 'react';
+import { render, type RenderOptions } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { instrument, traverseFiber } from './core.js';
+import type { FiberRoot } from './types.js';
+
+describe('traverseFiber', () => {
+  const onCommitFiberRoot = vi.fn();
+  instrument({ onCommitFiberRoot });
+
+  const renderWithFiber = (ui: React.ReactNode, options?: RenderOptions) => {
+    const result = render(ui, options);
+    const fiber: FiberRoot = onCommitFiberRoot.mock.lastCall?.[1];
+    return { ...result, fiber };
+  };
+
+  const { fiber } = renderWithFiber(
+    <div key="root">
+      <div key="a">
+        <div key="a1" />
+        <div key="a2" />
+      </div>
+      <div key="b" />
+      <div key="c" />
+      <div key="d">
+        <div key="d1">
+          <div key="d11" />
+        </div>
+      </div>
+    </div>,
+  );
+
+  it('should traverse a fiber', () => {
+    const handler = vi.fn();
+    traverseFiber(fiber.current, fiber => handler(fiber.key));
+    const keys = handler.mock.calls.map(call => call[0]).slice(1);
+    const expected = ['root', 'a', 'a1', 'a2', 'b', 'c', 'd', 'd1', 'd11'];
+    expect(keys).toEqual(expected);
+  });
+
+  it('should traverse a fiber in reverse', () => {
+    const handler = vi.fn();
+    const d11 = traverseFiber(fiber.current, fiber => fiber.key === 'd11');
+    expect(d11?.key).toBe('d11');
+    traverseFiber(d11, fiber => handler(fiber.key), true);
+    const keys = handler.mock.calls.map(call => call[0]).slice(0, -1);
+    expect(keys).toEqual(['d11', 'd1', 'd', 'root']);
+  });
+});

--- a/src/core.test.tsx
+++ b/src/core.test.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { render, type RenderOptions } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { instrument, traverseFiber } from './core.js';
-import type { FiberRoot } from './types.js';
+import type { Fiber, FiberRoot } from './types.js';
 
 describe('traverseFiber', () => {
   const onCommitFiberRoot = vi.fn();
@@ -31,19 +31,108 @@ describe('traverseFiber', () => {
   );
 
   it('should traverse a fiber', () => {
-    const handler = vi.fn();
-    traverseFiber(fiber.current, fiber => handler(fiber.key));
-    const keys = handler.mock.calls.map(call => call[0]).slice(1);
-    const expected = ['root', 'a', 'a1', 'a2', 'b', 'c', 'd', 'd1', 'd11'];
-    expect(keys).toEqual(expected);
+    const order: string[] = [];
+    traverseFiber(fiber.current, fiber => {
+      fiber.key && order.push(fiber.key);
+    });
+    expect(order).toEqual([
+      'root',
+      'a',
+      'a1',
+      'a2',
+      'b',
+      'c',
+      'd',
+      'd1',
+      'd11',
+    ]);
   });
 
   it('should traverse a fiber in reverse', () => {
-    const handler = vi.fn();
+    const order: string[] = [];
     const d11 = traverseFiber(fiber.current, fiber => fiber.key === 'd11');
     expect(d11?.key).toBe('d11');
-    traverseFiber(d11, fiber => handler(fiber.key), true);
-    const keys = handler.mock.calls.map(call => call[0]).slice(0, -1);
-    expect(keys).toEqual(['d11', 'd1', 'd', 'root']);
+
+    traverseFiber(
+      d11,
+      fiber => {
+        fiber.key && order.push(fiber.key);
+      },
+      true,
+    );
+    expect(order).toEqual(['d11', 'd1', 'd', 'root']);
+  });
+
+  it('should traverse a fiber with entry and leave handlers', () => {
+    const enterOrder: string[] = [];
+    const leaveOrder: string[] = [];
+    traverseFiber(fiber.current, {
+      enter: fiber => {
+        fiber.key && enterOrder.push(fiber.key);
+      },
+      leave: fiber => {
+        fiber.key && leaveOrder.push(fiber.key);
+      },
+    });
+    expect(enterOrder).toEqual([
+      'root',
+      'a',
+      'a1',
+      'a2',
+      'b',
+      'c',
+      'd',
+      'd1',
+      'd11',
+    ]);
+    expect(leaveOrder).toEqual([
+      'a1',
+      'a2',
+      'a',
+      'b',
+      'c',
+      'd11',
+      'd1',
+      'd',
+      'root',
+    ]);
+  });
+
+  it('should traverse a fiber with entry and leave handlers in reverse', () => {
+    const d11 = traverseFiber(fiber.current, fiber => fiber.key === 'd11');
+    expect(d11?.key).toBe('d11');
+
+    const enterOrder: string[] = [];
+    const leaveOrder: string[] = [];
+    traverseFiber(d11, {
+      ascending: true,
+      enter: fiber => {
+        fiber.key && enterOrder.push(fiber.key);
+      },
+      leave: fiber => {
+        fiber.key && leaveOrder.push(fiber.key);
+      },
+    });
+    expect(enterOrder).toEqual(['d11', 'd1', 'd', 'root']);
+    expect(leaveOrder).toEqual(['root', 'd', 'd1', 'd11']);
+  });
+
+  it('should traverse a fiber and get stack', () => {
+    const stack: Fiber[] = [];
+    traverseFiber(fiber.current, {
+      enter: fiber => {
+        if (fiber.key === 'd11') {
+          const keys = stack.map(fiber => fiber.key).filter(Boolean);
+          expect(keys).toEqual(['root', 'd', 'd1']);
+        }
+
+        stack.push(fiber);
+      },
+      leave: fiber => {
+        const last = stack.pop();
+        expect(last).toBe(fiber);
+      },
+    });
+    expect(stack).toEqual([]);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"jsx": "react",
+		"jsx": "react-jsx",
 		"module": "NodeNext",
 		"esModuleInterop": true,
 		"strictNullChecks": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
 			reporter: ["text", "json", "html"],
 			include: ["src/*.ts"],
 		},
+		setupFiles: ["./setup-test.ts"],
 	},
 });


### PR DESCRIPTION
https://github.com/aidenybai/bippy/issues/18

@aidenybai I have refactored the `traverseFiber` into stack-based implementation and can accept an object syntax with enter & leave handlers. But it can also accept the previous selector handler as an enter handler.

I changed the jsx option from `react` to `react-jsx` for resolving some biome warnings. But it might be bring some compatiable issues to applications with legacy jsx runtime react version. Not sure is it acceptable.

This pull request includes several changes to the testing setup and the `traverseFiber` function. The most important changes involve adding new tests for `traverseFiber`, enhancing the `traverseFiber` function, and updating the test configuration.

### Enhancements to `traverseFiber` function:

* [`src/core.ts`](diffhunk://#diff-033ecd338eec0994fe53c0896219baee901e20068b8fbe6259a23d5759584b06R439-R525): Introduced `FiberSelector` type and `TraverseFiberOptions` interface to improve the flexibility of the `traverseFiber` function. The function now supports both entry and leave handlers and can traverse the fiber tree in ascending order.

### New tests for `traverseFiber`:

* [`src/core.test.tsx`](diffhunk://#diff-c6a3a333ec4fbd5c75375889d39a76fe807f3244d05c4e6710727b5ac8cbd5fdR1-R138): Added comprehensive tests for the `traverseFiber` function, including tests for traversing in both directions, handling entry and leave events, and verifying stack behavior.

### Updates to testing setup:

* [`setup-test.ts`](diffhunk://#diff-08aece9beebe3703df39bc21a6100eb4145efb613967666e78a7f398020f1978R1): Added an import for `./src/rdt-hook` to the test setup file.
* [`vitest.config.ts`](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92R10): Updated the test configuration to include `setupFiles` pointing to `./setup-test.ts`.