### PR TITLE
fix: fiber stack sequence

### DIFF
--- a/packages/bippy/src/core.ts
+++ b/packages/bippy/src/core.ts
@@ -338,11 +338,7 @@ export const getFiberStack = (fiber: Fiber): Fiber[] => {
     stack.push(currentFiber);
     currentFiber = currentFiber.return;
   }
-  const newStack = new Array(stack.length);
-  for (let i = 0; i < stack.length; i++) {
-    newStack[i] = stack[stack.length - i - 1];
-  }
-  return newStack;
+  return stack;
 };
 
 /**

--- a/packages/bippy/src/test/core/fiber.test.tsx
+++ b/packages/bippy/src/test/core/fiber.test.tsx
@@ -1,20 +1,23 @@
+
 import { describe, expect, it } from 'vitest';
-import type { Fiber } from '../../types.js';
 import {
-  isValidFiber,
-  isHostFiber,
-  isCompositeFiber,
-  didFiberRender,
   didFiberCommit,
-  getMutatedHostFibers,
+  didFiberRender,
+  getFiberFromHostInstance,
   getFiberStack,
+  getMutatedHostFibers,
   getNearestHostFiber,
   getNearestHostFibers,
   getTimings,
-  traverseFiber,
-  getFiberFromHostInstance,
   instrument,
+  isCompositeFiber,
+  isHostFiber,
+  isValidFiber,
+  traverseFiber,
 } from '../../index.js';
+import type { Fiber } from '../../types.js';
+// FIXME(Alexis): Both React and @testing-library/react should be after index.js
+// but the linter/import sorter keeps moving them on top
 // biome-ignore lint/correctness/noUnusedImports: needed for JSX
 import React from 'react';
 import { render, screen } from '@testing-library/react';
@@ -185,8 +188,8 @@ describe('getFiberStack', () => {
       onCommitFiberRoot: (_rendererID, fiberRoot) => {
         manualFiberStack = [];
         maybeFiber = fiberRoot.current.child.child;
-        manualFiberStack.push(fiberRoot.current.child);
         manualFiberStack.push(fiberRoot.current.child.child);
+        manualFiberStack.push(fiberRoot.current.child);
       },
     });
     render(


### PR DESCRIPTION
`getFiberStack` currently returns the fiber stack in reverse order, contrary to what the comment mentions (it should start from the target fiber up to the root, but currently it is from the root down to the target fiber)

Luckily, react-scan doesn't use this yet.