### PR TITLE
Rework source map

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,10 +11,17 @@
     "ignore": ["*.gen.ts", "node_modules", "dist", "coverage"]
   },
   "formatter": {
+    "enabled": true,
     "indentStyle": "space",
     "indentWidth": 2,
     "lineWidth": 80,
     "lineEnding": "lf"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "all"
+    }
   },
   "organizeImports": {
     "enabled": true
@@ -51,11 +58,6 @@
           "fix": "unsafe"
         }
       }
-    }
-  },
-  "javascript": {
-    "formatter": {
-      "quoteStyle": "single"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "sherif": "^1.2.0"
   },
   "dependencies": {
-    "source-map": "^0.7.4"
+    "@biomejs/biome": "^1.9.4"
   }
 }

--- a/packages/bippy/package.json
+++ b/packages/bippy/package.json
@@ -1,125 +1,127 @@
 {
-	"name": "bippy",
-	"version": "0.2.24",
-	"description": "hack into react internals",
-	"keywords": [
-		"bippy",
-		"react",
-		"react-instrumentation",
-		"react instrumentation",
-		"fiber",
-		"internals"
-	],
-	"homepage": "https://bippy.dev",
-	"bugs": {
-		"url": "https://github.com/aidenybai/bippy/issues"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/aidenybai/bippy.git"
-	},
-	"license": "MIT",
-	"author": {
-		"name": "Aiden Bai",
-		"email": "aiden@million.dev"
-	},
-	"sideEffects": false,
-	"type": "module",
-	"exports": {
-		"./package.json": "./package.json",
-		".": {
-			"import": {
-				"types": "./dist/index.d.ts",
-				"default": "./dist/index.js"
-			},
-			"require": {
-				"types": "./dist/index.d.cts",
-				"default": "./dist/index.cjs"
-			}
-		},
-		"./core": {
-			"import": {
-				"types": "./dist/core.d.ts",
-				"default": "./dist/core.js"
-			},
-			"require": {
-				"types": "./dist/core.d.cts",
-				"default": "./dist/core.cjs"
-			}
-		},
-		"./sw": {
-			"import": {
-				"types": "./dist/sw.d.ts",
-				"default": "./dist/sw.js"
-			},
-			"require": {
-				"types": "./dist/sw.d.cts",
-				"default": "./dist/sw.cjs"
-			}
-		},
-		"./experiments/inspect": {
-			"import": {
-				"types": "./dist/experiments/inspect.d.ts",
-				"default": "./dist/experiments/inspect.js"
-			},
-			"require": {
-				"types": "./dist/experiments/inspect.d.cts",
-				"default": "./dist/experiments/inspect.cjs"
-			}
-		},
-		"./dist/*": "./dist/*.js",
-		"./dist/*.js": "./dist/*.js",
-		"./dist/*.cjs": "./dist/*.cjs",
-		"./dist/*.mjs": "./dist/*.mjs"
-	},
-	"main": "dist/index.js",
-	"module": "dist/index.js",
-	"browser": "dist/index.global.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist",
-		"bin",
-		"package.json",
-		"README.md",
-		"LICENSE"
-	],
-	"scripts": {
-		"build": "NODE_ENV=production tsup",
-		"dev": "NODE_ENV=development tsup --watch",
-		"publint": "publint",
-		"test": "vitest",
-		"coverage": "vitest run --coverage",
-		"prepublishOnly": "cp ../../README.md . && pnpm build"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "1.9.4",
-		"@testing-library/dom": "^10.4.0",
-		"@testing-library/react": "^16.1.0",
-		"@types/node": "^20",
-		"@types/react": "^19.0.4",
-		"@types/react-dom": "^19.0.2",
-		"@vitest/coverage-istanbul": "2.1.8",
-		"esbuild": "^0.24.2",
-		"happy-dom": "^15.11.7",
-		"pkg-pr-new": "^0.0.39",
-		"publint": "^0.2.12",
-		"react": "19.0.0",
-		"react-devtools-inline": "^6.0.1",
-		"react-dom": "19.0.0",
-		"react-inspector": "^6.0.2",
-		"react-reconciler": "^0.31.0",
-		"react-refresh": "^0.16.0",
-		"terser": "^5.36.0",
-		"tsup": "^8.2.4",
-		"vitest": "^2.1.8"
-	},
-	"publishConfig": {
-		"access": "public"
-	},
-	"peerDependencies": {
-		"react": ">=17.0.1"
-	},
-	"dependencies": {
-		"@types/react-reconciler": "^0.28.9"
-	}
+  "name": "bippy",
+  "version": "0.2.24",
+  "description": "hack into react internals",
+  "keywords": [
+    "bippy",
+    "react",
+    "react-instrumentation",
+    "react instrumentation",
+    "fiber",
+    "internals"
+  ],
+  "homepage": "https://bippy.dev",
+  "bugs": {
+    "url": "https://github.com/aidenybai/bippy/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aidenybai/bippy.git"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Aiden Bai",
+    "email": "aiden@million.dev"
+  },
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./core": {
+      "import": {
+        "types": "./dist/core.d.ts",
+        "default": "./dist/core.js"
+      },
+      "require": {
+        "types": "./dist/core.d.cts",
+        "default": "./dist/core.cjs"
+      }
+    },
+    "./sw": {
+      "import": {
+        "types": "./dist/sw.d.ts",
+        "default": "./dist/sw.js"
+      },
+      "require": {
+        "types": "./dist/sw.d.cts",
+        "default": "./dist/sw.cjs"
+      }
+    },
+    "./experiments/inspect": {
+      "import": {
+        "types": "./dist/experiments/inspect.d.ts",
+        "default": "./dist/experiments/inspect.js"
+      },
+      "require": {
+        "types": "./dist/experiments/inspect.d.cts",
+        "default": "./dist/experiments/inspect.cjs"
+      }
+    },
+    "./dist/*": "./dist/*.js",
+    "./dist/*.js": "./dist/*.js",
+    "./dist/*.cjs": "./dist/*.cjs",
+    "./dist/*.mjs": "./dist/*.mjs"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "browser": "dist/index.global.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "bin",
+    "package.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "NODE_ENV=production tsup",
+    "dev": "NODE_ENV=development tsup --watch",
+    "publint": "publint",
+    "test": "vitest",
+    "coverage": "vitest run --coverage",
+    "prepublishOnly": "cp ../../README.md . && pnpm build"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "1.9.4",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/react": "^16.1.0",
+    "@types/node": "^20",
+    "@types/react": "^19.0.4",
+    "@types/react-dom": "^19.0.2",
+    "@vitest/coverage-istanbul": "2.1.8",
+    "esbuild": "^0.24.2",
+    "happy-dom": "^15.11.7",
+    "pkg-pr-new": "^0.0.39",
+    "publint": "^0.2.12",
+    "react": "19.0.0",
+    "react-devtools-inline": "^6.0.1",
+    "react-dom": "19.0.0",
+    "react-inspector": "^6.0.2",
+    "react-reconciler": "^0.31.0",
+    "react-refresh": "^0.16.0",
+    "terser": "^5.36.0",
+    "tsup": "^8.2.4",
+    "vitest": "^2.1.8"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.1"
+  },
+  "dependencies": {
+    "@types/react-reconciler": "^0.28.9",
+    "error-stack-parser-es": "^1.0.5",
+    "source-map-js": "^1.2.1"
+  }
 }

--- a/packages/bippy/src/core.ts
+++ b/packages/bippy/src/core.ts
@@ -1,7 +1,9 @@
 // Note: do not import React in this file
 // since it will be executed before the react devtools hook is created
 
+import * as errorStackParser from 'error-stack-parser-es/lite';
 import type * as React from 'react';
+import { type RawSourceMap, SourceMapConsumer } from 'source-map-js';
 import {
   BIPPY_INSTRUMENTATION_STRING,
   getRDTHook,
@@ -480,9 +482,8 @@ export const getType = (type: unknown): React.ComponentType<unknown> | null => {
 /**
  * Returns the display name of the {@link Fiber}.
  */
-export const getDisplayName = (fiber: Fiber): string | null => {
-  if (typeof fiber.type === 'string') return fiber.type;
-  const currentType = fiber.type as FiberType;
+export const getDisplayName = (type: unknown): string | null => {
+  const currentType = type as FiberType;
   if (
     typeof currentType !== 'function' &&
     !(typeof currentType === 'object' && currentType)
@@ -555,10 +556,9 @@ export const getFiberId = (fiber: Fiber): number => {
 interface FiberSource {
   fileName: string;
   lineNumber: number;
-  columnNumber: number | undefined;
+  columnNumber: number;
 }
 
-const componentFrameCache = new Map<React.ComponentType<unknown>, string>();
 let reentry = false;
 
 const describeBuiltInComponentFrame = (name: string): string => {
@@ -584,271 +584,83 @@ const reenableLogs = (prev: {
   console.warn = prev.warn;
 };
 
-// VLQ encoding table
-const VLQ_BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-const VLQ_BASE64_VALUES = new Map(
-  [...VLQ_BASE64_CHARS].map((char, i) => [char, i])
-);
+const INLINE_SOURCEMAP_REGEX = /^data:application\/json[^,]+base64,/;
+const SOURCEMAP_REGEX =
+  /(?:\/\/[@#][ \t]+sourceMappingURL=([^\s'"]+?)[ \t]*$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^*]+?)[ \t]*(?:\*\/)[ \t]*$)/;
 
-// Decode a VLQ value
-const decodeVLQ = (str: string): [number, number] => {
-  let result = 0;
-  let shift = 0;
-  let consumed = 0;
+async function getSourceMap(url: string, content: string) {
+  const lines = content.split('\n');
+  let sourceMapUrl: string | undefined;
+  for (let i = lines.length - 1; i >= 0 && !sourceMapUrl; i--) {
+    const result = lines[i].match(SOURCEMAP_REGEX);
+    if (result) {
+      sourceMapUrl = result[1];
+    }
+  }
 
-  do {
-    if (consumed >= str.length) break;
-    const c = str[consumed];
-    const digit = VLQ_BASE64_VALUES.get(c);
-    if (digit === undefined) break;
-
-    // VLQ digits are 5 bits:
-    // 4 bits: value
-    // 1 bit: continuation
-    const value = digit & 31; // 31 = 00011111
-    const hasContinuation = digit & 32; // 32 = 00100000
-
-    result += value << shift;
-    shift += 5;
-    consumed++;
-
-    if (!hasContinuation) break;
-  } while (true);
-
-  // The least significant bit represents the sign
-  const shouldNegate = result & 1;
-  result >>>= 1;
-  return [shouldNegate ? -result : result, consumed];
-};
-
-// Parse sourcemap mappings to find original position
-const findOriginalPosition = (
-  mappings: string,
-  targetLine: number,
-  targetColumn: number
-): { line: number; column: number; sourceIndex: number } | null => {
-  let generatedLine = 1;
-  let generatedColumn = 0;
-  let sourceFileIndex = 0;
-  let originalLine = 0;
-  let originalColumn = 0;
-  let lastMatch = null;
-
-  // Previous state for relative mappings
-  let prevSourceFileIndex = 0;
-  let prevOriginalLine = 0;
-  let prevOriginalColumn = 0;
-
-  console.debug('[bippy] Finding position for line', targetLine, 'column', targetColumn);
-
-  const lines = mappings.split(';');
-  if (targetLine > lines.length) {
-    console.debug('[bippy] Target line', targetLine, 'is beyond mappings length', lines.length);
+  if (!sourceMapUrl) {
     return null;
   }
 
-  // Process lines until we find our target
-  for (const line of lines) {
-    // Reset column at start of each line
-    generatedColumn = 0;
-
-    if (!line) {
-      generatedLine++;
-      continue;
-    }
-
-    const segments = line.split(',');
-    for (const segment of segments) {
-      if (!segment) continue;
-
-      let index = 0;
-
-      // Parse each VLQ section
-      const [colDelta, len1] = decodeVLQ(segment.slice(index));
-      generatedColumn += colDelta;
-      index += len1;
-      if (index >= segment.length) continue;
-
-      const [srcIndexDelta, len2] = decodeVLQ(segment.slice(index));
-      sourceFileIndex = prevSourceFileIndex + srcIndexDelta;
-      index += len2;
-      if (index >= segment.length) continue;
-
-      const [lineDelta, len3] = decodeVLQ(segment.slice(index));
-      originalLine = prevOriginalLine + lineDelta;
-      index += len3;
-      if (index >= segment.length) continue;
-
-      const [colDelta2, len4] = decodeVLQ(segment.slice(index));
-      originalColumn = prevOriginalColumn + colDelta2;
-
-      // If we're on the target line
-      if (generatedLine === targetLine) {
-        console.debug('[bippy] Found mapping at line', generatedLine, ':', {
-          generatedColumn,
-          targetColumn,
-          originalLine: originalLine + 1,
-          originalColumn,
-          sourceFileIndex
-        });
-
-        // Store any mapping before our target column
-        if (generatedColumn <= targetColumn) {
-          lastMatch = {
-            line: originalLine + 1, // sourcemap lines are 0-based
-            column: originalColumn,
-            sourceIndex: sourceFileIndex
-          };
-          // Update previous state
-          prevSourceFileIndex = sourceFileIndex;
-          prevOriginalLine = originalLine;
-          prevOriginalColumn = originalColumn;
-        }
-        // If we found an exact match, return it
-        if (generatedColumn === targetColumn) {
-          console.debug('[bippy] Found exact match');
-          return lastMatch;
-        }
-      }
-    }
-    // Reset column deltas at end of line, but keep other state
-    prevOriginalColumn = 0;
-    generatedColumn = 0;
-    generatedLine++;
+  if (
+    !(INLINE_SOURCEMAP_REGEX.test(sourceMapUrl) || sourceMapUrl.startsWith('/'))
+  ) {
+    // Resolve path if it's a relative access
+    const parsedURL = url.split('/');
+    parsedURL[parsedURL.length - 1] = sourceMapUrl;
+    sourceMapUrl = parsedURL.join('/');
   }
+  const response = await fetch(sourceMapUrl);
+  const rawSourceMap: RawSourceMap = await response.json();
 
-  console.debug('[bippy] Returning last match:', lastMatch);
-  return lastMatch;
-};
-
-interface SourceMap {
-  version: number;
-  sources: string[];
-  names: string[];
-  mappings: string;
-  file?: string;
-  sourceRoot?: string;
-  sourcesContent?: (string | null)[];
+  return new SourceMapConsumer(rawSourceMap);
 }
 
-const parseDataUrl = (dataUrl: string): string | null => {
-  try {
-    const [header, base64] = dataUrl.split(',');
-    if (!header.includes('application/json')) return null;
-    return atob(base64);
-  } catch {
-    return null;
+function getActualFileSource(path: string): string {
+  if (path.startsWith('file://')) {
+    return `/_build/@fs${path.substring('file://'.length)}`;
   }
-};
+  return path;
+}
 
 const parseStackFrame = async (frame: string): Promise<FiberSource | null> => {
-  // Example frame format: "    at Component (/path/to/file.js:10:20)"
-  const match = frame.match(/\((.+):(\d+):(\d+)\)$/);
-  if (!match) return null;
+  const source = errorStackParser.parseStack(frame);
 
-  const url = match[1];
-  const line = Number.parseInt(match[2], 10);
-  const column = Number.parseInt(match[3], 10);
-
-  console.debug('[bippy] Parsing stack frame:', { url, line, column });
-
-  // Handle both absolute and relative paths
-  let fileName = url;
-  let lineNumber = line;
-  let columnNumber = column;
-
-  // Handle Vite dev server URLs
-  if (fileName.startsWith('http://localhost:') || fileName.startsWith('https://localhost:')) {
-    try {
-      // First fetch the file to get its sourcemap
-      const response = await fetch(fileName);
-      const text = await response.text();
-
-      // Look for sourcemap in the file (both //# and //@)
-      const sourcemapUrl = text.match(/\/\/[#@]\s*sourceMappingURL=(.+)$/m)?.[1]?.trim();
-      console.debug('[bippy] Found sourcemap URL:', sourcemapUrl);
-
-      if (sourcemapUrl) {
-        let sourcemap: SourceMap | undefined;
-
-        // Handle data URLs
-        if (sourcemapUrl.startsWith('data:')) {
-          const sourcemapJson = parseDataUrl(sourcemapUrl);
-          if (sourcemapJson) {
-            sourcemap = JSON.parse(sourcemapJson);
-          }
-        } else {
-          // Get absolute sourcemap URL for non-data URLs
-          const absoluteSourcemapUrl = sourcemapUrl.startsWith('http')
-            ? sourcemapUrl
-            : new URL(sourcemapUrl, fileName).toString();
-
-          // Fetch and parse the sourcemap
-          const sourcemapResponse = await fetch(absoluteSourcemapUrl);
-          sourcemap = await sourcemapResponse.json();
-        }
-
-        if (sourcemap?.version === 3) {
-          console.debug('[bippy] Valid sourcemap:', {
-            version: sourcemap.version,
-            sourceCount: sourcemap.sources.length,
-            mappingsLength: sourcemap.mappings.length
-          });
-
-          // Find the original position
-          const originalPos = findOriginalPosition(sourcemap.mappings, line, column);
-          if (originalPos) {
-            const source = sourcemap.sources[originalPos.sourceIndex];
-            if (!source) {
-              console.debug('[bippy] Invalid source index:', originalPos.sourceIndex);
-              return null;
-            }
-
-            // Get the absolute path from the sourcemap
-            const sourceRoot = sourcemap.sourceRoot || '';
-            const absolutePath = source.startsWith('/') ? source : `/${source}`;
-
-            // Try to extract the workspace path
-            const workspacePath = process.cwd();
-            const srcIndex = workspacePath.indexOf('/src/');
-            const workspaceRoot = srcIndex !== -1 ? workspacePath.slice(0, srcIndex) : workspacePath;
-
-            // Combine paths, ensuring we have the full absolute path
-            fileName = `${workspaceRoot}${absolutePath}`;
-
-            // Clean up any remaining webpack prefixes
-            fileName = fileName.replace(/^webpack:\/\/\//, '');
-
-            lineNumber = originalPos.line;
-            columnNumber = originalPos.column;
-
-            console.debug('[bippy] Mapped position:', { fileName, lineNumber, columnNumber });
-          } else {
-            console.debug('[bippy] No position mapping found');
-          }
-        } else {
-          console.debug('[bippy] Invalid sourcemap version:', sourcemap?.version);
-        }
-      } else {
-        console.debug('[bippy] No sourcemap found, using fallback');
-        // Fallback to Vite's URL parsing if no sourcemap
-        const sourceUrl = new URL(fileName);
-        const source = sourceUrl.searchParams.get('file');
-        if (source) {
-          // Use the full absolute path from Vite
-          fileName = source.startsWith('/') ? source : `/${source}`;
-        } else {
-          const relativePath = sourceUrl.pathname.match(/\/src\/(.+)$/)?.[1];
-          if (relativePath) {
-            fileName = `${process.cwd()}/src/${relativePath}`;
-          }
-        }
-      }
-    } catch (err) {
-      console.debug('[bippy] Failed to get source mapping:', err);
-    }
+  if (!source.length) {
+    return null;
   }
 
+  // Handle both absolute and relative paths
+
+  const { file, line, col } = source[0];
+
+  if (!file || !line) {
+    return null;
+  }
+
+  console.debug('[bippy] Parsing stack frame:', source[0]);
+
+  const fileName = file || '';
+  const lineNumber = line || 0;
+  const columnNumber = col || 0;
+
+  const response = await fetch(getActualFileSource(fileName));
+  if (response.ok) {
+    const content = await response.text();
+    const sourcemap = await getSourceMap(fileName, content);
+
+    if (sourcemap) {
+      const result = sourcemap.originalPositionFor({
+        line: lineNumber,
+        column: columnNumber,
+      });
+      return {
+        fileName: result.source || '',
+        lineNumber: result.line || 0,
+        columnNumber: result.column || 0,
+      };
+    }
+  }
   return {
     fileName,
     lineNumber,
@@ -856,9 +668,161 @@ const parseStackFrame = async (frame: string): Promise<FiberSource | null> => {
   };
 };
 
-// Make getFiberSource async to handle file fetching
-export const getFiberSource = async (fiber: Fiber): Promise<FiberSource | null> => {
+// https://github.com/hoxyq/react/blob/e450e6b97653fc5b7a56ec700e87546abfd91aa3/packages/react-devtools-shared/src/backend/DevToolsComponentStackFrame.js#L67
+function describeNativeComponentFrame(
+  fn: React.ComponentType<unknown>,
+  construct: boolean,
+  currentDispatcherRef: React.MutableRefObject<unknown>,
+) {
+  if (!fn || reentry) {
+    return '';
+  }
 
+  const previousPrepareStackTrace = Error.prepareStackTrace;
+  Error.prepareStackTrace = undefined;
+  reentry = true;
+
+  const previousDispatcher = currentDispatcherRef.current;
+  currentDispatcherRef.current = null;
+  const prevLogs = disableLogs();
+
+  const RunInRootFrame = {
+    DetermineComponentFrameRoot(): [string | null, string | null] {
+      let control: Error | undefined;
+      try {
+        // Handle both class and function components
+        if (construct) {
+          // For class components, we need to create an instance
+          const Fake = () => {
+            throw Error();
+          };
+          Object.defineProperty(Fake.prototype, 'props', {
+            set: () => {
+              throw Error();
+            },
+          });
+          if (typeof Reflect === 'object' && Reflect.construct) {
+            try {
+              Reflect.construct(Fake, []);
+            } catch (x) {
+              control = x as Error;
+            }
+            Reflect.construct(fn as new () => unknown, [], Fake);
+          } else {
+            try {
+              Fake.call(null);
+            } catch (x) {
+              control = x as Error;
+            }
+            (fn as new () => unknown).call(Fake.prototype);
+          }
+        } else {
+          try {
+            throw Error();
+          } catch (x) {
+            control = x as Error;
+          }
+          const maybePromise = (fn as () => unknown)();
+
+          if (
+            maybePromise &&
+            typeof maybePromise === 'object' &&
+            'catch' in maybePromise &&
+            typeof maybePromise.catch === 'function'
+          ) {
+            maybePromise.catch(() => {});
+          }
+        }
+      } catch (sample) {
+        if (
+          sample instanceof Error &&
+          control &&
+          control.stack &&
+          sample.stack
+        ) {
+          return [sample.stack, control.stack];
+        }
+      }
+      return [null, null];
+    },
+  };
+
+  (
+    RunInRootFrame.DetermineComponentFrameRoot as React.ComponentType<unknown>
+  ).displayName = 'DetermineComponentFrameRoot';
+  const namePropDescriptor = Object.getOwnPropertyDescriptor(
+    RunInRootFrame.DetermineComponentFrameRoot,
+    'name',
+  );
+  if (namePropDescriptor?.configurable) {
+    Object.defineProperty(RunInRootFrame.DetermineComponentFrameRoot, 'name', {
+      value: 'DetermineComponentFrameRoot',
+    });
+  }
+
+  try {
+    const [sampleStack, controlStack] =
+      RunInRootFrame.DetermineComponentFrameRoot();
+    if (sampleStack && controlStack) {
+      const sampleLines = sampleStack.split('\n');
+      const controlLines = controlStack.split('\n');
+      let s = 0;
+      let c = 0;
+      while (
+        s < sampleLines.length &&
+        !sampleLines[s].includes('DetermineComponentFrameRoot')
+      ) {
+        s++;
+      }
+      while (
+        c < controlLines.length &&
+        !controlLines[c].includes('DetermineComponentFrameRoot')
+      ) {
+        c++;
+      }
+      if (s === sampleLines.length || c === controlLines.length) {
+        s = sampleLines.length - 1;
+        c = controlLines.length - 1;
+        while (s >= 1 && c >= 0 && sampleLines[s] !== controlLines[c]) {
+          c--;
+        }
+      }
+      for (; s >= 1 && c >= 0; s--, c--) {
+        if (sampleLines[s] !== controlLines[c]) {
+          if (s !== 1 || c !== 1) {
+            do {
+              s--;
+              c--;
+              if (c < 0 || sampleLines[s] !== controlLines[c]) {
+                // biome-ignore lint/style/useTemplate: <explanation>
+                let frame = '\n' + sampleLines[s].replace(' at new ', ' at ');
+                if (fn.displayName && frame.includes('<anonymous>')) {
+                  frame = frame.replace('<anonymous>', fn.displayName);
+                }
+                return frame;
+              }
+            } while (s >= 1 && c >= 0);
+          }
+          break;
+        }
+      }
+    }
+  } finally {
+    reentry = false;
+    Error.prepareStackTrace = previousPrepareStackTrace;
+    currentDispatcherRef.current = previousDispatcher;
+    reenableLogs(prevLogs);
+  }
+
+  const name = fn ? fn.displayName || fn.name : '';
+  const syntheticFrame = name ? describeBuiltInComponentFrame(name) : '';
+  return syntheticFrame;
+}
+
+// Make getFiberSource async to handle file fetching
+export const getFiberSource = async (
+  fiber: Fiber,
+): Promise<FiberSource | null> => {
   const rdtHook = getRDTHook();
   let currentDispatcherRef: React.MutableRefObject<unknown> | undefined;
   for (const renderer of rdtHook.renderers.values()) {
@@ -888,161 +852,12 @@ export const getFiberSource = async (fiber: Fiber): Promise<FiberSource | null> 
     return null;
   }
 
-  const cachedFrame = componentFrameCache.get(componentFunction);
-  if (cachedFrame) {
-    return parseStackFrame(cachedFrame);
-  }
-
-  const previousPrepareStackTrace = Error.prepareStackTrace;
-  Error.prepareStackTrace = undefined;
-  reentry = true;
-
-  const previousDispatcher = currentDispatcherRef.current;
-  currentDispatcherRef.current = null;
-  const prevLogs = disableLogs();
-
-  try {
-    const RunInRootFrame = {
-      DetermineComponentFrameRoot(): [string | null, string | null] {
-        let control: Error | undefined;
-        try {
-          try {
-            throw Error();
-          } catch (x) {
-            control = x as Error;
-          }
-
-          // Handle both class and function components
-          if (fiber.tag === ClassComponentTag) {
-            // For class components, we need to create an instance
-            const Fake = () => {
-              throw Error();
-            };
-            Object.defineProperty(Fake.prototype, 'props', {
-              set: () => {
-                throw Error();
-              },
-            });
-            if (typeof Reflect === 'object' && Reflect.construct) {
-              try {
-                Reflect.construct(Fake, []);
-              } catch (x) {
-                control = x as Error;
-              }
-              Reflect.construct(
-                componentFunction as new () => unknown,
-                [],
-                Fake,
-              );
-            }
-          } else {
-            // For function components
-            const funcComponent = componentFunction as () => React.ReactNode;
-            const result = funcComponent();
-            // Only handle Promise-like results
-            if (
-              result &&
-              typeof result === 'object' &&
-              'catch' in result &&
-              typeof result.catch === 'function'
-            ) {
-              result.catch(() => {});
-            }
-          }
-        } catch (sample) {
-          if (
-            sample instanceof Error &&
-            control &&
-            control.stack &&
-            sample.stack
-          ) {
-            return [sample.stack, control.stack];
-          }
-        }
-        return [null, null];
-      },
-    };
-
-    Object.defineProperty(
-      RunInRootFrame.DetermineComponentFrameRoot,
-      'displayName',
-      {
-        value: 'DetermineComponentFrameRoot',
-        configurable: true,
-      },
-    );
-
-    const [sampleStack, controlStack] =
-      RunInRootFrame.DetermineComponentFrameRoot();
-
-    if (sampleStack && controlStack) {
-      const sampleLines = sampleStack.split('\n');
-      const controlLines = controlStack.split('\n');
-
-      let s = 0;
-      let c = 0;
-
-      while (
-        s < sampleLines.length &&
-        !sampleLines[s].includes('DetermineComponentFrameRoot')
-      ) {
-        s++;
-      }
-      while (
-        c < controlLines.length &&
-        !controlLines[c].includes('DetermineComponentFrameRoot')
-      ) {
-        c++;
-      }
-
-      if (s === sampleLines.length || c === controlLines.length) {
-        s = sampleLines.length - 1;
-        c = controlLines.length - 1;
-        while (s >= 1 && c >= 0 && sampleLines[s] !== controlLines[c]) {
-          c--;
-        }
-      }
-
-      for (; s >= 1 && c >= 0; s--, c--) {
-        if (sampleLines[s] !== controlLines[c]) {
-          if (s !== 1 || c !== 1) {
-            do {
-              s--;
-              c--;
-              if (c < 0 || sampleLines[s] !== controlLines[c]) {
-                let frame = sampleLines[s].replace(' at new ', ' at ');
-                if (
-                  componentFunction.displayName &&
-                  frame.includes('<anonymous>')
-                ) {
-                  frame = frame.replace(
-                    '<anonymous>',
-                    componentFunction.displayName,
-                  );
-                }
-                // console.log('[getFiberSource] Found stack frame:', frame);
-                componentFrameCache.set(componentFunction, frame);
-                return parseStackFrame(frame);
-              }
-            } while (s >= 1 && c >= 0);
-          }
-          break;
-        }
-      }
-    }
-  } finally {
-    reentry = false;
-    Error.prepareStackTrace = previousPrepareStackTrace;
-    currentDispatcherRef.current = previousDispatcher;
-    reenableLogs(prevLogs);
-  }
-
-  const name = componentFunction.displayName || componentFunction.name || '';
-  const syntheticFrame = name ? describeBuiltInComponentFrame(name) : '';
-  if (name) {
-    componentFrameCache.set(componentFunction, syntheticFrame);
-  }
-  return null;
+  const frame = describeNativeComponentFrame(
+    componentFunction,
+    fiber.tag === ClassComponentTag,
+    currentDispatcherRef,
+  );
+  return parseStackFrame(frame);
 };
 
 export const mountFiberRecursively = (

--- a/packages/bippy/src/experiments/inspect.tsx
+++ b/packages/bippy/src/experiments/inspect.tsx
@@ -254,6 +254,30 @@ export const RawInspector = React.memo(
     const getFiberForDisplay = useCallback(() => {
       if (selectedFiber) return selectedFiber;
       const fiber = getFiberFromHostInstance(element);
+      const parentCompositeFiber = traverseFiber(
+        fiber,
+        (f) => {
+          if (isCompositeFiber(f)) return true;
+        },
+        true,
+      );
+
+      console.group('fiber');
+      if (fiber) {
+        console.log(getDisplayName(fiber), fiber?._debugSource);
+      }
+      if (parentCompositeFiber) {
+        console.log(
+          getDisplayName(parentCompositeFiber),
+          parentCompositeFiber?._debugSource,
+        );
+      }
+      if (fiber) {
+        console.log(getDisplayName(fiber), getFiberSource(fiber));
+      }
+      console.groupEnd();
+
+      // );
       return fiber;
     }, [selectedFiber, element]);
 

--- a/packages/bippy/src/experiments/inspect.tsx
+++ b/packages/bippy/src/experiments/inspect.tsx
@@ -1,31 +1,31 @@
+import React, {
+  type MouseEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
+import ReactDOM from 'react-dom';
 import {
+  ObjectLabel,
+  ObjectRootLabel,
+  Inspector as ReactInspector,
+} from 'react-inspector';
+import {
+  type Fiber,
+  detectReactBuildType,
   getDisplayName,
   getFiberFromHostInstance,
-  traverseFiber,
-  isInstrumentationActive,
-  getRDTHook,
-  detectReactBuildType,
-  getFiberStack,
   getFiberId,
-  type Fiber,
+  getFiberSource,
+  getFiberStack,
   getNearestHostFiber,
+  getRDTHook,
   hasRDTHook,
   isCompositeFiber,
-  getFiberSource,
+  isInstrumentationActive,
+  traverseFiber,
 } from '../index.js';
-import React, {
-  useState,
-  useEffect,
-  type ReactNode,
-  type MouseEvent,
-  useCallback,
-} from 'react';
-import {
-  Inspector as ReactInspector,
-  ObjectRootLabel,
-  ObjectLabel,
-} from 'react-inspector';
-import ReactDOM from 'react-dom';
 
 const FIBER_PROP_EXPLANATIONS: Record<string, string> = {
   tag: 'Numeric type identifier for this fiber (e.g. 1=FunctionComponent, 5=HostComponent)',
@@ -254,30 +254,6 @@ export const RawInspector = React.memo(
     const getFiberForDisplay = useCallback(() => {
       if (selectedFiber) return selectedFiber;
       const fiber = getFiberFromHostInstance(element);
-      const parentCompositeFiber = traverseFiber(
-        fiber,
-        (f) => {
-          if (isCompositeFiber(f)) return true;
-        },
-        true,
-      );
-
-      console.group('fiber');
-      if (fiber) {
-        console.log(getDisplayName(fiber), fiber?._debugSource);
-      }
-      if (parentCompositeFiber) {
-        console.log(
-          getDisplayName(parentCompositeFiber),
-          parentCompositeFiber?._debugSource,
-        );
-      }
-      if (fiber) {
-        console.log(getDisplayName(fiber), getFiberSource(fiber));
-      }
-      console.groupEnd();
-
-      // );
       return fiber;
     }, [selectedFiber, element]);
 
@@ -543,7 +519,11 @@ export const RawInspector = React.memo(
                   margin: 0,
                 }}
               >
-                {`<${typeof fiber.type === 'string' ? fiber.type : getDisplayName(fiber.type) || 'unknown'}>`}
+                {`<${
+                  typeof fiber.type === 'string'
+                    ? fiber.type
+                    : getDisplayName(fiber.type) || 'unknown'
+                }>`}
                 {!isDialogMode && (
                   <span
                     style={{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      source-map:
-        specifier: ^0.7.4
-        version: 0.7.4
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
     devDependencies:
       '@changesets/changelog-git':
         specifier: ^0.2.0
@@ -2412,10 +2412,6 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-
-  source-map@0.7.4:
-    resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
-    engines: {node: '>= 8'}
 
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
@@ -5010,8 +5006,6 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
-
-  source-map@0.7.4: {}
 
   source-map@0.8.0-beta.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,12 @@ importers:
       '@types/react-reconciler':
         specifier: ^0.28.9
         version: 0.28.9(@types/react@19.0.4)
+      error-stack-parser-es:
+        specifier: ^1.0.5
+        version: 1.0.5
+      source-map-js:
+        specifier: ^1.2.1
+        version: 1.2.1
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.4
@@ -1599,6 +1605,9 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
   es-module-lexer@1.5.4:
     resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
@@ -4198,6 +4207,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@4.5.0: {}
+
+  error-stack-parser-es@1.0.5: {}
 
   es-module-lexer@1.5.4: {}
 


### PR DESCRIPTION
- We'll be using [`error-stack-parser-es`](https://github.com/antfu-collective/error-stack-parser-es) and [`source-map-js`](https://www.npmjs.com/package/source-map-js)
- Since React 19 drops `__debugSource`, the implementation will always be inaccurate (known issue, see facebook/react for similar issues or just test RDT's source inaccuracy)

Related:
- https://github.com/facebook/react/pull/28351
- https://github.com/facebook/react/issues/29164