### PR TITLE
fix(source): don't cache transient source-map fetch failures

### DIFF
--- a/packages/bippy/src/source/symbolication.ts
+++ b/packages/bippy/src/source/symbolication.ts
@@ -65,7 +65,12 @@ const SOURCEMAP_REGEX =
   /(?:\/\/[@#][ \t]+sourceMappingURL=([^\s'"]+?)[ \t]*$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^*]+?)[ \t]*(?:\*\/)[ \t]*$)/;
 
 export const sourceMapCache = new Map<string, null | SourceMap>();
-const _pendingSourceMapRequests = new Map<string, null | Promise<null | SourceMap>>();
+interface SourceMapResult {
+  sourceMap: null | SourceMap;
+  isTransientFailure: boolean;
+}
+
+const _pendingSourceMapRequests = new Map<string, Promise<SourceMapResult>>();
 
 const getSourceFromMappings = (
   mappings: SourceMapMappings,
@@ -238,6 +243,11 @@ const isFetchableUrl = (url: string): boolean => {
   return scheme === "http:" || scheme === "https:";
 };
 
+// Resolves a bundle's source map, or null when the bundle definitively has
+// none. A thrown fetch (network error or aborted request) is left to propagate
+// so getSourceMap can treat it as transient and avoid caching it: a non-ok
+// response, a missing sourceMappingURL, or an undecodable map are definitive and
+// return null, but a dropped connection is not and must stay retryable.
 export const getSourceMapImpl = async (
   bundleUrl: string,
   fetchFn: (url: string) => Promise<Response> = fetch,
@@ -246,17 +256,11 @@ export const getSourceMapImpl = async (
     return null;
   }
 
-  let bundleContent: string | undefined;
-  try {
-    const bundleResponse = await fetchFn(bundleUrl);
-    if (!bundleResponse.ok) {
-      return null;
-    }
-    bundleContent = await bundleResponse.text();
-  } catch {
+  const bundleResponse = await fetchFn(bundleUrl);
+  if (!bundleResponse.ok) {
     return null;
   }
-
+  const bundleContent = await bundleResponse.text();
   if (!bundleContent) {
     return null;
   }
@@ -268,11 +272,12 @@ export const getSourceMapImpl = async (
     return null;
   }
 
+  const sourceMapResponse = await fetchFn(sourceMapUrl);
+  if (!sourceMapResponse.ok) {
+    return null;
+  }
+
   try {
-    const sourceMapResponse = await fetchFn(sourceMapUrl);
-    if (!sourceMapResponse.ok) {
-      return null;
-    }
     const rawSourceMap = (await sourceMapResponse.json()) as RawSourceMap;
 
     return "sections" in rawSourceMap
@@ -289,31 +294,30 @@ export const getSourceMap = async (
   fetchFn?: (url: string) => Promise<Response>,
 ): Promise<null | SourceMap> => {
   if (useCache && sourceMapCache.has(file)) {
-    const cachedValue = sourceMapCache.get(file);
-    if (cachedValue === null || cachedValue === undefined) {
-      return null;
-    }
-    return cachedValue;
+    return sourceMapCache.get(file) ?? null;
   }
 
-  if (useCache && _pendingSourceMapRequests.has(file)) {
-    return _pendingSourceMapRequests.get(file)!;
+  const pendingRequest = useCache ? _pendingSourceMapRequests.get(file) : undefined;
+  if (pendingRequest) {
+    return (await pendingRequest).sourceMap;
   }
 
-  const fetchPromise = getSourceMapImpl(file, fetchFn);
+  // A transient fetch failure (aborted request or network error) rejects; a
+  // definitive "no map" resolves to null. Only definitive results are cached:
+  // caching a transient null would pin the bundle to a degraded result for the
+  // rest of the page's lifetime, even after the network recovers.
+  const fetchPromise: Promise<SourceMapResult> = getSourceMapImpl(file, fetchFn).then(
+    (sourceMap) => ({ sourceMap, isTransientFailure: false }),
+    () => ({ sourceMap: null, isTransientFailure: true }),
+  );
   if (useCache) {
     _pendingSourceMapRequests.set(file, fetchPromise);
   }
 
-  const sourceMap = await fetchPromise;
+  const { sourceMap, isTransientFailure } = await fetchPromise;
   if (useCache) {
     _pendingSourceMapRequests.delete(file);
-  }
-
-  if (useCache) {
-    if (sourceMap === null) {
-      sourceMapCache.set(file, null);
-    } else {
+    if (!isTransientFailure) {
       sourceMapCache.set(file, sourceMap);
     }
   }

--- a/packages/bippy/src/test/source.test.tsx
+++ b/packages/bippy/src/test/source.test.tsx
@@ -5,7 +5,7 @@ import React, { useState } from "react";
 import { expect, it } from "vitest";
 import type { Fiber } from "../types.js";
 import { instrument } from "../index.js";
-import { getSource, getOwnerStack } from "../source/index.js";
+import { getSource, getOwnerStack, getSourceMap, sourceMapCache } from "../source/index.js";
 import { normalizeFileName } from "../source/get-source.js";
 import { extractLocation } from "../source/parse-stack.js";
 
@@ -314,4 +314,62 @@ it("extractLocation should handle path starting with route group (no Chrome wrap
 it("extractLocation should handle file with parentheses in name", () => {
   const result = extractLocation("file(1).js:10:5");
   expect(result).toEqual(["file(1).js", "10", "5"]);
+});
+
+const SOURCE_MAP_BODY = JSON.stringify({
+  version: 3,
+  sources: ["app.tsx"],
+  sourcesContent: ["const value = 1;"],
+  names: [],
+  mappings: "",
+});
+
+const bundleResponse = (sourceMappingUrl: string): Response =>
+  new Response(`const value = 1;\n//# sourceMappingURL=${sourceMappingUrl}`, { status: 200 });
+
+const sourceMapResponse = (): Response =>
+  new Response(SOURCE_MAP_BODY, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+it("getSourceMap retries after a transient source-map fetch failure instead of caching null", async () => {
+  const file = "http://localhost/transient-bundle.js";
+  sourceMapCache.delete(file);
+  let sourceMapAttempts = 0;
+
+  const fetchFn = (url: string): Promise<Response> => {
+    if (url.endsWith(".map")) {
+      sourceMapAttempts++;
+      if (sourceMapAttempts === 1) {
+        return Promise.reject(new DOMException("Aborted", "AbortError"));
+      }
+      return Promise.resolve(sourceMapResponse());
+    }
+    return Promise.resolve(bundleResponse("transient-bundle.js.map"));
+  };
+
+  const firstResult = await getSourceMap(file, true, fetchFn);
+  expect(firstResult).toBeNull();
+  expect(sourceMapCache.has(file)).toBe(false);
+
+  const secondResult = await getSourceMap(file, true, fetchFn);
+  expect(secondResult).not.toBeNull();
+  expect(sourceMapAttempts).toBe(2);
+});
+
+it("getSourceMap caches a definitive missing source map and does not refetch", async () => {
+  const file = "http://localhost/no-map-bundle.js";
+  sourceMapCache.delete(file);
+  let bundleAttempts = 0;
+
+  const fetchFn = (_url: string): Promise<Response> => {
+    bundleAttempts++;
+    return Promise.resolve(new Response("const value = 1;", { status: 200 }));
+  };
+
+  expect(await getSourceMap(file, true, fetchFn)).toBeNull();
+  expect(await getSourceMap(file, true, fetchFn)).toBeNull();
+  expect(bundleAttempts).toBe(1);
+  expect(sourceMapCache.get(file)).toBeNull();
 });


### PR DESCRIPTION
## Problem

`getSourceMap` caches a `null` result for **any** failure, then returns that cached `null` for the bundle's entire page lifetime (`symbolication.ts`):

```ts
if (useCache && sourceMapCache.has(file)) {
  const cachedValue = sourceMapCache.get(file);
  if (cachedValue === null || cachedValue === undefined) return null; // poisoned
  ...
}
...
if (sourceMap === null) sourceMapCache.set(file, null); // caches even an aborted fetch
```

That conflates two very different cases:
- **Definitive** "no map": non-ok response, no `sourceMappingURL`, undecodable map. Caching `null` is correct.
- **Transient** failure: an aborted request or network error. Caching `null` is wrong.

A consumer that aborts the bundle/source-map fetch (e.g. [react-grab](https://github.com/aidenybai/react-grab) cancels it under connection-pool pressure via the `fetchFn` hook + an `AbortSignal`) then permanently degrades source resolution for **every component in that bundle**, even after the network recovers, until a full page reload.

## Fix

- `getSourceMapImpl` lets a thrown fetch (network error / abort) **propagate** instead of swallowing it to `null`. Definitive cases still return `null`.
- `getSourceMap` treats a rejection as transient: it returns `null` but **does not cache** it, so a later call retries once the network recovers. Definitive `null`s are still cached (no refetch).
- `getSourceMap` keeps its no-throw contract (concurrent waiters get `null`, never a rejection).

## Tests

- retries after a transient source-map fetch failure instead of caching `null`
- caches a definitive missing source map and does not refetch

`pnpm build` passes (dts clean). The 3 pre-existing `getOwnerStack` symbolication-fetch timeouts in `source.test.tsx` fail identically on `main` in this environment and are unrelated to this change.