### PR TITLE
Add experimental conditional hooks runtime

### DIFF
--- a/packages/bippy/package.json
+++ b/packages/bippy/package.json
@@ -59,6 +59,16 @@
         "default": "./dist/core.cjs"
       }
     },
+    "./conditional-hooks": {
+      "import": {
+        "types": "./dist/conditional-hooks.d.ts",
+        "default": "./dist/conditional-hooks.js"
+      },
+      "require": {
+        "types": "./dist/conditional-hooks.d.cts",
+        "default": "./dist/conditional-hooks.cjs"
+      }
+    },
     "./install-hook-only": {
       "import": {
         "types": "./dist/install-hook-only.d.ts",

--- a/packages/bippy/src/conditional-hooks.ts
+++ b/packages/bippy/src/conditional-hooks.ts
@@ -1,0 +1,968 @@
+import "./install-hook-only.js";
+
+import { instrument, traverseFiber } from "./core.js";
+import { _renderers, getRDTHook, onRendererInject } from "./rdt-hook.js";
+import type { Fiber, FiberRoot, ReactRenderer } from "./types.js";
+import { toUnsubscribe, type Unsubscribe } from "./unsubscribe.js";
+
+interface ConditionalHookDispatcher {
+  readContext?: (...arguments_: unknown[]) => unknown;
+  useCallback?: (...arguments_: unknown[]) => unknown;
+  useContext?: (...arguments_: unknown[]) => unknown;
+  useDebugValue?: (...arguments_: unknown[]) => unknown;
+  useEffect?: (...arguments_: unknown[]) => unknown;
+  useLayoutEffect?: (...arguments_: unknown[]) => unknown;
+  useMemo?: (...arguments_: unknown[]) => unknown;
+  useReducer?: (...arguments_: unknown[]) => unknown;
+  useRef?: (...arguments_: unknown[]) => unknown;
+  useState?: (...arguments_: unknown[]) => unknown;
+}
+
+interface ConditionalHookDispatcherRef {
+  H?: ConditionalHookDispatcher | null;
+  current?: ConditionalHookDispatcher | null;
+}
+
+interface ConditionalHookRuntime {
+  activeFiber: Fiber | null;
+  currentDispatcher: ConditionalHookDispatcher | null;
+  dispatcherKey: "H" | "current";
+  dispatcherRef: ConditionalHookDispatcherRef;
+  getHookKey: ConditionalHookKeyResolver;
+  interceptReactHooks: boolean;
+  originalDescriptor: PropertyDescriptor | undefined;
+  proxyByDispatcher: WeakMap<object, ConditionalHookDispatcher>;
+  renderer: ReactRenderer;
+}
+
+interface ConditionalHookScope {
+  cells: Map<PropertyKey, ConditionalHookCell>;
+  didCommit: boolean;
+  didUnmount: boolean;
+  effects: Map<PropertyKey, ConditionalEffectCell>;
+  fiber: Fiber;
+  hookKinds: Map<PropertyKey, ConditionalHookKind>;
+  layoutEffectsDisconnected: boolean;
+  passiveEffectsDisconnected: boolean;
+  renderer: ReactRenderer;
+}
+
+interface ConditionalRenderFrame {
+  callCounts: Map<PropertyKey, number>;
+  cells: Map<PropertyKey, ConditionalHookCell>;
+  effects: Map<PropertyKey, ConditionalEffectRegistration>;
+  fiber: Fiber;
+  hookKinds: Map<PropertyKey, ConditionalHookKind>;
+  reducerActionCounts: Map<PropertyKey, number>;
+  reducerOverrides: Map<PropertyKey, (state: unknown, action: unknown) => unknown>;
+  replayedCells: Set<PropertyKey>;
+  renderPhaseUpdates: Map<PropertyKey, unknown[]>;
+  scope: ConditionalHookScope;
+}
+
+interface ConditionalVisibilityState {
+  layoutEffectsHidden: boolean;
+  passiveEffectsHidden: boolean;
+}
+
+interface ConditionalStateCell {
+  dispatch: (action: unknown) => void;
+  kind: "state";
+  value: unknown;
+}
+
+interface ConditionalReducerCell {
+  dispatch: (action: unknown) => void;
+  kind: "reducer";
+  pendingActions: unknown[];
+  reducer: (state: unknown, action: unknown) => unknown;
+  value: unknown;
+}
+
+interface ConditionalRefCell {
+  kind: "ref";
+  value: ConditionalRef<unknown>;
+}
+
+interface ConditionalMemoCell {
+  dependencies: readonly unknown[] | undefined;
+  kind: "memo";
+  value: unknown;
+}
+
+interface ConditionalEffectCell {
+  cleanup: (() => void) | undefined;
+  create: ConditionalEffectRegistration["create"];
+  dependencies: readonly unknown[] | undefined;
+  kind: ConditionalEffectKind;
+  version: number;
+}
+
+interface ConditionalEffectRegistration {
+  create: () => (() => void) | void;
+  dependencies: readonly unknown[] | undefined;
+  kind: ConditionalEffectKind;
+}
+
+export interface ConditionalRef<Value> {
+  current: Value;
+}
+
+export interface ConditionalStateSetter<State> {
+  (action: State | ((previousState: State) => State)): void;
+}
+
+export interface ConditionalReducerDispatcher<Action> {
+  (action: Action): void;
+}
+
+export interface ConditionalHooksInstallation extends Unsubscribe {
+  readonly supportedRenderers: number;
+}
+
+export interface ConditionalHooksOptions {
+  getHookKey?: ConditionalHookKeyResolver;
+  interceptReactHooks?: boolean;
+}
+
+export interface ConditionalHookKeyResolver {
+  (hookName: string, stack: string): PropertyKey;
+}
+
+type ConditionalHookCell =
+  | ConditionalMemoCell
+  | ConditionalReducerCell
+  | ConditionalRefCell
+  | ConditionalStateCell;
+
+type ConditionalEffectKind = "effect" | "layout-effect";
+
+type ConditionalHookKind = ConditionalHookCell["kind"] | ConditionalEffectKind;
+
+const runtimes = new Set<ConditionalHookRuntime>();
+const scopes = new Set<ConditionalHookScope>();
+const runtimeByDispatcherRef = new WeakMap<object, ConditionalHookRuntime>();
+const scopeByFiber = new WeakMap<Fiber, ConditionalHookScope>();
+const renderFrameByFiber = new WeakMap<Fiber, ConditionalRenderFrame>();
+
+let installation: ConditionalHooksInstallation | null = null;
+let scheduledUpdateVersion = 0;
+
+const getCurrentFiber = (renderer: ReactRenderer): Fiber | null => {
+  try {
+    return renderer.getCurrentFiber?.() ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const isContextOnlyDispatcher = (dispatcher: ConditionalHookDispatcher | null): boolean => {
+  if (!dispatcher) return true;
+  return (
+    typeof dispatcher.useState === "function" &&
+    dispatcher.useState === dispatcher.useReducer &&
+    dispatcher.useReducer === dispatcher.useRef &&
+    dispatcher.useRef === dispatcher.useEffect
+  );
+};
+
+const defaultHookKeyResolver: ConditionalHookKeyResolver = (hookName, stack) => {
+  const callsite = stack
+    .split("\n")
+    .map((line) => line.trim())
+    .find(
+      (line) =>
+        line.startsWith("at ") &&
+        !line.includes("conditional-hooks") &&
+        !line.includes("node_modules/react/") &&
+        !line.includes("node_modules/.vite/deps/react") &&
+        !line.includes("react.development.js") &&
+        !line.includes("react.production.js"),
+    );
+  if (!callsite) {
+    throw new Error(`Could not derive a callsite key for React.${hookName}().`);
+  }
+  return `${hookName}:${callsite}`;
+};
+
+const getAutomaticHookKey = (runtime: ConditionalHookRuntime, hookName: string): PropertyKey => {
+  const { frame } = getScope();
+  const stack = new Error().stack ?? "";
+  const callsiteKey = runtime.getHookKey(hookName, stack);
+  const occurrence = frame.callCounts.get(callsiteKey) ?? 0;
+  frame.callCounts.set(callsiteKey, occurrence + 1);
+  return `react:${String(callsiteKey)}:${occurrence}`;
+};
+
+const getDependencies = (value: unknown): readonly unknown[] | undefined =>
+  Array.isArray(value) ? value : undefined;
+
+const createDispatcherProxy = (
+  runtime: ConditionalHookRuntime,
+  dispatcher: ConditionalHookDispatcher,
+): ConditionalHookDispatcher =>
+  new Proxy(dispatcher, {
+    get: (target, property, receiver) => {
+      if (property === "useState") {
+        return (initialState: unknown) =>
+          useConditionalState(getAutomaticHookKey(runtime, "useState"), initialState);
+      }
+      if (property === "useReducer") {
+        return (reducer: unknown, initialState: unknown, initialize: unknown) => {
+          if (typeof reducer !== "function") throw new TypeError("useReducer requires a reducer.");
+          const initializer =
+            typeof initialize === "function" ? (value: unknown) => initialize(value) : undefined;
+          return useConditionalReducer(
+            getAutomaticHookKey(runtime, "useReducer"),
+            (state: unknown, action: unknown) => reducer(state, action),
+            initialState,
+            initializer,
+          );
+        };
+      }
+      if (property === "useRef") {
+        return (initialValue: unknown) =>
+          useConditionalRef(getAutomaticHookKey(runtime, "useRef"), initialValue);
+      }
+      if (property === "useMemo") {
+        return (create: unknown, dependencies: unknown) => {
+          if (typeof create !== "function") throw new TypeError("useMemo requires a function.");
+          return useConditionalMemo(
+            getAutomaticHookKey(runtime, "useMemo"),
+            () => create(),
+            getDependencies(dependencies),
+          );
+        };
+      }
+      if (property === "useCallback") {
+        return (callback: unknown, dependencies: unknown) => {
+          if (typeof callback !== "function") {
+            throw new TypeError("useCallback requires a function.");
+          }
+          return useConditionalMemo(
+            getAutomaticHookKey(runtime, "useCallback"),
+            () => callback,
+            getDependencies(dependencies),
+          );
+        };
+      }
+      if (property === "useEffect" || property === "useLayoutEffect") {
+        return (create: unknown, dependencies: unknown) => {
+          if (typeof create !== "function") {
+            throw new TypeError(`${property} requires a function.`);
+          }
+          registerEffect(
+            getAutomaticHookKey(runtime, property),
+            property === "useEffect" ? "effect" : "layout-effect",
+            () => create(),
+            getDependencies(dependencies),
+          );
+        };
+      }
+      if (property === "useContext" && typeof target.readContext === "function") {
+        return target.readContext;
+      }
+      if (property === "useDebugValue") return (): void => {};
+      return Reflect.get(target, property, receiver);
+    },
+  });
+
+const getRuntimeDispatcher = (
+  runtime: ConditionalHookRuntime,
+): ConditionalHookDispatcher | null => {
+  const dispatcher = runtime.currentDispatcher;
+  if (!runtime.interceptReactHooks || !dispatcher || isContextOnlyDispatcher(dispatcher)) {
+    return dispatcher;
+  }
+  const existingProxy = runtime.proxyByDispatcher.get(dispatcher);
+  if (existingProxy) return existingProxy;
+  const proxy = createDispatcherProxy(runtime, dispatcher);
+  runtime.proxyByDispatcher.set(dispatcher, proxy);
+  return proxy;
+};
+
+const associateScopeWithFiber = (scope: ConditionalHookScope, fiber: Fiber): void => {
+  scope.fiber = fiber;
+  scopeByFiber.set(fiber, scope);
+  if (fiber.alternate) scopeByFiber.set(fiber.alternate, scope);
+};
+
+const beginRender = (runtime: ConditionalHookRuntime, fiber: Fiber): void => {
+  runtime.activeFiber = fiber;
+  const scope =
+    scopeByFiber.get(fiber) ?? (fiber.alternate ? scopeByFiber.get(fiber.alternate) : undefined);
+  if (!scope) return;
+  const previousFrame = renderFrameByFiber.get(fiber);
+  const shouldReplayStrictCells =
+    !scope.didCommit && (fiber.mode & 0b0001000) !== 0 && previousFrame !== undefined;
+  associateScopeWithFiber(scope, fiber);
+  renderFrameByFiber.set(fiber, {
+    callCounts: new Map(),
+    cells: shouldReplayStrictCells ? new Map(previousFrame.cells) : new Map(),
+    effects: new Map(),
+    fiber,
+    hookKinds: new Map(),
+    reducerActionCounts: new Map(),
+    reducerOverrides: new Map(),
+    replayedCells: shouldReplayStrictCells ? new Set(previousFrame.cells.keys()) : new Set(),
+    renderPhaseUpdates: new Map(),
+    scope,
+  });
+};
+
+const handleDispatcherChange = (
+  runtime: ConditionalHookRuntime,
+  dispatcher: ConditionalHookDispatcher | null,
+): void => {
+  const previousDispatcher = runtime.currentDispatcher;
+  runtime.currentDispatcher = dispatcher;
+  if (isContextOnlyDispatcher(dispatcher)) {
+    runtime.activeFiber = null;
+    return;
+  }
+  const fiber = getCurrentFiber(runtime.renderer);
+  if (fiber && (fiber !== runtime.activeFiber || dispatcher !== previousDispatcher)) {
+    beginRender(runtime, fiber);
+  }
+};
+
+const restoreRuntime = (runtime: ConditionalHookRuntime): void => {
+  const descriptor = runtime.originalDescriptor;
+  if (descriptor) {
+    Object.defineProperty(runtime.dispatcherRef, runtime.dispatcherKey, descriptor);
+    runtime.dispatcherRef[runtime.dispatcherKey] = runtime.currentDispatcher;
+  } else {
+    delete runtime.dispatcherRef[runtime.dispatcherKey];
+    runtime.dispatcherRef[runtime.dispatcherKey] = runtime.currentDispatcher;
+  }
+  runtimes.delete(runtime);
+  runtimeByDispatcherRef.delete(runtime.dispatcherRef);
+};
+
+const installRenderer = (renderer: ReactRenderer, options: ConditionalHooksOptions): boolean => {
+  if (
+    typeof renderer.getCurrentFiber !== "function" ||
+    typeof renderer.scheduleUpdate !== "function"
+  ) {
+    return false;
+  }
+  const dispatcherRef = renderer.currentDispatcherRef;
+  if (!dispatcherRef || typeof dispatcherRef !== "object") return false;
+  if (runtimeByDispatcherRef.has(dispatcherRef)) return true;
+
+  const dispatcherKey = "H" in dispatcherRef ? "H" : "current";
+  const originalDescriptor = Object.getOwnPropertyDescriptor(dispatcherRef, dispatcherKey);
+  if (originalDescriptor?.configurable === false) return false;
+
+  const runtime: ConditionalHookRuntime = {
+    activeFiber: null,
+    currentDispatcher: dispatcherRef[dispatcherKey] ?? null,
+    dispatcherKey,
+    dispatcherRef,
+    getHookKey: options.getHookKey ?? defaultHookKeyResolver,
+    interceptReactHooks: options.interceptReactHooks ?? false,
+    originalDescriptor,
+    proxyByDispatcher: new WeakMap(),
+    renderer,
+  };
+
+  Object.defineProperty(dispatcherRef, dispatcherKey, {
+    configurable: true,
+    enumerable: originalDescriptor?.enumerable ?? true,
+    get: () => getRuntimeDispatcher(runtime),
+    set: (dispatcher: ConditionalHookDispatcher | null) => {
+      handleDispatcherChange(runtime, dispatcher);
+    },
+  });
+
+  runtimes.add(runtime);
+  runtimeByDispatcherRef.set(dispatcherRef, runtime);
+  return true;
+};
+
+const getActiveRuntime = (): { fiber: Fiber; runtime: ConditionalHookRuntime } => {
+  for (const runtime of runtimes) {
+    const fiber = runtime.activeFiber ?? getCurrentFiber(runtime.renderer);
+    if (fiber) {
+      if (runtime.activeFiber !== fiber) beginRender(runtime, fiber);
+      return { fiber, runtime };
+    }
+  }
+  throw new Error(
+    "Conditional hooks require a React development renderer and must be called while a component is rendering. Call installConditionalHooks() before rendering.",
+  );
+};
+
+const getScope = (): { frame: ConditionalRenderFrame; scope: ConditionalHookScope } => {
+  const { fiber, runtime } = getActiveRuntime();
+  let scope =
+    scopeByFiber.get(fiber) ?? (fiber.alternate ? scopeByFiber.get(fiber.alternate) : undefined);
+  if (!scope) {
+    scope = {
+      cells: new Map(),
+      didCommit: false,
+      didUnmount: false,
+      effects: new Map(),
+      fiber,
+      hookKinds: new Map(),
+      layoutEffectsDisconnected: false,
+      passiveEffectsDisconnected: false,
+      renderer: runtime.renderer,
+    };
+    associateScopeWithFiber(scope, fiber);
+  }
+  let frame = renderFrameByFiber.get(fiber);
+  if (!frame || frame.scope !== scope) {
+    frame = {
+      callCounts: new Map(),
+      cells: new Map(),
+      effects: new Map(),
+      fiber,
+      hookKinds: new Map(),
+      reducerActionCounts: new Map(),
+      reducerOverrides: new Map(),
+      replayedCells: new Set(),
+      renderPhaseUpdates: new Map(),
+      scope,
+    };
+    renderFrameByFiber.set(fiber, frame);
+  }
+  return { frame, scope };
+};
+
+const registerHookKind = (
+  frame: ConditionalRenderFrame,
+  scope: ConditionalHookScope,
+  key: PropertyKey,
+  kind: ConditionalHookKind,
+): void => {
+  const previousKind = frame.hookKinds.get(key) ?? scope.hookKinds.get(key);
+  if (previousKind && previousKind !== kind) {
+    throw new Error(
+      `Conditional hook key ${String(key)} changed from ${previousKind} to ${kind}. Keys must identify one hook callsite.`,
+    );
+  }
+  frame.hookKinds.set(key, kind);
+};
+
+const scheduleScopeUpdate = (scope: ConditionalHookScope): void => {
+  if (scope.didUnmount) return;
+  const scheduleUpdate = scope.renderer.scheduleUpdate;
+  if (!scheduleUpdate) {
+    throw new Error("The active React renderer does not expose scheduleUpdate().");
+  }
+  // HACK: DevTools schedules a no-op lane, so cloning props bypasses React's bailout check.
+  const currentFiber = getCurrentFiberBranch(scope.fiber);
+  currentFiber.memoizedProps = { ...currentFiber.memoizedProps };
+  if (currentFiber.tag === 14 || currentFiber.tag === 15) {
+    const pendingProps = {
+      ...currentFiber.pendingProps,
+      __bippyConditionalHookUpdate: ++scheduledUpdateVersion,
+    };
+    currentFiber.pendingProps = pendingProps;
+    if (currentFiber.alternate) currentFiber.alternate.pendingProps = pendingProps;
+  }
+  scheduleUpdate(currentFiber);
+};
+
+const getCurrentFiberBranch = (fiber: Fiber): Fiber => {
+  let root = fiber;
+  while (root.return) root = root.return;
+  if (root.stateNode?.current === root) return fiber;
+  return fiber.alternate ?? fiber;
+};
+
+const getRenderFrameForScope = (
+  scope: ConditionalHookScope,
+): ConditionalRenderFrame | undefined => {
+  const fiber = getCurrentFiber(scope.renderer);
+  if (!fiber) return undefined;
+  const activeScope =
+    scopeByFiber.get(fiber) ?? (fiber.alternate ? scopeByFiber.get(fiber.alternate) : undefined);
+  if (activeScope !== scope) return undefined;
+  return renderFrameByFiber.get(fiber);
+};
+
+const enqueueRenderPhaseUpdate = (
+  frame: ConditionalRenderFrame,
+  key: PropertyKey,
+  action: unknown,
+): void => {
+  const updates = frame.renderPhaseUpdates.get(key);
+  if (updates) updates.push(action);
+  else frame.renderPhaseUpdates.set(key, [action]);
+};
+
+const areDependenciesEqual = (
+  previousDependencies: readonly unknown[] | undefined,
+  nextDependencies: readonly unknown[] | undefined,
+): boolean => {
+  if (!previousDependencies || !nextDependencies) return false;
+  if (previousDependencies.length !== nextDependencies.length) return false;
+  return previousDependencies.every((dependency, index) =>
+    Object.is(dependency, nextDependencies[index]),
+  );
+};
+
+const runEffectCleanup = (cell: ConditionalEffectCell): void => {
+  const cleanup = cell.cleanup;
+  cell.cleanup = undefined;
+  cleanup?.();
+};
+
+const startEffect = (
+  scope: ConditionalHookScope,
+  key: PropertyKey,
+  cell: ConditionalEffectCell,
+  create: ConditionalEffectRegistration["create"],
+): void => {
+  const version = ++cell.version;
+  const invoke = (): void => {
+    if (scope.didUnmount || scope.effects.get(key) !== cell || cell.version !== version) return;
+    cell.cleanup = create() || undefined;
+  };
+  if (cell.kind === "layout-effect") {
+    invoke();
+  } else {
+    queueMicrotask(invoke);
+  }
+};
+
+const isStrictEffectsFiber = (fiber: Fiber): boolean => (fiber.mode & 0b0010000) !== 0;
+
+const getVisibilityState = (fiber: Fiber): ConditionalVisibilityState => {
+  let layoutEffectsHidden = false;
+  let passiveEffectsHidden = false;
+  let ancestor = fiber.return;
+  while (ancestor) {
+    if (ancestor.tag === 22 && ancestor.memoizedState !== null) {
+      layoutEffectsHidden = true;
+    }
+    if (ancestor.tag === 31 && ancestor.memoizedProps.mode === "hidden") {
+      layoutEffectsHidden = true;
+      passiveEffectsHidden = true;
+    }
+    ancestor = ancestor.return;
+  }
+  return { layoutEffectsHidden, passiveEffectsHidden };
+};
+
+const reconnectEffects = (scope: ConditionalHookScope, kind: ConditionalEffectKind): void => {
+  for (const [key, cell] of scope.effects) {
+    if (cell.kind === kind) startEffect(scope, key, cell, cell.create);
+  }
+};
+
+const disconnectEffects = (scope: ConditionalHookScope, kind: ConditionalEffectKind): void => {
+  for (const cell of scope.effects.values()) {
+    if (cell.kind === kind) runEffectCleanup(cell);
+  }
+};
+
+const updateScopeVisibility = (scope: ConditionalHookScope): void => {
+  associateScopeWithFiber(scope, getCurrentFiberBranch(scope.fiber));
+  const visibility = getVisibilityState(scope.fiber);
+  const shouldDisconnectLayoutEffects = visibility.layoutEffectsHidden;
+  const shouldDisconnectPassiveEffects = visibility.passiveEffectsHidden;
+
+  if (shouldDisconnectLayoutEffects !== scope.layoutEffectsDisconnected) {
+    scope.layoutEffectsDisconnected = shouldDisconnectLayoutEffects;
+    if (shouldDisconnectLayoutEffects) disconnectEffects(scope, "layout-effect");
+    else reconnectEffects(scope, "layout-effect");
+  }
+  if (shouldDisconnectPassiveEffects !== scope.passiveEffectsDisconnected) {
+    scope.passiveEffectsDisconnected = shouldDisconnectPassiveEffects;
+    if (shouldDisconnectPassiveEffects) disconnectEffects(scope, "effect");
+    else reconnectEffects(scope, "effect");
+  }
+};
+
+const applyRenderPhaseUpdates = (frame: ConditionalRenderFrame): boolean => {
+  let didStateChange = false;
+  for (const [key, actions] of frame.renderPhaseUpdates) {
+    const cell = frame.cells.get(key) ?? frame.scope.cells.get(key);
+    if (!cell || (cell.kind !== "state" && cell.kind !== "reducer")) continue;
+    let nextValue = cell.value;
+    for (const action of actions) {
+      if (cell.kind === "state") {
+        nextValue = typeof action === "function" ? action(nextValue) : action;
+      } else {
+        const reducer = frame.reducerOverrides.get(key) ?? cell.reducer;
+        nextValue = reducer(nextValue, action);
+      }
+    }
+    if (Object.is(cell.value, nextValue)) continue;
+    cell.value = nextValue;
+    didStateChange = true;
+  }
+  return didStateChange;
+};
+
+const commitRenderFrame = (
+  frame: ConditionalRenderFrame,
+  pendingLayoutEffects: Array<[ConditionalHookScope, PropertyKey, ConditionalEffectCell]>,
+  pendingStrictLayoutEffects: Array<[ConditionalHookScope, PropertyKey, ConditionalEffectCell]>,
+  pendingStrictPassiveEffects: Array<[ConditionalHookScope, PropertyKey, ConditionalEffectCell]>,
+): void => {
+  const { effects, scope } = frame;
+  scopes.add(scope);
+  associateScopeWithFiber(scope, frame.fiber);
+  for (const [key, kind] of frame.hookKinds) scope.hookKinds.set(key, kind);
+  for (const [key, cell] of frame.cells) {
+    const previousCell = scope.cells.get(key);
+    if (
+      previousCell?.kind === "reducer" &&
+      cell.kind === "reducer" &&
+      previousCell.dispatch === cell.dispatch
+    ) {
+      previousCell.value = cell.value;
+    } else {
+      scope.cells.set(key, cell);
+    }
+  }
+  for (const [key, reducer] of frame.reducerOverrides) {
+    const cell = scope.cells.get(key);
+    if (cell?.kind === "reducer") {
+      cell.reducer = reducer;
+      const actionCount = frame.reducerActionCounts.get(key) ?? 0;
+      if (actionCount > 0) cell.pendingActions.splice(0, actionCount);
+    }
+  }
+  const isInitialCommit = !scope.didCommit;
+  scope.didCommit = true;
+
+  if (applyRenderPhaseUpdates(frame)) {
+    queueMicrotask(() => scheduleScopeUpdate(scope));
+    return;
+  }
+
+  for (const [key, cell] of scope.effects) {
+    if (effects.has(key)) continue;
+    runEffectCleanup(cell);
+    scope.effects.delete(key);
+  }
+
+  const changedEffects: Array<[PropertyKey, ConditionalEffectCell]> = [];
+  for (const [key, registration] of effects) {
+    const previousCell = scope.effects.get(key);
+    if (
+      previousCell &&
+      previousCell.kind === registration.kind &&
+      areDependenciesEqual(previousCell.dependencies, registration.dependencies)
+    ) {
+      previousCell.create = registration.create;
+      continue;
+    }
+    if (previousCell) runEffectCleanup(previousCell);
+    const cell: ConditionalEffectCell = {
+      cleanup: undefined,
+      create: registration.create,
+      dependencies: registration.dependencies,
+      kind: registration.kind,
+      version: previousCell?.version ?? 0,
+    };
+    scope.effects.set(key, cell);
+    changedEffects.push([key, cell]);
+  }
+
+  const visibility = getVisibilityState(scope.fiber);
+  const areLayoutEffectsHidden = visibility.layoutEffectsHidden;
+  const arePassiveEffectsHidden = visibility.passiveEffectsHidden;
+  for (const [key, cell] of changedEffects) {
+    if (cell.kind === "layout-effect" && areLayoutEffectsHidden) continue;
+    if (cell.kind === "effect" && arePassiveEffectsHidden) continue;
+    if (cell.kind === "layout-effect") pendingLayoutEffects.push([scope, key, cell]);
+    else startEffect(scope, key, cell, cell.create);
+  }
+
+  if (isInitialCommit && isStrictEffectsFiber(frame.fiber)) {
+    const layoutEffects = areLayoutEffectsHidden
+      ? []
+      : changedEffects.filter(([, cell]) => cell.kind === "layout-effect");
+    for (const [key, cell] of layoutEffects) {
+      pendingStrictLayoutEffects.push([scope, key, cell]);
+    }
+    const passiveEffects = arePassiveEffectsHidden
+      ? []
+      : changedEffects.filter(([, cell]) => cell.kind === "effect");
+    for (const [key, cell] of passiveEffects) {
+      pendingStrictPassiveEffects.push([scope, key, cell]);
+    }
+  }
+};
+
+const commitRoot = (root: FiberRoot): void => {
+  const pendingLayoutEffects: Array<[ConditionalHookScope, PropertyKey, ConditionalEffectCell]> =
+    [];
+  const pendingStrictLayoutEffects: Array<
+    [ConditionalHookScope, PropertyKey, ConditionalEffectCell]
+  > = [];
+  const pendingStrictPassiveEffects: Array<
+    [ConditionalHookScope, PropertyKey, ConditionalEffectCell]
+  > = [];
+  traverseFiber(root.current, (fiber) => {
+    const frame = renderFrameByFiber.get(fiber);
+    if (!frame) return;
+    renderFrameByFiber.delete(fiber);
+    commitRenderFrame(
+      frame,
+      pendingLayoutEffects,
+      pendingStrictLayoutEffects,
+      pendingStrictPassiveEffects,
+    );
+  });
+  for (const [scope, key, cell] of pendingLayoutEffects) {
+    startEffect(scope, key, cell, cell.create);
+  }
+  if (pendingStrictLayoutEffects.length > 0 || pendingStrictPassiveEffects.length > 0) {
+    queueMicrotask(() => {
+      for (const [, , cell] of pendingStrictLayoutEffects) runEffectCleanup(cell);
+      for (const [, , cell] of pendingStrictPassiveEffects) runEffectCleanup(cell);
+      for (const [scope, key, cell] of pendingStrictLayoutEffects) {
+        startEffect(scope, key, cell, cell.create);
+      }
+      for (const [scope, key, cell] of pendingStrictPassiveEffects) {
+        startEffect(scope, key, cell, cell.create);
+      }
+    });
+  }
+  for (const scope of scopes) updateScopeVisibility(scope);
+};
+
+const disposeScope = (scope: ConditionalHookScope): void => {
+  if (scope.didUnmount) return;
+  scope.didUnmount = true;
+  for (const cell of scope.effects.values()) runEffectCleanup(cell);
+  scope.effects.clear();
+  scope.cells.clear();
+  scope.hookKinds.clear();
+  scopeByFiber.delete(scope.fiber);
+  renderFrameByFiber.delete(scope.fiber);
+  if (scope.fiber.alternate) {
+    scopeByFiber.delete(scope.fiber.alternate);
+    renderFrameByFiber.delete(scope.fiber.alternate);
+  }
+  scopes.delete(scope);
+};
+
+const unmountFiber = (fiber: Fiber): void => {
+  const scope =
+    scopeByFiber.get(fiber) ?? (fiber.alternate ? scopeByFiber.get(fiber.alternate) : undefined);
+  if (scope) disposeScope(scope);
+};
+
+export const installConditionalHooks = (
+  options: ConditionalHooksOptions = {},
+): ConditionalHooksInstallation => {
+  if (installation) return installation;
+
+  const rdtHook = getRDTHook();
+  for (const renderer of [..._renderers, ...rdtHook.renderers.values()]) {
+    installRenderer(renderer, options);
+  }
+  const unsubscribeRendererInject = onRendererInject((renderer) => {
+    installRenderer(renderer, options);
+  });
+  const unsubscribeInstrumentation = instrument({
+    name: "bippy-conditional-hooks",
+    onCommitFiberRoot: (_rendererId, root) => commitRoot(root),
+    onCommitFiberUnmount: (_rendererId, fiber) => unmountFiber(fiber),
+  });
+
+  let didUnsubscribe = false;
+  const unsubscribe = toUnsubscribe(() => {
+    if (didUnsubscribe) return;
+    didUnsubscribe = true;
+    unsubscribeRendererInject();
+    unsubscribeInstrumentation();
+    for (const scope of scopes) disposeScope(scope);
+    for (const runtime of runtimes) restoreRuntime(runtime);
+    if (installation === unsubscribe) installation = null;
+  });
+
+  installation = Object.defineProperty(unsubscribe, "supportedRenderers", {
+    configurable: true,
+    get: () => runtimes.size,
+  });
+  return installation;
+};
+
+const ensureInstalled = (): void => {
+  if (!installation) installConditionalHooks();
+};
+
+export const useConditionalState = <State>(
+  key: PropertyKey,
+  initialState: State | (() => State),
+): [State, ConditionalStateSetter<State>] => {
+  ensureInstalled();
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "state");
+  let cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (!cell) {
+    const stateCell: ConditionalStateCell = {
+      dispatch: (action) => {
+        if (scope.didUnmount) return;
+        const renderFrame = getRenderFrameForScope(scope);
+        if (renderFrame) {
+          enqueueRenderPhaseUpdate(renderFrame, key, action);
+          return;
+        }
+        if (scope.cells.get(key) !== stateCell) return;
+        const nextValue = typeof action === "function" ? action(stateCell.value) : action;
+        if (typeof action === "function" && (scope.fiber.mode & 0b0001000) !== 0) {
+          action(stateCell.value);
+        }
+        if (Object.is(stateCell.value, nextValue)) return;
+        stateCell.value = nextValue;
+        scheduleScopeUpdate(scope);
+      },
+      kind: "state",
+      value: typeof initialState === "function" ? initialState() : initialState,
+    };
+    cell = stateCell;
+    frame.cells.set(key, cell);
+  } else if (frame.replayedCells.delete(key) && typeof initialState === "function") {
+    initialState();
+  }
+  if (cell.kind !== "state") throw new Error(`Conditional hook key ${String(key)} is not state.`);
+  return [cell.value, cell.dispatch] as [State, ConditionalStateSetter<State>];
+};
+
+export const useConditionalReducer = <State, Action, InitialState>(
+  key: PropertyKey,
+  reducer: (state: State, action: Action) => State,
+  initialState: InitialState,
+  initialize?: (initialState: InitialState) => State,
+): [State, ConditionalReducerDispatcher<Action>] => {
+  ensureInstalled();
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "reducer");
+  let cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (!cell) {
+    const reducerCell: ConditionalReducerCell = {
+      dispatch: (action) => {
+        if (scope.didUnmount) return;
+        const renderFrame = getRenderFrameForScope(scope);
+        if (renderFrame) {
+          enqueueRenderPhaseUpdate(renderFrame, key, action);
+          return;
+        }
+        if (scope.cells.get(key) !== reducerCell) return;
+        reducerCell.pendingActions.push(action);
+        scheduleScopeUpdate(scope);
+      },
+      kind: "reducer",
+      pendingActions: [],
+      reducer: (state, action) => reducer(state as State, action as Action),
+      value: initialize ? initialize(initialState) : initialState,
+    };
+    cell = reducerCell;
+    frame.cells.set(key, cell);
+  } else if (frame.replayedCells.delete(key) && initialize) {
+    initialize(initialState);
+  }
+  if (cell.kind !== "reducer") {
+    throw new Error(`Conditional hook key ${String(key)} is not a reducer.`);
+  }
+  const currentReducer = (state: unknown, action: unknown): unknown =>
+    reducer(state as State, action as Action);
+  frame.reducerOverrides.set(key, currentReducer);
+  if (cell.pendingActions.length > 0) {
+    let nextValue = cell.value;
+    for (const action of cell.pendingActions) nextValue = currentReducer(nextValue, action);
+    const renderedCell: ConditionalReducerCell = {
+      ...cell,
+      value: nextValue,
+    };
+    frame.cells.set(key, renderedCell);
+    frame.reducerActionCounts.set(key, cell.pendingActions.length);
+    cell = renderedCell;
+  }
+  return [cell.value, cell.dispatch] as [State, ConditionalReducerDispatcher<Action>];
+};
+
+export const useConditionalRef = <Value>(
+  key: PropertyKey,
+  initialValue: Value,
+): ConditionalRef<Value> => {
+  ensureInstalled();
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "ref");
+  let cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (!cell) {
+    cell = {
+      kind: "ref",
+      value: { current: initialValue },
+    };
+    frame.cells.set(key, cell);
+  }
+  if (cell.kind !== "ref") throw new Error(`Conditional hook key ${String(key)} is not a ref.`);
+  return cell.value as ConditionalRef<Value>;
+};
+
+export const useConditionalMemo = <Value>(
+  key: PropertyKey,
+  create: () => Value,
+  dependencies?: readonly unknown[],
+): Value => {
+  ensureInstalled();
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "memo");
+  const cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (cell?.kind === "memo" && frame.replayedCells.delete(key)) {
+    create();
+    return cell.value as Value;
+  }
+  if (cell?.kind === "memo" && areDependenciesEqual(cell.dependencies, dependencies)) {
+    return cell.value as Value;
+  }
+  if (cell && cell.kind !== "memo") {
+    throw new Error(`Conditional hook key ${String(key)} is not memoized.`);
+  }
+  const value = create();
+  frame.cells.set(key, {
+    dependencies,
+    kind: "memo",
+    value,
+  });
+  return value;
+};
+
+export const useConditionalCallback = <Callback extends (...arguments_: never[]) => unknown>(
+  key: PropertyKey,
+  callback: Callback,
+  dependencies?: readonly unknown[],
+): Callback => useConditionalMemo(key, () => callback, dependencies);
+
+const registerEffect = (
+  key: PropertyKey,
+  kind: ConditionalEffectKind,
+  create: () => (() => void) | void,
+  dependencies?: readonly unknown[],
+): void => {
+  ensureInstalled();
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, kind);
+  frame.effects.set(key, {
+    create,
+    dependencies,
+    kind,
+  });
+};
+
+export const useConditionalEffect = (
+  key: PropertyKey,
+  create: () => (() => void) | void,
+  dependencies?: readonly unknown[],
+): void => {
+  registerEffect(key, "effect", create, dependencies);
+};
+
+export const useConditionalLayoutEffect = (
+  key: PropertyKey,
+  create: () => (() => void) | void,
+  dependencies?: readonly unknown[],
+): void => {
+  registerEffect(key, "layout-effect", create, dependencies);
+};

--- a/packages/bippy/src/conditional-hooks.ts
+++ b/packages/bippy/src/conditional-hooks.ts
@@ -203,14 +203,14 @@ const createDispatcherProxy = (
     get: (target, property, receiver) => {
       if (property === "useState") {
         return (initialState: unknown) =>
-          useConditionalState(getAutomaticHookKey(runtime, "useState"), initialState);
+          readStateCell(getAutomaticHookKey(runtime, "useState"), initialState);
       }
       if (property === "useReducer") {
         return (reducer: unknown, initialState: unknown, initialize: unknown) => {
           if (typeof reducer !== "function") throw new TypeError("useReducer requires a reducer.");
           const initializer =
             typeof initialize === "function" ? (value: unknown) => initialize(value) : undefined;
-          return useConditionalReducer(
+          return readReducerCell(
             getAutomaticHookKey(runtime, "useReducer"),
             (state: unknown, action: unknown) => reducer(state, action),
             initialState,
@@ -220,12 +220,12 @@ const createDispatcherProxy = (
       }
       if (property === "useRef") {
         return (initialValue: unknown) =>
-          useConditionalRef(getAutomaticHookKey(runtime, "useRef"), initialValue);
+          readRefCell(getAutomaticHookKey(runtime, "useRef"), initialValue);
       }
       if (property === "useMemo") {
         return (create: unknown, dependencies: unknown) => {
           if (typeof create !== "function") throw new TypeError("useMemo requires a function.");
-          return useConditionalMemo(
+          return readMemoCell(
             getAutomaticHookKey(runtime, "useMemo"),
             () => create(),
             getDependencies(dependencies),
@@ -237,7 +237,7 @@ const createDispatcherProxy = (
           if (typeof callback !== "function") {
             throw new TypeError("useCallback requires a function.");
           }
-          return useConditionalMemo(
+          return readMemoCell(
             getAutomaticHookKey(runtime, "useCallback"),
             () => callback,
             getDependencies(dependencies),
@@ -788,7 +788,7 @@ const ensureInstalled = (): void => {
   if (!installation) installConditionalHooks();
 };
 
-const useConditionalState = <State>(
+const readStateCell = <State>(
   key: PropertyKey,
   initialState: State | (() => State),
 ): [State, ConditionalStateSetter<State>] => {
@@ -826,7 +826,7 @@ const useConditionalState = <State>(
   return [cell.value, cell.dispatch] as [State, ConditionalStateSetter<State>];
 };
 
-const useConditionalReducer = <State, Action, InitialState>(
+const readReducerCell = <State, Action, InitialState>(
   key: PropertyKey,
   reducer: (state: State, action: Action) => State,
   initialState: InitialState,
@@ -879,7 +879,7 @@ const useConditionalReducer = <State, Action, InitialState>(
   return [cell.value, cell.dispatch] as [State, ConditionalReducerDispatcher<Action>];
 };
 
-const useConditionalRef = <Value>(key: PropertyKey, initialValue: Value): ConditionalRef<Value> => {
+const readRefCell = <Value>(key: PropertyKey, initialValue: Value): ConditionalRef<Value> => {
   ensureInstalled();
   const { frame, scope } = getScope();
   registerHookKind(frame, scope, key, "ref");
@@ -895,7 +895,7 @@ const useConditionalRef = <Value>(key: PropertyKey, initialValue: Value): Condit
   return cell.value as ConditionalRef<Value>;
 };
 
-const useConditionalMemo = <Value>(
+const readMemoCell = <Value>(
   key: PropertyKey,
   create: () => Value,
   dependencies?: readonly unknown[],

--- a/packages/bippy/src/conditional-hooks.ts
+++ b/packages/bippy/src/conditional-hooks.ts
@@ -29,7 +29,6 @@ interface ConditionalHookRuntime {
   dispatcherKey: "H" | "current";
   dispatcherRef: ConditionalHookDispatcherRef;
   getHookKey: ConditionalHookKeyResolver;
-  interceptReactHooks: boolean;
   originalDescriptor: PropertyDescriptor | undefined;
   proxyByDispatcher: WeakMap<object, ConditionalHookDispatcher>;
   renderer: ReactRenderer;
@@ -104,15 +103,15 @@ interface ConditionalEffectRegistration {
   kind: ConditionalEffectKind;
 }
 
-export interface ConditionalRef<Value> {
+interface ConditionalRef<Value> {
   current: Value;
 }
 
-export interface ConditionalStateSetter<State> {
+interface ConditionalStateSetter<State> {
   (action: State | ((previousState: State) => State)): void;
 }
 
-export interface ConditionalReducerDispatcher<Action> {
+interface ConditionalReducerDispatcher<Action> {
   (action: Action): void;
 }
 
@@ -122,7 +121,6 @@ export interface ConditionalHooksInstallation extends Unsubscribe {
 
 export interface ConditionalHooksOptions {
   getHookKey?: ConditionalHookKeyResolver;
-  interceptReactHooks?: boolean;
 }
 
 export interface ConditionalHookKeyResolver {
@@ -271,7 +269,7 @@ const getRuntimeDispatcher = (
   runtime: ConditionalHookRuntime,
 ): ConditionalHookDispatcher | null => {
   const dispatcher = runtime.currentDispatcher;
-  if (!runtime.interceptReactHooks || !dispatcher || isContextOnlyDispatcher(dispatcher)) {
+  if (!dispatcher || isContextOnlyDispatcher(dispatcher)) {
     return dispatcher;
   }
   const existingProxy = runtime.proxyByDispatcher.get(dispatcher);
@@ -360,7 +358,6 @@ const installRenderer = (renderer: ReactRenderer, options: ConditionalHooksOptio
     dispatcherKey,
     dispatcherRef,
     getHookKey: options.getHookKey ?? defaultHookKeyResolver,
-    interceptReactHooks: options.interceptReactHooks ?? false,
     originalDescriptor,
     proxyByDispatcher: new WeakMap(),
     renderer,
@@ -791,7 +788,7 @@ const ensureInstalled = (): void => {
   if (!installation) installConditionalHooks();
 };
 
-export const useConditionalState = <State>(
+const useConditionalState = <State>(
   key: PropertyKey,
   initialState: State | (() => State),
 ): [State, ConditionalStateSetter<State>] => {
@@ -829,7 +826,7 @@ export const useConditionalState = <State>(
   return [cell.value, cell.dispatch] as [State, ConditionalStateSetter<State>];
 };
 
-export const useConditionalReducer = <State, Action, InitialState>(
+const useConditionalReducer = <State, Action, InitialState>(
   key: PropertyKey,
   reducer: (state: State, action: Action) => State,
   initialState: InitialState,
@@ -882,10 +879,7 @@ export const useConditionalReducer = <State, Action, InitialState>(
   return [cell.value, cell.dispatch] as [State, ConditionalReducerDispatcher<Action>];
 };
 
-export const useConditionalRef = <Value>(
-  key: PropertyKey,
-  initialValue: Value,
-): ConditionalRef<Value> => {
+const useConditionalRef = <Value>(key: PropertyKey, initialValue: Value): ConditionalRef<Value> => {
   ensureInstalled();
   const { frame, scope } = getScope();
   registerHookKind(frame, scope, key, "ref");
@@ -901,7 +895,7 @@ export const useConditionalRef = <Value>(
   return cell.value as ConditionalRef<Value>;
 };
 
-export const useConditionalMemo = <Value>(
+const useConditionalMemo = <Value>(
   key: PropertyKey,
   create: () => Value,
   dependencies?: readonly unknown[],
@@ -929,12 +923,6 @@ export const useConditionalMemo = <Value>(
   return value;
 };
 
-export const useConditionalCallback = <Callback extends (...arguments_: never[]) => unknown>(
-  key: PropertyKey,
-  callback: Callback,
-  dependencies?: readonly unknown[],
-): Callback => useConditionalMemo(key, () => callback, dependencies);
-
 const registerEffect = (
   key: PropertyKey,
   kind: ConditionalEffectKind,
@@ -949,20 +937,4 @@ const registerEffect = (
     dependencies,
     kind,
   });
-};
-
-export const useConditionalEffect = (
-  key: PropertyKey,
-  create: () => (() => void) | void,
-  dependencies?: readonly unknown[],
-): void => {
-  registerEffect(key, "effect", create, dependencies);
-};
-
-export const useConditionalLayoutEffect = (
-  key: PropertyKey,
-  create: () => (() => void) | void,
-  dependencies?: readonly unknown[],
-): void => {
-  registerEffect(key, "layout-effect", create, dependencies);
 };

--- a/packages/bippy/src/index.ts
+++ b/packages/bippy/src/index.ts
@@ -1,3 +1,4 @@
 import "./install-hook-only.js";
 
 export * from "./core.js";
+export * from "./conditional-hooks.js";

--- a/packages/bippy/src/types.ts
+++ b/packages/bippy/src/types.ts
@@ -400,7 +400,7 @@ export interface ReactRenderer {
   // dev only: https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactFiberReconciler.js#L842
   findFiberByHostInstance?: (hostInstance: unknown) => Fiber | null;
   // react devtools
-  getCurrentFiber?: (fiber: Fiber) => Fiber | null;
+  getCurrentFiber?: () => Fiber | null;
   overrideContext?: (fiber: Fiber, contextType: unknown, path: string[], value: unknown) => void;
 
   overrideHookState?: (fiber: Fiber, id: string, path: string[], value: unknown) => void;

--- a/packages/bippy/tests/conditional-hooks-adversarial.test.tsx
+++ b/packages/bippy/tests/conditional-hooks-adversarial.test.tsx
@@ -1,11 +1,4 @@
-import {
-  installConditionalHooks,
-  type ConditionalHooksOptions,
-  useConditionalEffect,
-  useConditionalLayoutEffect,
-  useConditionalMemo,
-  useConditionalState,
-} from "../src/index.js";
+import { installConditionalHooks, type ConditionalHooksOptions } from "../src/index.js";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -71,7 +64,7 @@ describe("conditional hook adversarial cases", () => {
     install();
     const conditionalInitialize = vi.fn(() => 0);
     const ConditionalComponent = (): React.ReactNode => {
-      useConditionalState("state", conditionalInitialize);
+      React.useState(conditionalInitialize);
       return null;
     };
     render(
@@ -103,14 +96,10 @@ describe("conditional hook adversarial cases", () => {
     install();
     const conditionalEvents: string[] = [];
     const ConditionalComponent = (): React.ReactNode => {
-      useConditionalEffect(
-        "effect",
-        () => {
-          conditionalEvents.push("mount");
-          return () => conditionalEvents.push("cleanup");
-        },
-        [],
-      );
+      React.useEffect(() => {
+        conditionalEvents.push("mount");
+        return () => conditionalEvents.push("cleanup");
+      }, []);
       return null;
     };
     render(
@@ -127,7 +116,7 @@ describe("conditional hook adversarial cases", () => {
     const renders: number[] = [];
 
     const Component = (): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
+      const [count, setCount] = React.useState(0);
       renders.push(count);
       if (count < 3) setCount(count + 1);
       return <span>{count}</span>;
@@ -144,8 +133,8 @@ describe("conditional hook adversarial cases", () => {
     const events: string[] = [];
 
     const Component = ({ signal }: SignalProperties): React.ReactNode => {
-      const [counter, setCounter] = useConditionalState("counter", 0);
-      const [previousSignal, setPreviousSignal] = useConditionalState("signal", true);
+      const [counter, setCounter] = React.useState(0);
+      const [previousSignal, setPreviousSignal] = React.useState(true);
       if (previousSignal !== signal) {
         setCounter((value) => value + 1);
         setPreviousSignal(signal);
@@ -193,14 +182,10 @@ describe("conditional hook adversarial cases", () => {
     const deferred = createDeferred<void>();
 
     const Component = ({ shouldSuspend, value }: MemoRollbackProperties): React.ReactNode => {
-      const memoized = useConditionalMemo(
-        "memo",
-        () => {
-          computedValues.push(value);
-          return value;
-        },
-        [value],
-      );
+      const memoized = React.useMemo(() => {
+        computedValues.push(value);
+        return value;
+      }, [value]);
       if (shouldSuspend) throw deferred.promise;
       return <span>{memoized}</span>;
     };
@@ -233,14 +218,10 @@ describe("conditional hook adversarial cases", () => {
     let didResolve = false;
 
     const Child = (): React.ReactNode => {
-      useConditionalLayoutEffect(
-        "layout",
-        () => {
-          events.push("mount");
-          return () => events.push("cleanup");
-        },
-        [],
-      );
+      React.useLayoutEffect(() => {
+        events.push("mount");
+        return () => events.push("cleanup");
+      }, []);
       return <span>child</span>;
     };
     const SuspenseContent = ({ shouldSuspend }: SuspenseContentProperties): React.ReactNode => {
@@ -286,7 +267,7 @@ describe("conditional hook adversarial cases", () => {
     install();
 
     const Counter = React.memo((): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
+      const [count, setCount] = React.useState(0);
       return <button onClick={() => setCount((value) => value + 1)}>{count}</button>;
     });
 
@@ -296,7 +277,7 @@ describe("conditional hook adversarial cases", () => {
   });
 
   it("tracks provider updates through intercepted useContext", async () => {
-    install({ interceptReactHooks: true });
+    install();
     const ValueContext = React.createContext("first");
 
     const Child = React.memo((): React.ReactNode => {
@@ -323,14 +304,10 @@ describe("conditional hook adversarial cases", () => {
     const events: string[] = [];
 
     const Child = ({ name }: EffectChildProperties): React.ReactNode => {
-      useConditionalEffect(
-        "effect",
-        () => {
-          events.push(`mount:${name}`);
-          return () => events.push(`cleanup:${name}`);
-        },
-        [],
-      );
+      React.useEffect(() => {
+        events.push(`mount:${name}`);
+        return () => events.push(`cleanup:${name}`);
+      }, []);
       return <span>{name}</span>;
     };
 
@@ -347,11 +324,11 @@ describe("conditional hook adversarial cases", () => {
     expect(events).toEqual(["mount:first", "mount:second", "cleanup:first", "cleanup:second"]);
   });
 
-  it("isolates identical explicit keys across separate roots", async () => {
+  it("isolates identical automatic callsites across separate roots", async () => {
     install();
 
     const Counter = ({ name }: EffectChildProperties): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
+      const [count, setCount] = React.useState(0);
       return (
         <button onClick={() => setCount((value) => value + 1)}>
           {name}:{count}
@@ -372,8 +349,8 @@ describe("conditional hook adversarial cases", () => {
     install();
 
     const Component = (): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
-      useConditionalEffect("effect", () => setCount((value) => value + 1), []);
+      const [count, setCount] = React.useState(0);
+      React.useEffect(() => setCount((value) => value + 1), []);
       return <span>{count}</span>;
     };
 
@@ -382,7 +359,7 @@ describe("conditional hook adversarial cases", () => {
   });
 
   it("restores the native dispatcher when installation is disposed", async () => {
-    const installation = install({ interceptReactHooks: true });
+    const installation = install();
     installation();
 
     const Component = (): React.ReactNode => {

--- a/packages/bippy/tests/conditional-hooks-adversarial.test.tsx
+++ b/packages/bippy/tests/conditional-hooks-adversarial.test.tsx
@@ -1,0 +1,397 @@
+import {
+  installConditionalHooks,
+  type ConditionalHooksOptions,
+  useConditionalEffect,
+  useConditionalLayoutEffect,
+  useConditionalMemo,
+  useConditionalState,
+} from "../src/index.js";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface Deferred<Value> {
+  promise: Promise<Value>;
+  resolve: (value: Value) => void;
+}
+
+interface EffectChildProperties {
+  name: string;
+}
+
+interface MemoRollbackProperties {
+  shouldSuspend: boolean;
+  value: number;
+}
+
+interface SignalProperties {
+  signal: boolean;
+}
+
+interface SuspenseContentProperties {
+  shouldSuspend: boolean;
+}
+
+const installations: Array<ReturnType<typeof installConditionalHooks>> = [];
+
+const install = (options?: ConditionalHooksOptions): ReturnType<typeof installConditionalHooks> => {
+  const installation = installConditionalHooks(options);
+  installations.push(installation);
+  return installation;
+};
+
+const createDeferred = <Value,>(): Deferred<Value> => {
+  let resolvePromise: ((value: Value) => void) | undefined;
+  const promise = new Promise<Value>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (!resolvePromise) throw new Error("Deferred resolver was not initialized.");
+  return { promise, resolve: resolvePromise };
+};
+
+afterEach(() => {
+  cleanup();
+  for (const installation of installations.splice(0)) installation();
+});
+
+describe("conditional hook adversarial cases", () => {
+  it("matches native Strict Mode state initializer replay", () => {
+    const nativeInitialize = vi.fn(() => 0);
+    const NativeComponent = (): React.ReactNode => {
+      React.useState(nativeInitialize);
+      return null;
+    };
+    const nativeRendered = render(
+      <React.StrictMode>
+        <NativeComponent />
+      </React.StrictMode>,
+    );
+    nativeRendered.unmount();
+
+    install();
+    const conditionalInitialize = vi.fn(() => 0);
+    const ConditionalComponent = (): React.ReactNode => {
+      useConditionalState("state", conditionalInitialize);
+      return null;
+    };
+    render(
+      <React.StrictMode>
+        <ConditionalComponent />
+      </React.StrictMode>,
+    );
+
+    expect(conditionalInitialize).toHaveBeenCalledTimes(nativeInitialize.mock.calls.length);
+  });
+
+  it("matches native Strict Mode passive effect replay", async () => {
+    const nativeEvents: string[] = [];
+    const NativeComponent = (): React.ReactNode => {
+      React.useEffect(() => {
+        nativeEvents.push("mount");
+        return () => nativeEvents.push("cleanup");
+      }, []);
+      return null;
+    };
+    const nativeRendered = render(
+      <React.StrictMode>
+        <NativeComponent />
+      </React.StrictMode>,
+    );
+    await waitFor(() => expect(nativeEvents).toEqual(["mount", "cleanup", "mount"]));
+    nativeRendered.unmount();
+
+    install();
+    const conditionalEvents: string[] = [];
+    const ConditionalComponent = (): React.ReactNode => {
+      useConditionalEffect(
+        "effect",
+        () => {
+          conditionalEvents.push("mount");
+          return () => conditionalEvents.push("cleanup");
+        },
+        [],
+      );
+      return null;
+    };
+    render(
+      <React.StrictMode>
+        <ConditionalComponent />
+      </React.StrictMode>,
+    );
+
+    await waitFor(() => expect(conditionalEvents).toEqual(nativeEvents.slice(0, 3)));
+  });
+
+  it("converges render-phase state updates", async () => {
+    install();
+    const renders: number[] = [];
+
+    const Component = (): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      renders.push(count);
+      if (count < 3) setCount(count + 1);
+      return <span>{count}</span>;
+    };
+
+    render(<Component />);
+    await waitFor(() => expect(screen.getByText("3")).toBeDefined());
+    expect(renders).toEqual([0, 1, 2, 3]);
+  });
+
+  it("discards render-phase updates from a suspended attempt", async () => {
+    install();
+    const deferred = createDeferred<void>();
+    const events: string[] = [];
+
+    const Component = ({ signal }: SignalProperties): React.ReactNode => {
+      const [counter, setCounter] = useConditionalState("counter", 0);
+      const [previousSignal, setPreviousSignal] = useConditionalState("signal", true);
+      if (previousSignal !== signal) {
+        setCounter((value) => value + 1);
+        setPreviousSignal(signal);
+        if (counter === 0) {
+          events.push("suspend");
+          throw deferred.promise;
+        }
+      }
+      return <span>{counter}</span>;
+    };
+
+    const rendered = render(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Component signal />
+      </React.Suspense>,
+    );
+    expect(screen.getByText("0")).toBeDefined();
+
+    rendered.rerender(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Component signal={false} />
+      </React.Suspense>,
+    );
+    expect(screen.getByText("loading")).toBeDefined();
+
+    rendered.rerender(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Component signal={false} />
+      </React.Suspense>,
+    );
+    const attemptsAfterFirstSuspension = events.length;
+    expect(attemptsAfterFirstSuspension).toBeGreaterThan(0);
+    rendered.rerender(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Component signal={false} />
+      </React.Suspense>,
+    );
+    expect(events.length).toBeGreaterThan(attemptsAfterFirstSuspension);
+    expect(screen.getByText("loading")).toBeDefined();
+  });
+
+  it("rolls memo cells back when a render suspends", () => {
+    install();
+    const computedValues: number[] = [];
+    const deferred = createDeferred<void>();
+
+    const Component = ({ shouldSuspend, value }: MemoRollbackProperties): React.ReactNode => {
+      const memoized = useConditionalMemo(
+        "memo",
+        () => {
+          computedValues.push(value);
+          return value;
+        },
+        [value],
+      );
+      if (shouldSuspend) throw deferred.promise;
+      return <span>{memoized}</span>;
+    };
+
+    const rendered = render(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Component shouldSuspend={false} value={0} />
+      </React.Suspense>,
+    );
+    rendered.rerender(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Component shouldSuspend value={1} />
+      </React.Suspense>,
+    );
+    expect(screen.getByText("loading")).toBeDefined();
+    rendered.rerender(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Component shouldSuspend={false} value={0} />
+      </React.Suspense>,
+    );
+
+    expect(computedValues.filter((value) => value === 0)).toEqual([0]);
+    expect(computedValues.every((value) => value === 0 || value === 1)).toBe(true);
+  });
+
+  it("disconnects and reconnects layout effects when Suspense hides content", async () => {
+    install();
+    const deferred = createDeferred<void>();
+    const events: string[] = [];
+    let didResolve = false;
+
+    const Child = (): React.ReactNode => {
+      useConditionalLayoutEffect(
+        "layout",
+        () => {
+          events.push("mount");
+          return () => events.push("cleanup");
+        },
+        [],
+      );
+      return <span>child</span>;
+    };
+    const SuspenseContent = ({ shouldSuspend }: SuspenseContentProperties): React.ReactNode => {
+      return (
+        <>
+          <Child />
+          {shouldSuspend && !didResolve
+            ? (() => {
+                throw deferred.promise;
+              })()
+            : null}
+        </>
+      );
+    };
+
+    const rendered = render(
+      <React.Suspense fallback={<span>loading</span>}>
+        <SuspenseContent shouldSuspend={false} />
+      </React.Suspense>,
+    );
+    expect(events).toEqual(["mount"]);
+    rendered.rerender(
+      <React.Suspense fallback={<span>loading</span>}>
+        <SuspenseContent shouldSuspend />
+      </React.Suspense>,
+    );
+    expect(events).toEqual(["mount", "cleanup"]);
+
+    await act(async () => {
+      didResolve = true;
+      deferred.resolve();
+      await deferred.promise;
+    });
+    rendered.rerender(
+      <React.Suspense fallback={<span>loading</span>}>
+        <SuspenseContent shouldSuspend={false} />
+      </React.Suspense>,
+    );
+    expect(events).toEqual(["mount", "cleanup", "mount"]);
+  });
+
+  it("updates a memoized component from its conditional setter", async () => {
+    install();
+
+    const Counter = React.memo((): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      return <button onClick={() => setCount((value) => value + 1)}>{count}</button>;
+    });
+
+    render(<Counter />);
+    fireEvent.click(screen.getByText("0"));
+    await waitFor(() => expect(screen.getByText("1")).toBeDefined());
+  });
+
+  it("tracks provider updates through intercepted useContext", async () => {
+    install({ interceptReactHooks: true });
+    const ValueContext = React.createContext("first");
+
+    const Child = React.memo((): React.ReactNode => {
+      const value = React.useContext(ValueContext);
+      return <span>{value}</span>;
+    });
+    const Component = (): React.ReactNode => {
+      const [value, setValue] = React.useState("first");
+      return (
+        <ValueContext.Provider value={value}>
+          <button onClick={() => setValue("second")}>update</button>
+          <Child />
+        </ValueContext.Provider>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("update"));
+    await waitFor(() => expect(screen.getByText("second")).toBeDefined());
+  });
+
+  it("does not clean effects on retained siblings after deletion and reorder", async () => {
+    install();
+    const events: string[] = [];
+
+    const Child = ({ name }: EffectChildProperties): React.ReactNode => {
+      useConditionalEffect(
+        "effect",
+        () => {
+          events.push(`mount:${name}`);
+          return () => events.push(`cleanup:${name}`);
+        },
+        [],
+      );
+      return <span>{name}</span>;
+    };
+
+    const rendered = render(
+      <>
+        <Child key="first" name="first" />
+        <Child key="second" name="second" />
+      </>,
+    );
+    await waitFor(() => expect(events).toEqual(["mount:first", "mount:second"]));
+    rendered.rerender(<Child key="second" name="second" />);
+    expect(events).toEqual(["mount:first", "mount:second", "cleanup:first"]);
+    rendered.unmount();
+    expect(events).toEqual(["mount:first", "mount:second", "cleanup:first", "cleanup:second"]);
+  });
+
+  it("isolates identical explicit keys across separate roots", async () => {
+    install();
+
+    const Counter = ({ name }: EffectChildProperties): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      return (
+        <button onClick={() => setCount((value) => value + 1)}>
+          {name}:{count}
+        </button>
+      );
+    };
+
+    const firstRoot = render(<Counter name="first" />);
+    const secondRoot = render(<Counter name="second" />);
+    fireEvent.click(screen.getByText("first:0"));
+    await waitFor(() => expect(screen.getByText("first:1")).toBeDefined());
+    expect(screen.getByText("second:0")).toBeDefined();
+    firstRoot.unmount();
+    secondRoot.unmount();
+  });
+
+  it("supports a state update from passive effect setup", async () => {
+    install();
+
+    const Component = (): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      useConditionalEffect("effect", () => setCount((value) => value + 1), []);
+      return <span>{count}</span>;
+    };
+
+    render(<Component />);
+    await waitFor(() => expect(screen.getByText("1")).toBeDefined());
+  });
+
+  it("restores the native dispatcher when installation is disposed", async () => {
+    const installation = install({ interceptReactHooks: true });
+    installation();
+
+    const Component = (): React.ReactNode => {
+      const [count, setCount] = React.useState(0);
+      return <button onClick={() => setCount((value) => value + 1)}>{count}</button>;
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("0"));
+    await waitFor(() => expect(screen.getByText("1")).toBeDefined());
+  });
+});

--- a/packages/bippy/tests/conditional-hooks-edge-cases.test.tsx
+++ b/packages/bippy/tests/conditional-hooks-edge-cases.test.tsx
@@ -1,12 +1,4 @@
-import {
-  installConditionalHooks,
-  type ConditionalHooksOptions,
-  type ConditionalStateSetter,
-  useConditionalEffect,
-  useConditionalLayoutEffect,
-  useConditionalRef,
-  useConditionalState,
-} from "../src/index.js";
+import { installConditionalHooks, type ConditionalHooksOptions } from "../src/index.js";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -43,7 +35,7 @@ afterEach(() => {
 
 describe("conditional hook edge cases", () => {
   it("does not commit an effect from a suspended render", async () => {
-    install({ interceptReactHooks: true });
+    install();
     const deferred = createDeferred<void>();
     const events: string[] = [];
     let didResolve = false;
@@ -82,13 +74,9 @@ describe("conditional hook edge cases", () => {
     const events: string[] = [];
 
     const BrokenComponent = (): React.ReactNode => {
-      useConditionalEffect(
-        "aborted-effect",
-        () => {
-          events.push("mounted");
-        },
-        [],
-      );
+      React.useEffect(() => {
+        events.push("mounted");
+      }, []);
       throw new Error("render aborted");
     };
 
@@ -103,14 +91,10 @@ describe("conditional hook edge cases", () => {
 
     const Component = (): React.ReactNode => {
       const [version, setVersion] = React.useState(0);
-      useConditionalEffect(
-        "dependency-effect",
-        () => {
-          events.push(`start:${version}`);
-          return () => events.push(`stop:${version}`);
-        },
-        [version],
-      );
+      React.useEffect(() => {
+        events.push(`start:${version}`);
+        return () => events.push(`stop:${version}`);
+      }, [version]);
       return <button onClick={() => setVersion((value) => value + 1)}>{version}</button>;
     };
 
@@ -125,14 +109,10 @@ describe("conditional hook edge cases", () => {
     const events: string[] = [];
 
     const Component = (): React.ReactNode => {
-      useConditionalLayoutEffect(
-        "layout-effect",
-        () => {
-          events.push("mounted");
-          return () => events.push("cleaned");
-        },
-        [],
-      );
+      React.useLayoutEffect(() => {
+        events.push("mounted");
+        return () => events.push("cleaned");
+      }, []);
       return <span>content</span>;
     };
 
@@ -147,7 +127,7 @@ describe("conditional hook edge cases", () => {
     const effect = vi.fn();
 
     const Component = (): React.ReactNode => {
-      useConditionalEffect("queued-effect", effect, []);
+      React.useEffect(effect, []);
       return null;
     };
 
@@ -162,14 +142,10 @@ describe("conditional hook edge cases", () => {
     const events: string[] = [];
 
     const Component = (): React.ReactNode => {
-      useConditionalEffect(
-        "installed-effect",
-        () => {
-          events.push("mounted");
-          return () => events.push("cleaned");
-        },
-        [],
-      );
+      React.useEffect(() => {
+        events.push("mounted");
+        return () => events.push("cleaned");
+      }, []);
       return null;
     };
 
@@ -189,11 +165,11 @@ describe("conditional hook edge cases", () => {
     expect(secondInstallation.supportedRenderers).toBe(supportedRenderers);
   });
 
-  it("gives a remounted Fiber fresh keyed state", async () => {
+  it("gives a remounted Fiber fresh conditional state", async () => {
     install();
 
     const Counter = (): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
+      const [count, setCount] = React.useState(0);
       return <button onClick={() => setCount((value) => value + 1)}>count:{count}</button>;
     };
 
@@ -215,7 +191,7 @@ describe("conditional hook edge cases", () => {
   });
 
   it("retains same-callsite loop cells when the loop shrinks and grows", async () => {
-    install({ interceptReactHooks: true });
+    install();
 
     const Component = (): React.ReactNode => {
       const [itemCount, setItemCount] = React.useState(1);
@@ -251,7 +227,7 @@ describe("conditional hook edge cases", () => {
     install();
 
     const Component = (): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
+      const [count, setCount] = React.useState(0);
       const incrementTwice = (): void => {
         setCount((value) => value + 1);
         setCount((value) => value + 1);
@@ -270,7 +246,7 @@ describe("conditional hook edge cases", () => {
 
     const Component = (): React.ReactNode => {
       renderCount++;
-      const [count, setCount] = useConditionalState("count", 0);
+      const [count, setCount] = React.useState(0);
       return <button onClick={() => setCount(0)}>{count}</button>;
     };
 
@@ -283,10 +259,10 @@ describe("conditional hook edge cases", () => {
 
   it("ignores a captured setter after its Fiber unmounts", () => {
     install();
-    let capturedSetter: ConditionalStateSetter<number> | undefined;
+    let capturedSetter: React.Dispatch<React.SetStateAction<number>> | undefined;
 
     const Component = (): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
+      const [count, setCount] = React.useState(0);
       capturedSetter = setCount;
       return <span>{count}</span>;
     };
@@ -297,19 +273,5 @@ describe("conditional hook edge cases", () => {
     const update = vi.fn((value: number) => value + 1);
     expect(() => capturedSetter?.(update)).not.toThrow();
     expect(update).not.toHaveBeenCalled();
-  });
-
-  it("rejects one explicit key being reused for different hook kinds", () => {
-    install();
-
-    const BrokenComponent = (): React.ReactNode => {
-      useConditionalState("shared-key", 0);
-      useConditionalRef("shared-key", null);
-      return null;
-    };
-
-    expect(() => render(<BrokenComponent />)).toThrowError(
-      "Conditional hook key shared-key changed from state to ref",
-    );
   });
 });

--- a/packages/bippy/tests/conditional-hooks-edge-cases.test.tsx
+++ b/packages/bippy/tests/conditional-hooks-edge-cases.test.tsx
@@ -1,0 +1,315 @@
+import {
+  installConditionalHooks,
+  type ConditionalHooksOptions,
+  type ConditionalStateSetter,
+  useConditionalEffect,
+  useConditionalLayoutEffect,
+  useConditionalRef,
+  useConditionalState,
+} from "../src/index.js";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface Deferred<Value> {
+  promise: Promise<Value>;
+  resolve: (value: Value) => void;
+}
+
+const installations: Array<ReturnType<typeof installConditionalHooks>> = [];
+
+const install = (options?: ConditionalHooksOptions): ReturnType<typeof installConditionalHooks> => {
+  const installation = installConditionalHooks(options);
+  installations.push(installation);
+  return installation;
+};
+
+const createDeferred = <Value,>(): Deferred<Value> => {
+  let resolvePromise: ((value: Value) => void) | undefined;
+  const promise = new Promise<Value>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (!resolvePromise) throw new Error("Deferred resolver was not initialized.");
+  return {
+    promise,
+    resolve: resolvePromise,
+  };
+};
+
+afterEach(() => {
+  cleanup();
+  for (const installation of installations.splice(0)) installation();
+});
+
+describe("conditional hook edge cases", () => {
+  it("does not commit an effect from a suspended render", async () => {
+    install({ interceptReactHooks: true });
+    const deferred = createDeferred<void>();
+    const events: string[] = [];
+    let didResolve = false;
+
+    const SuspendedComponent = (): React.ReactNode => {
+      React.useState(0);
+      React.useEffect(() => {
+        events.push("mounted");
+        return () => events.push("cleaned");
+      }, []);
+      if (!didResolve) throw deferred.promise;
+      return <span>resolved</span>;
+    };
+
+    render(
+      <React.Suspense fallback={<span>loading</span>}>
+        <SuspendedComponent />
+      </React.Suspense>,
+    );
+    expect(screen.getByText("loading")).toBeDefined();
+    await Promise.resolve();
+    expect(events).toEqual([]);
+
+    await act(async () => {
+      didResolve = true;
+      deferred.resolve();
+      await deferred.promise;
+    });
+
+    expect(screen.getByText("resolved")).toBeDefined();
+    await waitFor(() => expect(events).toEqual(["mounted"]));
+  });
+
+  it("does not commit an effect from a render that throws", async () => {
+    install();
+    const events: string[] = [];
+
+    const BrokenComponent = (): React.ReactNode => {
+      useConditionalEffect(
+        "aborted-effect",
+        () => {
+          events.push("mounted");
+        },
+        [],
+      );
+      throw new Error("render aborted");
+    };
+
+    expect(() => render(<BrokenComponent />)).toThrowError("render aborted");
+    await Promise.resolve();
+    expect(events).toEqual([]);
+  });
+
+  it("cleans up changed effect dependencies before starting the replacement", async () => {
+    install();
+    const events: string[] = [];
+
+    const Component = (): React.ReactNode => {
+      const [version, setVersion] = React.useState(0);
+      useConditionalEffect(
+        "dependency-effect",
+        () => {
+          events.push(`start:${version}`);
+          return () => events.push(`stop:${version}`);
+        },
+        [version],
+      );
+      return <button onClick={() => setVersion((value) => value + 1)}>{version}</button>;
+    };
+
+    render(<Component />);
+    await waitFor(() => expect(events).toEqual(["start:0"]));
+    fireEvent.click(screen.getByText("0"));
+    await waitFor(() => expect(events).toEqual(["start:0", "stop:0", "start:1"]));
+  });
+
+  it("runs layout effects synchronously and cleans them on unmount", () => {
+    install();
+    const events: string[] = [];
+
+    const Component = (): React.ReactNode => {
+      useConditionalLayoutEffect(
+        "layout-effect",
+        () => {
+          events.push("mounted");
+          return () => events.push("cleaned");
+        },
+        [],
+      );
+      return <span>content</span>;
+    };
+
+    const rendered = render(<Component />);
+    expect(events).toEqual(["mounted"]);
+    rendered.unmount();
+    expect(events).toEqual(["mounted", "cleaned"]);
+  });
+
+  it("cancels a queued passive effect when the component unmounts first", async () => {
+    install();
+    const effect = vi.fn();
+
+    const Component = (): React.ReactNode => {
+      useConditionalEffect("queued-effect", effect, []);
+      return null;
+    };
+
+    const rendered = render(<Component />);
+    rendered.unmount();
+    await Promise.resolve();
+    expect(effect).not.toHaveBeenCalled();
+  });
+
+  it("cleans active effects when the conditional hook installation is disposed", async () => {
+    const installation = install();
+    const events: string[] = [];
+
+    const Component = (): React.ReactNode => {
+      useConditionalEffect(
+        "installed-effect",
+        () => {
+          events.push("mounted");
+          return () => events.push("cleaned");
+        },
+        [],
+      );
+      return null;
+    };
+
+    render(<Component />);
+    await waitFor(() => expect(events).toEqual(["mounted"]));
+    installation();
+    expect(events).toEqual(["mounted", "cleaned"]);
+  });
+
+  it("keeps a newer installation active when an older disposer is called twice", () => {
+    const firstInstallation = install();
+    firstInstallation();
+    const secondInstallation = install();
+    const supportedRenderers = secondInstallation.supportedRenderers;
+    expect(supportedRenderers).toBeGreaterThan(0);
+    firstInstallation();
+    expect(secondInstallation.supportedRenderers).toBe(supportedRenderers);
+  });
+
+  it("gives a remounted Fiber fresh keyed state", async () => {
+    install();
+
+    const Counter = (): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      return <button onClick={() => setCount((value) => value + 1)}>count:{count}</button>;
+    };
+
+    const Component = (): React.ReactNode => {
+      const [generation, setGeneration] = React.useState(0);
+      return (
+        <div>
+          <button onClick={() => setGeneration((value) => value + 1)}>remount</button>
+          <Counter key={generation} />
+        </div>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("count:0"));
+    await waitFor(() => expect(screen.getByText("count:1")).toBeDefined());
+    fireEvent.click(screen.getByText("remount"));
+    expect(screen.getByText("count:0")).toBeDefined();
+  });
+
+  it("retains same-callsite loop cells when the loop shrinks and grows", async () => {
+    install({ interceptReactHooks: true });
+
+    const Component = (): React.ReactNode => {
+      const [itemCount, setItemCount] = React.useState(1);
+      const items: React.ReactNode[] = [];
+      for (let index = 0; index < itemCount; index++) {
+        const [value, setValue] = React.useState(index);
+        items.push(
+          <button key={index} onClick={() => setValue((currentValue) => currentValue + 10)}>
+            {index}:{value}
+          </button>,
+        );
+      }
+      return (
+        <div>
+          <button onClick={() => setItemCount(1)}>shrink</button>
+          <button onClick={() => setItemCount(3)}>grow</button>
+          {items}
+        </div>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("grow"));
+    fireEvent.click(screen.getByText("1:1"));
+    await waitFor(() => expect(screen.getByText("1:11")).toBeDefined());
+    fireEvent.click(screen.getByText("shrink"));
+    expect(screen.queryByText("1:11")).toBeNull();
+    fireEvent.click(screen.getByText("grow"));
+    expect(screen.getByText("1:11")).toBeDefined();
+  });
+
+  it("applies multiple functional updates from one event", async () => {
+    install();
+
+    const Component = (): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      const incrementTwice = (): void => {
+        setCount((value) => value + 1);
+        setCount((value) => value + 1);
+      };
+      return <button onClick={incrementTwice}>{count}</button>;
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("0"));
+    await waitFor(() => expect(screen.getByText("2")).toBeDefined());
+  });
+
+  it("does not rerender for an Object.is-equal state update", async () => {
+    install();
+    let renderCount = 0;
+
+    const Component = (): React.ReactNode => {
+      renderCount++;
+      const [count, setCount] = useConditionalState("count", 0);
+      return <button onClick={() => setCount(0)}>{count}</button>;
+    };
+
+    render(<Component />);
+    expect(renderCount).toBe(1);
+    fireEvent.click(screen.getByText("0"));
+    await Promise.resolve();
+    expect(renderCount).toBe(1);
+  });
+
+  it("ignores a captured setter after its Fiber unmounts", () => {
+    install();
+    let capturedSetter: ConditionalStateSetter<number> | undefined;
+
+    const Component = (): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      capturedSetter = setCount;
+      return <span>{count}</span>;
+    };
+
+    const rendered = render(<Component />);
+    rendered.unmount();
+    expect(capturedSetter).toBeDefined();
+    const update = vi.fn((value: number) => value + 1);
+    expect(() => capturedSetter?.(update)).not.toThrow();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("rejects one explicit key being reused for different hook kinds", () => {
+    install();
+
+    const BrokenComponent = (): React.ReactNode => {
+      useConditionalState("shared-key", 0);
+      useConditionalRef("shared-key", null);
+      return null;
+    };
+
+    expect(() => render(<BrokenComponent />)).toThrowError(
+      "Conditional hook key shared-key changed from state to ref",
+    );
+  });
+});

--- a/packages/bippy/tests/conditional-hooks-react-upstream.test.tsx
+++ b/packages/bippy/tests/conditional-hooks-react-upstream.test.tsx
@@ -1,14 +1,4 @@
-import {
-  installConditionalHooks,
-  type ConditionalHooksOptions,
-  type ConditionalReducerDispatcher,
-  useConditionalCallback,
-  useConditionalEffect,
-  useConditionalLayoutEffect,
-  useConditionalMemo,
-  useConditionalReducer,
-  useConditionalState,
-} from "../src/index.js";
+import { installConditionalHooks, type ConditionalHooksOptions } from "../src/index.js";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -58,19 +48,12 @@ afterEach(() => {
 });
 
 describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
-  it("throws when called outside the render phase", () => {
-    install();
-    expect(() => useConditionalState("state", 0)).toThrowError(
-      "must be called while a component is rendering",
-    );
-  });
-
   it("updates multiple independent states", async () => {
     install();
 
     const Component = (): React.ReactNode => {
-      const [first, setFirst] = useConditionalState("first", 0);
-      const [second, setSecond] = useConditionalState("second", 10);
+      const [first, setFirst] = React.useState(0);
+      const [second, setSecond] = React.useState(10);
       return (
         <div>
           <button onClick={() => setFirst((value) => value + 1)}>first:{first}</button>
@@ -92,7 +75,7 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
     install();
 
     const Component = (): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
+      const [count, setCount] = React.useState(0);
       const update = (): void => {
         setCount(1);
         setCount((value) => value + 2);
@@ -112,15 +95,11 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
     const effects: number[] = [];
 
     const Component = (): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
+      const [count, setCount] = React.useState(0);
       renders.push(count);
-      useConditionalEffect(
-        "effect",
-        () => {
-          effects.push(count);
-        },
-        [count],
-      );
+      React.useEffect(() => {
+        effects.push(count);
+      }, [count]);
       if (count < 6) {
         setCount((value) => value + 1);
         setCount((value) => value + 1);
@@ -137,11 +116,10 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
 
   it("uses a reducer supplied by the render that processes a queued action", async () => {
     install();
-    let dispatch: ConditionalReducerDispatcher<number> | undefined;
+    let dispatch: ((action: number) => void) | undefined;
 
     const Component = ({ factor }: ReducerProperties): React.ReactNode => {
-      const [count, currentDispatch] = useConditionalReducer(
-        "count",
+      const [count, currentDispatch] = React.useReducer(
         (state: number, amount: number) => state + amount * factor,
         0,
       );
@@ -159,11 +137,10 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
 
   it("does not replay a previous no-op reducer action on a prop update", async () => {
     install();
-    let dispatch: ConditionalReducerDispatcher<number> | undefined;
+    let dispatch: ((action: number) => void) | undefined;
 
     const Component = ({ factor }: ReducerProperties): React.ReactNode => {
-      const [count, currentDispatch] = useConditionalReducer(
-        "count",
+      const [count, currentDispatch] = React.useReducer(
         (state: number, amount: number) => state + amount * factor,
         0,
       );
@@ -184,7 +161,7 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
     const reducer = vi.fn((state: number, amount: number) => state + amount);
 
     const Component = (): React.ReactNode => {
-      const [count, dispatch] = useConditionalReducer("count", reducer, 0);
+      const [count, dispatch] = React.useReducer(reducer, 0);
       const update = (): void => {
         dispatch(1);
         dispatch(2);
@@ -204,14 +181,10 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
     const events: string[] = [];
 
     const Component = ({ label }: EffectProperties): React.ReactNode => {
-      useConditionalEffect(
-        "effect",
-        () => {
-          events.push(`mount:${label}`);
-          return () => events.push(`cleanup:${label}`);
-        },
-        [label],
-      );
+      React.useEffect(() => {
+        events.push(`mount:${label}`);
+        return () => events.push(`cleanup:${label}`);
+      }, [label]);
       return <span>{label}</span>;
     };
 
@@ -227,22 +200,14 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
     const events: string[] = [];
 
     const Component = ({ label }: EffectProperties): React.ReactNode => {
-      useConditionalEffect(
-        "first",
-        () => {
-          events.push(`mount:first:${label}`);
-          return () => events.push(`cleanup:first:${label}`);
-        },
-        [label],
-      );
-      useConditionalEffect(
-        "second",
-        () => {
-          events.push(`mount:second:${label}`);
-          return () => events.push(`cleanup:second:${label}`);
-        },
-        [label],
-      );
+      React.useEffect(() => {
+        events.push(`mount:first:${label}`);
+        return () => events.push(`cleanup:first:${label}`);
+      }, [label]);
+      React.useEffect(() => {
+        events.push(`mount:second:${label}`);
+        return () => events.push(`cleanup:second:${label}`);
+      }, [label]);
       return null;
     };
 
@@ -266,14 +231,10 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
     const events: string[] = [];
 
     const Child = ({ label }: EffectProperties): React.ReactNode => {
-      useConditionalLayoutEffect(
-        "layout",
-        () => {
-          events.push(`mount:${label}`);
-          return () => events.push(`cleanup:${label}`);
-        },
-        [label],
-      );
+      React.useLayoutEffect(() => {
+        events.push(`mount:${label}`);
+        return () => events.push(`cleanup:${label}`);
+      }, [label]);
       return null;
     };
 
@@ -298,13 +259,9 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
     const observedText: string[] = [];
 
     const Component = ({ label }: EffectProperties): React.ReactNode => {
-      useConditionalLayoutEffect(
-        "layout",
-        () => {
-          observedText.push(screen.getByTestId("host").textContent ?? "");
-        },
-        [label],
-      );
+      React.useLayoutEffect(() => {
+        observedText.push(screen.getByTestId("host").textContent ?? "");
+      }, [label]);
       return <span data-testid="host">{label}</span>;
     };
 
@@ -319,14 +276,10 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
 
     const Component = ({ label }: EffectProperties): React.ReactNode => {
       if (label !== "skip") {
-        useConditionalEffect(
-          "effect",
-          () => {
-            events.push(`mount:${label}`);
-            return () => events.push(`cleanup:${label}`);
-          },
-          [],
-        );
+        React.useEffect(() => {
+          events.push(`mount:${label}`);
+          return () => events.push(`cleanup:${label}`);
+        }, []);
       }
       return <span>{label}</span>;
     };
@@ -344,7 +297,7 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
     const callbacks: Array<() => string> = [];
 
     const Component = ({ label }: EffectProperties): React.ReactNode => {
-      callbacks.push(useConditionalCallback("callback", () => label, [label]));
+      callbacks.push(React.useCallback(() => label, [label]));
       return null;
     };
 
@@ -361,7 +314,7 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
     const createMemo = vi.fn((label: string) => ({ label }));
 
     const Component = ({ label }: EffectProperties): React.ReactNode => {
-      const value = useConditionalMemo("memo", () => createMemo(label), [label]);
+      const value = React.useMemo(() => createMemo(label), [label]);
       return <span>{value.label}</span>;
     };
 
@@ -376,14 +329,10 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
     const events: string[] = [];
 
     const Component = (): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
-      useConditionalEffect(
-        "effect",
-        () => {
-          events.push(`effect:${count}`);
-        },
-        [count],
-      );
+      const [count, setCount] = React.useState(0);
+      React.useEffect(() => {
+        events.push(`effect:${count}`);
+      }, [count]);
       if (count > 0) setCount(0);
       return <button onClick={() => setCount(2)}>{count}</button>;
     };
@@ -400,13 +349,9 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
     const error = new Error("effect failed");
 
     const Component = (): React.ReactNode => {
-      useConditionalEffect(
-        "effect",
-        () => {
-          throw error;
-        },
-        [],
-      );
+      React.useEffect(() => {
+        throw error;
+      }, []);
       return null;
     };
 
@@ -418,20 +363,12 @@ describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
     const events: string[] = [];
 
     const Component = ({ label }: EffectProperties): React.ReactNode => {
-      useConditionalEffect(
-        "passive",
-        () => {
-          events.push(`passive:${label}`);
-        },
-        [label],
-      );
-      useConditionalLayoutEffect(
-        "layout",
-        () => {
-          events.push(`layout:${label}`);
-        },
-        [label],
-      );
+      React.useEffect(() => {
+        events.push(`passive:${label}`);
+      }, [label]);
+      React.useLayoutEffect(() => {
+        events.push(`layout:${label}`);
+      }, [label]);
       return null;
     };
 
@@ -447,7 +384,7 @@ describe("ports from StrictEffectsMode-test.js", () => {
     let initializationCount = 0;
 
     const Component = (): React.ReactNode => {
-      const [value] = useConditionalState("state", () => ++initializationCount);
+      const [value] = React.useState(() => ++initializationCount);
       return <span>{value}</span>;
     };
 
@@ -465,7 +402,7 @@ describe("ports from StrictEffectsMode-test.js", () => {
     let factoryCallCount = 0;
 
     const Component = (): React.ReactNode => {
-      const value = useConditionalMemo("memo", () => ++factoryCallCount, []);
+      const value = React.useMemo(() => ++factoryCallCount, []);
       return <span>{value}</span>;
     };
 
@@ -483,7 +420,7 @@ describe("ports from StrictEffectsMode-test.js", () => {
     const updater = vi.fn((value: number) => value + 1);
 
     const Component = (): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
+      const [count, setCount] = React.useState(0);
       return <button onClick={() => setCount(updater)}>{count}</button>;
     };
 
@@ -502,22 +439,14 @@ describe("ports from StrictEffectsMode-test.js", () => {
     const events: string[] = [];
 
     const Component = (): React.ReactNode => {
-      useConditionalEffect(
-        "first",
-        () => {
-          events.push("mount:first");
-          return () => events.push("cleanup:first");
-        },
-        [],
-      );
-      useConditionalEffect(
-        "second",
-        () => {
-          events.push("mount:second");
-          return () => events.push("cleanup:second");
-        },
-        [],
-      );
+      React.useEffect(() => {
+        events.push("mount:first");
+        return () => events.push("cleanup:first");
+      }, []);
+      React.useEffect(() => {
+        events.push("mount:second");
+        return () => events.push("cleanup:second");
+      }, []);
       return null;
     };
 
@@ -543,22 +472,14 @@ describe("ports from StrictEffectsMode-test.js", () => {
     const events: string[] = [];
 
     const Component = (): React.ReactNode => {
-      useConditionalLayoutEffect(
-        "first",
-        () => {
-          events.push("mount:first");
-          return () => events.push("cleanup:first");
-        },
-        [],
-      );
-      useConditionalLayoutEffect(
-        "second",
-        () => {
-          events.push("mount:second");
-          return () => events.push("cleanup:second");
-        },
-        [],
-      );
+      React.useLayoutEffect(() => {
+        events.push("mount:first");
+        return () => events.push("cleanup:first");
+      }, []);
+      React.useLayoutEffect(() => {
+        events.push("mount:second");
+        return () => events.push("cleanup:second");
+      }, []);
       return null;
     };
 
@@ -584,14 +505,10 @@ describe("ports from StrictEffectsMode-test.js", () => {
     const events: string[] = [];
 
     const Child = (): React.ReactNode => {
-      useConditionalEffect(
-        "effect",
-        () => {
-          events.push("mount");
-          return () => events.push("cleanup");
-        },
-        [],
-      );
+      React.useEffect(() => {
+        events.push("mount");
+        return () => events.push("cleanup");
+      }, []);
       return null;
     };
     const Component = (): React.ReactNode => {
@@ -613,14 +530,10 @@ describe("ports from StrictEffectsMode-test.js", () => {
     const events: string[] = [];
 
     const Child = ({ label }: EffectProperties): React.ReactNode => {
-      useConditionalEffect(
-        "effect",
-        () => {
-          events.push(`mount:${label}`);
-          return () => events.push(`cleanup:${label}`);
-        },
-        [],
-      );
+      React.useEffect(() => {
+        events.push(`mount:${label}`);
+        return () => events.push(`cleanup:${label}`);
+      }, []);
       return null;
     };
 
@@ -647,22 +560,14 @@ describe("ports from StrictEffectsMode-test.js", () => {
     const events: string[] = [];
 
     const Component = (): React.ReactNode => {
-      useConditionalLayoutEffect(
-        "layout",
-        () => {
-          events.push("mount:layout");
-          return () => events.push("cleanup:layout");
-        },
-        [],
-      );
-      useConditionalEffect(
-        "passive",
-        () => {
-          events.push("mount:passive");
-          return () => events.push("cleanup:passive");
-        },
-        [],
-      );
+      React.useLayoutEffect(() => {
+        events.push("mount:layout");
+        return () => events.push("cleanup:layout");
+      }, []);
+      React.useEffect(() => {
+        events.push("mount:passive");
+        return () => events.push("cleanup:passive");
+      }, []);
       return null;
     };
 
@@ -688,14 +593,10 @@ describe("ports from StrictEffectsMode-test.js", () => {
     const events: string[] = [];
 
     const Child = ({ label }: EffectProperties): React.ReactNode => {
-      useConditionalEffect(
-        "effect",
-        () => {
-          events.push(`mount:${label}`);
-          return () => events.push(`cleanup:${label}`);
-        },
-        [],
-      );
+      React.useEffect(() => {
+        events.push(`mount:${label}`);
+        return () => events.push(`cleanup:${label}`);
+      }, []);
       return <span>{label}</span>;
     };
     const Component = (): React.ReactNode => {
@@ -730,7 +631,7 @@ describe("ports from ReactSuspenseEffectsSemantics tests", () => {
     let didResolve = false;
 
     const Component = (): React.ReactNode => {
-      useConditionalState("state", initialize);
+      React.useState(initialize);
       if (!didResolve) throw deferred.promise;
       return <span>ready</span>;
     };
@@ -757,14 +658,10 @@ describe("ports from ReactSuspenseEffectsSemantics tests", () => {
     let didResolve = false;
 
     const Child = React.memo((): React.ReactNode => {
-      useConditionalLayoutEffect(
-        "layout",
-        () => {
-          events.push("mount");
-          return () => events.push("cleanup");
-        },
-        [],
-      );
+      React.useLayoutEffect(() => {
+        events.push("mount");
+        return () => events.push("cleanup");
+      }, []);
       return <span>child</span>;
     });
     const Content = ({ shouldSuspend }: SuspenseProperties): React.ReactNode => {
@@ -798,7 +695,7 @@ describe("ports from ReactSuspenseEffectsSemantics tests", () => {
     const cleanupEffect = vi.fn();
 
     const Child = (): React.ReactNode => {
-      useConditionalLayoutEffect("layout", () => cleanupEffect, []);
+      React.useLayoutEffect(() => cleanupEffect, []);
       return null;
     };
     const Content = ({ shouldSuspend }: SuspenseProperties): React.ReactNode => {
@@ -834,14 +731,10 @@ describe("ports from ReactSuspenseEffectsSemantics tests", () => {
     const events: string[] = [];
 
     const Child = ({ label }: EffectProperties): React.ReactNode => {
-      useConditionalLayoutEffect(
-        "layout",
-        () => {
-          events.push(`mount:${label}`);
-          return () => events.push(`cleanup:${label}`);
-        },
-        [],
-      );
+      React.useLayoutEffect(() => {
+        events.push(`mount:${label}`);
+        return () => events.push(`cleanup:${label}`);
+      }, []);
       return <span>{label}</span>;
     };
     const InnerContent = ({ shouldSuspend }: SuspenseProperties): React.ReactNode => {
@@ -878,7 +771,7 @@ describe("ports from ReactSuspenseEffectsSemantics tests", () => {
     const cleanupEffect = vi.fn();
 
     const Child = (): React.ReactNode => {
-      useConditionalLayoutEffect("layout", () => cleanupEffect, []);
+      React.useLayoutEffect(() => cleanupEffect, []);
       return null;
     };
     const Suspender = ({ label }: EffectProperties): React.ReactNode => {
@@ -909,14 +802,10 @@ describe("ports from Activity-test.js", () => {
     const events: string[] = [];
 
     const Child = (): React.ReactNode => {
-      useConditionalLayoutEffect(
-        "layout",
-        () => {
-          events.push("mount");
-          return () => events.push("cleanup");
-        },
-        [],
-      );
+      React.useLayoutEffect(() => {
+        events.push("mount");
+        return () => events.push("cleanup");
+      }, []);
       return <span>child</span>;
     };
 
@@ -946,14 +835,10 @@ describe("ports from Activity-test.js", () => {
     const events: string[] = [];
 
     const Child = (): React.ReactNode => {
-      useConditionalEffect(
-        "effect",
-        () => {
-          events.push("mount");
-          return () => events.push("cleanup");
-        },
-        [],
-      );
+      React.useEffect(() => {
+        events.push("mount");
+        return () => events.push("cleanup");
+      }, []);
       return <span>child</span>;
     };
 
@@ -983,7 +868,7 @@ describe("ports from Activity-test.js", () => {
     const Activity: React.ComponentType<ActivityProperties> = Reflect.get(React, "Activity");
 
     const Counter = (): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
+      const [count, setCount] = React.useState(0);
       return <button onClick={() => setCount((value) => value + 1)}>{count}</button>;
     };
 

--- a/packages/bippy/tests/conditional-hooks-react-upstream.test.tsx
+++ b/packages/bippy/tests/conditional-hooks-react-upstream.test.tsx
@@ -1,0 +1,1009 @@
+import {
+  installConditionalHooks,
+  type ConditionalHooksOptions,
+  type ConditionalReducerDispatcher,
+  useConditionalCallback,
+  useConditionalEffect,
+  useConditionalLayoutEffect,
+  useConditionalMemo,
+  useConditionalReducer,
+  useConditionalState,
+} from "../src/index.js";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface ActivityProperties {
+  children: React.ReactNode;
+  mode: "hidden" | "visible";
+}
+
+interface Deferred<Value> {
+  promise: Promise<Value>;
+  resolve: (value: Value) => void;
+}
+
+interface EffectProperties {
+  label: string;
+}
+
+interface ReducerProperties {
+  factor: number;
+}
+
+interface SuspenseProperties {
+  shouldSuspend: boolean;
+}
+
+const installations: Array<ReturnType<typeof installConditionalHooks>> = [];
+
+const install = (options?: ConditionalHooksOptions): ReturnType<typeof installConditionalHooks> => {
+  const installation = installConditionalHooks(options);
+  installations.push(installation);
+  return installation;
+};
+
+const createDeferred = <Value,>(): Deferred<Value> => {
+  let resolvePromise: ((value: Value) => void) | undefined;
+  const promise = new Promise<Value>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (!resolvePromise) throw new Error("Deferred resolver was not initialized.");
+  return { promise, resolve: resolvePromise };
+};
+
+afterEach(() => {
+  cleanup();
+  for (const installation of installations.splice(0)) installation();
+});
+
+describe("ports from ReactHooksWithNoopRenderer-test.js", () => {
+  it("throws when called outside the render phase", () => {
+    install();
+    expect(() => useConditionalState("state", 0)).toThrowError(
+      "must be called while a component is rendering",
+    );
+  });
+
+  it("updates multiple independent states", async () => {
+    install();
+
+    const Component = (): React.ReactNode => {
+      const [first, setFirst] = useConditionalState("first", 0);
+      const [second, setSecond] = useConditionalState("second", 10);
+      return (
+        <div>
+          <button onClick={() => setFirst((value) => value + 1)}>first:{first}</button>
+          <button onClick={() => setSecond((value) => value + 10)}>second:{second}</button>
+        </div>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("first:0"));
+    fireEvent.click(screen.getByText("second:10"));
+    await waitFor(() => {
+      expect(screen.getByText("first:1")).toBeDefined();
+      expect(screen.getByText("second:20")).toBeDefined();
+    });
+  });
+
+  it("applies value and functional state updates in dispatch order", async () => {
+    install();
+
+    const Component = (): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      const update = (): void => {
+        setCount(1);
+        setCount((value) => value + 2);
+        setCount(8);
+      };
+      return <button onClick={update}>{count}</button>;
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("0"));
+    await waitFor(() => expect(screen.getByText("8")).toBeDefined());
+  });
+
+  it("applies multiple render-phase updates before committing effects", async () => {
+    install();
+    const renders: number[] = [];
+    const effects: number[] = [];
+
+    const Component = (): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      renders.push(count);
+      useConditionalEffect(
+        "effect",
+        () => {
+          effects.push(count);
+        },
+        [count],
+      );
+      if (count < 6) {
+        setCount((value) => value + 1);
+        setCount((value) => value + 1);
+        setCount((value) => value + 1);
+      }
+      return <span>{count}</span>;
+    };
+
+    render(<Component />);
+    await waitFor(() => expect(screen.getByText("6")).toBeDefined());
+    await waitFor(() => expect(effects).toEqual([6]));
+    expect(renders).toEqual([0, 3, 6]);
+  });
+
+  it("uses a reducer supplied by the render that processes a queued action", async () => {
+    install();
+    let dispatch: ConditionalReducerDispatcher<number> | undefined;
+
+    const Component = ({ factor }: ReducerProperties): React.ReactNode => {
+      const [count, currentDispatch] = useConditionalReducer(
+        "count",
+        (state: number, amount: number) => state + amount * factor,
+        0,
+      );
+      dispatch = currentDispatch;
+      return <span>{count}</span>;
+    };
+
+    const rendered = render(<Component factor={1} />);
+    act(() => {
+      dispatch?.(1);
+      rendered.rerender(<Component factor={10} />);
+    });
+    await waitFor(() => expect(screen.getByText("10")).toBeDefined());
+  });
+
+  it("does not replay a previous no-op reducer action on a prop update", async () => {
+    install();
+    let dispatch: ConditionalReducerDispatcher<number> | undefined;
+
+    const Component = ({ factor }: ReducerProperties): React.ReactNode => {
+      const [count, currentDispatch] = useConditionalReducer(
+        "count",
+        (state: number, amount: number) => state + amount * factor,
+        0,
+      );
+      dispatch = currentDispatch;
+      return <span>{count}</span>;
+    };
+
+    const rendered = render(<Component factor={0} />);
+    act(() => dispatch?.(1));
+    expect(screen.getByText("0")).toBeDefined();
+    rendered.rerender(<Component factor={10} />);
+    await Promise.resolve();
+    expect(screen.getByText("0")).toBeDefined();
+  });
+
+  it("processes every reducer action in a batch exactly once", async () => {
+    install();
+    const reducer = vi.fn((state: number, amount: number) => state + amount);
+
+    const Component = (): React.ReactNode => {
+      const [count, dispatch] = useConditionalReducer("count", reducer, 0);
+      const update = (): void => {
+        dispatch(1);
+        dispatch(2);
+        dispatch(3);
+      };
+      return <button onClick={update}>{count}</button>;
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("0"));
+    await waitFor(() => expect(screen.getByText("6")).toBeDefined());
+    expect(reducer.mock.calls.map(([, amount]) => amount)).toEqual([1, 2, 3]);
+  });
+
+  it("skips effects when dependencies have not changed", async () => {
+    install();
+    const events: string[] = [];
+
+    const Component = ({ label }: EffectProperties): React.ReactNode => {
+      useConditionalEffect(
+        "effect",
+        () => {
+          events.push(`mount:${label}`);
+          return () => events.push(`cleanup:${label}`);
+        },
+        [label],
+      );
+      return <span>{label}</span>;
+    };
+
+    const rendered = render(<Component label="same" />);
+    await waitFor(() => expect(events).toEqual(["mount:same"]));
+    rendered.rerender(<Component label="same" />);
+    await Promise.resolve();
+    expect(events).toEqual(["mount:same"]);
+  });
+
+  it("unmounts all prior effects before creating replacements", async () => {
+    install();
+    const events: string[] = [];
+
+    const Component = ({ label }: EffectProperties): React.ReactNode => {
+      useConditionalEffect(
+        "first",
+        () => {
+          events.push(`mount:first:${label}`);
+          return () => events.push(`cleanup:first:${label}`);
+        },
+        [label],
+      );
+      useConditionalEffect(
+        "second",
+        () => {
+          events.push(`mount:second:${label}`);
+          return () => events.push(`cleanup:second:${label}`);
+        },
+        [label],
+      );
+      return null;
+    };
+
+    const rendered = render(<Component label="A" />);
+    await waitFor(() => expect(events).toEqual(["mount:first:A", "mount:second:A"]));
+    rendered.rerender(<Component label="B" />);
+    await waitFor(() =>
+      expect(events).toEqual([
+        "mount:first:A",
+        "mount:second:A",
+        "cleanup:first:A",
+        "cleanup:second:A",
+        "mount:first:B",
+        "mount:second:B",
+      ]),
+    );
+  });
+
+  it("unmounts sibling layout effects before creating any replacements", () => {
+    install();
+    const events: string[] = [];
+
+    const Child = ({ label }: EffectProperties): React.ReactNode => {
+      useConditionalLayoutEffect(
+        "layout",
+        () => {
+          events.push(`mount:${label}`);
+          return () => events.push(`cleanup:${label}`);
+        },
+        [label],
+      );
+      return null;
+    };
+
+    const rendered = render(
+      <>
+        <Child label="A0" />
+        <Child label="B0" />
+      </>,
+    );
+    events.length = 0;
+    rendered.rerender(
+      <>
+        <Child label="A1" />
+        <Child label="B1" />
+      </>,
+    );
+    expect(events).toEqual(["cleanup:A0", "cleanup:B0", "mount:A1", "mount:B1"]);
+  });
+
+  it("runs layout effects after host mutations", () => {
+    install();
+    const observedText: string[] = [];
+
+    const Component = ({ label }: EffectProperties): React.ReactNode => {
+      useConditionalLayoutEffect(
+        "layout",
+        () => {
+          observedText.push(screen.getByTestId("host").textContent ?? "");
+        },
+        [label],
+      );
+      return <span data-testid="host">{label}</span>;
+    };
+
+    const rendered = render(<Component label="A" />);
+    rendered.rerender(<Component label="B" />);
+    expect(observedText).toEqual(["A", "B"]);
+  });
+
+  it("deletes an effect after a render where it was skipped", async () => {
+    install();
+    const events: string[] = [];
+
+    const Component = ({ label }: EffectProperties): React.ReactNode => {
+      if (label !== "skip") {
+        useConditionalEffect(
+          "effect",
+          () => {
+            events.push(`mount:${label}`);
+            return () => events.push(`cleanup:${label}`);
+          },
+          [],
+        );
+      }
+      return <span>{label}</span>;
+    };
+
+    const rendered = render(<Component label="mount" />);
+    await waitFor(() => expect(events).toEqual(["mount:mount"]));
+    rendered.rerender(<Component label="skip" />);
+    expect(events).toEqual(["mount:mount", "cleanup:mount"]);
+    rendered.unmount();
+    expect(events).toEqual(["mount:mount", "cleanup:mount"]);
+  });
+
+  it("memoizes callbacks by dependency equality", () => {
+    install();
+    const callbacks: Array<() => string> = [];
+
+    const Component = ({ label }: EffectProperties): React.ReactNode => {
+      callbacks.push(useConditionalCallback("callback", () => label, [label]));
+      return null;
+    };
+
+    const rendered = render(<Component label="A" />);
+    rendered.rerender(<Component label="A" />);
+    rendered.rerender(<Component label="B" />);
+    expect(callbacks[1]).toBe(callbacks[0]);
+    expect(callbacks[2]).not.toBe(callbacks[1]);
+    expect(callbacks[2]?.()).toBe("B");
+  });
+
+  it("does not invoke memo factories on equal dependencies", () => {
+    install();
+    const createMemo = vi.fn((label: string) => ({ label }));
+
+    const Component = ({ label }: EffectProperties): React.ReactNode => {
+      const value = useConditionalMemo("memo", () => createMemo(label), [label]);
+      return <span>{value.label}</span>;
+    };
+
+    const rendered = render(<Component label="A" />);
+    rendered.rerender(<Component label="A" />);
+    rendered.rerender(<Component label="B" />);
+    expect(createMemo.mock.calls).toEqual([["A"], ["B"]]);
+  });
+
+  it("persists effect dependencies after render-phase updates", async () => {
+    install();
+    const events: string[] = [];
+
+    const Component = (): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      useConditionalEffect(
+        "effect",
+        () => {
+          events.push(`effect:${count}`);
+        },
+        [count],
+      );
+      if (count > 0) setCount(0);
+      return <button onClick={() => setCount(2)}>{count}</button>;
+    };
+
+    render(<Component />);
+    await waitFor(() => expect(events).toEqual(["effect:0"]));
+    fireEvent.click(screen.getByText("0"));
+    await waitFor(() => expect(screen.getByText("0")).toBeDefined());
+    expect(events).toEqual(["effect:0"]);
+  });
+
+  it.skip("routes passive effect setup errors through React error boundaries", async () => {
+    install();
+    const error = new Error("effect failed");
+
+    const Component = (): React.ReactNode => {
+      useConditionalEffect(
+        "effect",
+        () => {
+          throw error;
+        },
+        [],
+      );
+      return null;
+    };
+
+    expect(() => render(<Component />)).toThrow(error);
+  });
+
+  it.fails("flushes pending passive effects before a new layout effect", () => {
+    install();
+    const events: string[] = [];
+
+    const Component = ({ label }: EffectProperties): React.ReactNode => {
+      useConditionalEffect(
+        "passive",
+        () => {
+          events.push(`passive:${label}`);
+        },
+        [label],
+      );
+      useConditionalLayoutEffect(
+        "layout",
+        () => {
+          events.push(`layout:${label}`);
+        },
+        [label],
+      );
+      return null;
+    };
+
+    const rendered = render(<Component label="A" />);
+    rendered.rerender(<Component label="B" />);
+    expect(events).toEqual(["layout:A", "passive:A", "layout:B"]);
+  });
+});
+
+describe("ports from StrictEffectsMode-test.js", () => {
+  it("uses the first Strict Mode state initializer result", () => {
+    install();
+    let initializationCount = 0;
+
+    const Component = (): React.ReactNode => {
+      const [value] = useConditionalState("state", () => ++initializationCount);
+      return <span>{value}</span>;
+    };
+
+    render(
+      <React.StrictMode>
+        <Component />
+      </React.StrictMode>,
+    );
+    expect(initializationCount).toBe(2);
+    expect(screen.getByText("1")).toBeDefined();
+  });
+
+  it("uses the first Strict Mode memo factory result", () => {
+    install();
+    let factoryCallCount = 0;
+
+    const Component = (): React.ReactNode => {
+      const value = useConditionalMemo("memo", () => ++factoryCallCount, []);
+      return <span>{value}</span>;
+    };
+
+    render(
+      <React.StrictMode>
+        <Component />
+      </React.StrictMode>,
+    );
+    expect(factoryCallCount).toBe(2);
+    expect(screen.getByText("1")).toBeDefined();
+  });
+
+  it("double invokes state updater functions while using the first result", async () => {
+    install();
+    const updater = vi.fn((value: number) => value + 1);
+
+    const Component = (): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      return <button onClick={() => setCount(updater)}>{count}</button>;
+    };
+
+    render(
+      <React.StrictMode>
+        <Component />
+      </React.StrictMode>,
+    );
+    fireEvent.click(screen.getByText("0"));
+    await waitFor(() => expect(screen.getByText("1")).toBeDefined());
+    expect(updater).toHaveBeenCalledTimes(2);
+  });
+
+  it("double invokes multiple passive effects in global phase order", async () => {
+    install();
+    const events: string[] = [];
+
+    const Component = (): React.ReactNode => {
+      useConditionalEffect(
+        "first",
+        () => {
+          events.push("mount:first");
+          return () => events.push("cleanup:first");
+        },
+        [],
+      );
+      useConditionalEffect(
+        "second",
+        () => {
+          events.push("mount:second");
+          return () => events.push("cleanup:second");
+        },
+        [],
+      );
+      return null;
+    };
+
+    render(
+      <React.StrictMode>
+        <Component />
+      </React.StrictMode>,
+    );
+    await waitFor(() =>
+      expect(events).toEqual([
+        "mount:first",
+        "mount:second",
+        "cleanup:first",
+        "cleanup:second",
+        "mount:first",
+        "mount:second",
+      ]),
+    );
+  });
+
+  it("double invokes multiple layout effects in global phase order", async () => {
+    install();
+    const events: string[] = [];
+
+    const Component = (): React.ReactNode => {
+      useConditionalLayoutEffect(
+        "first",
+        () => {
+          events.push("mount:first");
+          return () => events.push("cleanup:first");
+        },
+        [],
+      );
+      useConditionalLayoutEffect(
+        "second",
+        () => {
+          events.push("mount:second");
+          return () => events.push("cleanup:second");
+        },
+        [],
+      );
+      return null;
+    };
+
+    render(
+      <React.StrictMode>
+        <Component />
+      </React.StrictMode>,
+    );
+    await waitFor(() =>
+      expect(events).toEqual([
+        "mount:first",
+        "mount:second",
+        "cleanup:first",
+        "cleanup:second",
+        "mount:first",
+        "mount:second",
+      ]),
+    );
+  });
+
+  it("double invokes effects for children mounted after the initial commit", async () => {
+    install();
+    const events: string[] = [];
+
+    const Child = (): React.ReactNode => {
+      useConditionalEffect(
+        "effect",
+        () => {
+          events.push("mount");
+          return () => events.push("cleanup");
+        },
+        [],
+      );
+      return null;
+    };
+    const Component = (): React.ReactNode => {
+      const [isVisible, setIsVisible] = React.useState(false);
+      return <button onClick={() => setIsVisible(true)}>{isVisible ? <Child /> : "show"}</button>;
+    };
+
+    render(
+      <React.StrictMode>
+        <Component />
+      </React.StrictMode>,
+    );
+    fireEvent.click(screen.getByText("show"));
+    await waitFor(() => expect(events).toEqual(["mount", "cleanup", "mount"]));
+  });
+
+  it("double invokes sibling passive effects in global phase order", async () => {
+    install();
+    const events: string[] = [];
+
+    const Child = ({ label }: EffectProperties): React.ReactNode => {
+      useConditionalEffect(
+        "effect",
+        () => {
+          events.push(`mount:${label}`);
+          return () => events.push(`cleanup:${label}`);
+        },
+        [],
+      );
+      return null;
+    };
+
+    render(
+      <React.StrictMode>
+        <Child label="A" />
+        <Child label="B" />
+      </React.StrictMode>,
+    );
+    await waitFor(() =>
+      expect(events).toEqual([
+        "mount:A",
+        "mount:B",
+        "cleanup:A",
+        "cleanup:B",
+        "mount:A",
+        "mount:B",
+      ]),
+    );
+  });
+
+  it("orders mixed layout and passive Strict Mode replays like React", async () => {
+    install();
+    const events: string[] = [];
+
+    const Component = (): React.ReactNode => {
+      useConditionalLayoutEffect(
+        "layout",
+        () => {
+          events.push("mount:layout");
+          return () => events.push("cleanup:layout");
+        },
+        [],
+      );
+      useConditionalEffect(
+        "passive",
+        () => {
+          events.push("mount:passive");
+          return () => events.push("cleanup:passive");
+        },
+        [],
+      );
+      return null;
+    };
+
+    render(
+      <React.StrictMode>
+        <Component />
+      </React.StrictMode>,
+    );
+    await waitFor(() =>
+      expect(events).toEqual([
+        "mount:layout",
+        "mount:passive",
+        "cleanup:layout",
+        "cleanup:passive",
+        "mount:layout",
+        "mount:passive",
+      ]),
+    );
+  });
+
+  it("does not replay effects when keyed children only reorder", async () => {
+    install();
+    const events: string[] = [];
+
+    const Child = ({ label }: EffectProperties): React.ReactNode => {
+      useConditionalEffect(
+        "effect",
+        () => {
+          events.push(`mount:${label}`);
+          return () => events.push(`cleanup:${label}`);
+        },
+        [],
+      );
+      return <span>{label}</span>;
+    };
+    const Component = (): React.ReactNode => {
+      const [labels, setLabels] = React.useState(["A", "B"]);
+      return (
+        <button onClick={() => setLabels((values) => [...values].reverse())}>
+          {labels.map((label) => (
+            <Child key={label} label={label} />
+          ))}
+        </button>
+      );
+    };
+
+    render(
+      <React.StrictMode>
+        <Component />
+      </React.StrictMode>,
+    );
+    await waitFor(() => expect(events.length).toBe(6));
+    events.length = 0;
+    fireEvent.click(screen.getByRole("button"));
+    await Promise.resolve();
+    expect(events).toEqual([]);
+  });
+});
+
+describe("ports from ReactSuspenseEffectsSemantics tests", () => {
+  it("restarts state initialization after an initial suspension", async () => {
+    install();
+    const deferred = createDeferred<void>();
+    const initialize = vi.fn(() => 0);
+    let didResolve = false;
+
+    const Component = (): React.ReactNode => {
+      useConditionalState("state", initialize);
+      if (!didResolve) throw deferred.promise;
+      return <span>ready</span>;
+    };
+
+    render(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Component />
+      </React.Suspense>,
+    );
+    const attemptsBeforeResolution = initialize.mock.calls.length;
+    await act(async () => {
+      didResolve = true;
+      deferred.resolve();
+      await deferred.promise;
+    });
+    expect(screen.getByText("ready")).toBeDefined();
+    expect(initialize.mock.calls.length).toBeGreaterThan(attemptsBeforeResolution);
+  });
+
+  it("disconnects a memoized descendant layout effect", async () => {
+    install();
+    const deferred = createDeferred<void>();
+    const events: string[] = [];
+    let didResolve = false;
+
+    const Child = React.memo((): React.ReactNode => {
+      useConditionalLayoutEffect(
+        "layout",
+        () => {
+          events.push("mount");
+          return () => events.push("cleanup");
+        },
+        [],
+      );
+      return <span>child</span>;
+    });
+    const Content = ({ shouldSuspend }: SuspenseProperties): React.ReactNode => {
+      if (shouldSuspend && !didResolve) throw deferred.promise;
+      return <Child />;
+    };
+
+    const rendered = render(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Content shouldSuspend={false} />
+      </React.Suspense>,
+    );
+    expect(events).toEqual(["mount"]);
+    rendered.rerender(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Content shouldSuspend />
+      </React.Suspense>,
+    );
+    expect(events).toEqual(["mount", "cleanup"]);
+    await act(async () => {
+      didResolve = true;
+      deferred.resolve();
+      await deferred.promise;
+    });
+    expect(events).toEqual(["mount", "cleanup", "mount"]);
+  });
+
+  it("destroys a hidden layout effect only once when the boundary unmounts", () => {
+    install();
+    const deferred = createDeferred<void>();
+    const cleanupEffect = vi.fn();
+
+    const Child = (): React.ReactNode => {
+      useConditionalLayoutEffect("layout", () => cleanupEffect, []);
+      return null;
+    };
+    const Content = ({ shouldSuspend }: SuspenseProperties): React.ReactNode => {
+      return (
+        <>
+          <Child />
+          {shouldSuspend
+            ? (() => {
+                throw deferred.promise;
+              })()
+            : null}
+        </>
+      );
+    };
+
+    const rendered = render(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Content shouldSuspend={false} />
+      </React.Suspense>,
+    );
+    rendered.rerender(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Content shouldSuspend />
+      </React.Suspense>,
+    );
+    rendered.unmount();
+    expect(cleanupEffect).toHaveBeenCalledTimes(1);
+  });
+
+  it("disconnects only effects inside the Suspense boundary that hides", () => {
+    install();
+    const deferred = createDeferred<void>();
+    const events: string[] = [];
+
+    const Child = ({ label }: EffectProperties): React.ReactNode => {
+      useConditionalLayoutEffect(
+        "layout",
+        () => {
+          events.push(`mount:${label}`);
+          return () => events.push(`cleanup:${label}`);
+        },
+        [],
+      );
+      return <span>{label}</span>;
+    };
+    const InnerContent = ({ shouldSuspend }: SuspenseProperties): React.ReactNode => {
+      if (shouldSuspend) throw deferred.promise;
+      return <Child label="inner" />;
+    };
+
+    const rendered = render(
+      <React.Suspense fallback={<span>outer-loading</span>}>
+        <Child label="outer" />
+        <React.Suspense fallback={<span>inner-loading</span>}>
+          <InnerContent shouldSuspend={false} />
+        </React.Suspense>
+      </React.Suspense>,
+    );
+    expect(events).toEqual(["mount:outer", "mount:inner"]);
+    rendered.rerender(
+      <React.Suspense fallback={<span>outer-loading</span>}>
+        <Child label="outer" />
+        <React.Suspense fallback={<span>inner-loading</span>}>
+          <InnerContent shouldSuspend />
+        </React.Suspense>
+      </React.Suspense>,
+    );
+    expect(screen.getByText("outer")).toBeDefined();
+    expect(screen.getByText("inner-loading")).toBeDefined();
+    expect(events).toEqual(["mount:outer", "mount:inner", "cleanup:inner"]);
+  });
+
+  it("disconnects each layout effect once when siblings suspend together", () => {
+    install();
+    const firstDeferred = createDeferred<void>();
+    const secondDeferred = createDeferred<void>();
+    const cleanupEffect = vi.fn();
+
+    const Child = (): React.ReactNode => {
+      useConditionalLayoutEffect("layout", () => cleanupEffect, []);
+      return null;
+    };
+    const Suspender = ({ label }: EffectProperties): React.ReactNode => {
+      if (label === "first") throw firstDeferred.promise;
+      throw secondDeferred.promise;
+    };
+
+    const rendered = render(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Child />
+      </React.Suspense>,
+    );
+    rendered.rerender(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Child />
+        <Suspender label="first" />
+        <Suspender label="second" />
+      </React.Suspense>,
+    );
+    expect(cleanupEffect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ports from Activity-test.js", () => {
+  it("mounts and unmounts layout effects as Activity visibility changes", () => {
+    install();
+    const Activity: React.ComponentType<ActivityProperties> = Reflect.get(React, "Activity");
+    const events: string[] = [];
+
+    const Child = (): React.ReactNode => {
+      useConditionalLayoutEffect(
+        "layout",
+        () => {
+          events.push("mount");
+          return () => events.push("cleanup");
+        },
+        [],
+      );
+      return <span>child</span>;
+    };
+
+    const rendered = render(
+      <Activity mode="hidden">
+        <Child />
+      </Activity>,
+    );
+    expect(events).toEqual([]);
+    rendered.rerender(
+      <Activity mode="visible">
+        <Child />
+      </Activity>,
+    );
+    expect(events).toEqual(["mount"]);
+    rendered.rerender(
+      <Activity mode="hidden">
+        <Child />
+      </Activity>,
+    );
+    expect(events).toEqual(["mount", "cleanup"]);
+  });
+
+  it("connects and disconnects passive effects as Activity visibility changes", async () => {
+    install();
+    const Activity: React.ComponentType<ActivityProperties> = Reflect.get(React, "Activity");
+    const events: string[] = [];
+
+    const Child = (): React.ReactNode => {
+      useConditionalEffect(
+        "effect",
+        () => {
+          events.push("mount");
+          return () => events.push("cleanup");
+        },
+        [],
+      );
+      return <span>child</span>;
+    };
+
+    const rendered = render(
+      <Activity mode="hidden">
+        <Child />
+      </Activity>,
+    );
+    await Promise.resolve();
+    expect(events).toEqual([]);
+    rendered.rerender(
+      <Activity mode="visible">
+        <Child />
+      </Activity>,
+    );
+    await waitFor(() => expect(events).toEqual(["mount"]));
+    rendered.rerender(
+      <Activity mode="hidden">
+        <Child />
+      </Activity>,
+    );
+    expect(events).toEqual(["mount", "cleanup"]);
+  });
+
+  it("retains conditional state while Activity is hidden", async () => {
+    install();
+    const Activity: React.ComponentType<ActivityProperties> = Reflect.get(React, "Activity");
+
+    const Counter = (): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      return <button onClick={() => setCount((value) => value + 1)}>{count}</button>;
+    };
+
+    const rendered = render(
+      <Activity mode="visible">
+        <Counter />
+      </Activity>,
+    );
+    fireEvent.click(screen.getByText("0"));
+    await waitFor(() => expect(screen.getByText("1")).toBeDefined());
+    rendered.rerender(
+      <Activity mode="hidden">
+        <Counter />
+      </Activity>,
+    );
+    rendered.rerender(
+      <Activity mode="visible">
+        <Counter />
+      </Activity>,
+    );
+    expect(screen.getByText("1")).toBeDefined();
+  });
+});

--- a/packages/bippy/tests/conditional-hooks-stress.test.tsx
+++ b/packages/bippy/tests/conditional-hooks-stress.test.tsx
@@ -1,0 +1,563 @@
+import {
+  installConditionalHooks,
+  type ConditionalHooksOptions,
+  type ConditionalReducerDispatcher,
+  type ConditionalStateSetter,
+  useConditionalCallback,
+  useConditionalEffect,
+  useConditionalMemo,
+  useConditionalReducer,
+  useConditionalRef,
+  useConditionalState,
+} from "../src/index.js";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface Deferred<Value> {
+  promise: Promise<Value>;
+  resolve: (value: Value) => void;
+}
+
+interface FactorCounterProperties {
+  factor: number;
+}
+
+interface KeyedCounterProperties {
+  name: string;
+}
+
+interface VersionedEffectProperties {
+  version: number;
+}
+
+const installations: Array<ReturnType<typeof installConditionalHooks>> = [];
+
+const install = (options?: ConditionalHooksOptions): ReturnType<typeof installConditionalHooks> => {
+  const installation = installConditionalHooks(options);
+  installations.push(installation);
+  return installation;
+};
+
+const createDeferred = <Value,>(): Deferred<Value> => {
+  let resolvePromise: ((value: Value) => void) | undefined;
+  const promise = new Promise<Value>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (!resolvePromise) throw new Error("Deferred resolver was not initialized.");
+  return { promise, resolve: resolvePromise };
+};
+
+afterEach(() => {
+  cleanup();
+  for (const installation of installations.splice(0)) installation();
+});
+
+describe("conditional hook stress cases", () => {
+  it("runs a lazy state initializer only once across branch toggles", () => {
+    install();
+    const initialize = vi.fn(() => 7);
+
+    const Component = (): React.ReactNode => {
+      const [isVisible, setIsVisible] = React.useState(true);
+      const content = isVisible ? useConditionalState("value", initialize)[0] : "hidden";
+      return <button onClick={() => setIsVisible((value) => !value)}>{content}</button>;
+    };
+
+    render(<Component />);
+    expect(screen.getByText("7")).toBeDefined();
+    fireEvent.click(screen.getByText("7"));
+    fireEvent.click(screen.getByText("hidden"));
+    expect(screen.getByText("7")).toBeDefined();
+    expect(initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs a reducer initializer only once", async () => {
+    install();
+    const initialize = vi.fn((value: number) => value * 2);
+
+    const Component = (): React.ReactNode => {
+      const [renderVersion, setRenderVersion] = React.useState(0);
+      const [count] = useConditionalReducer("count", (state: number) => state, 3, initialize);
+      return (
+        <button onClick={() => setRenderVersion((value) => value + 1)}>
+          {count}:{renderVersion}
+        </button>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("6:0"));
+    await waitFor(() => expect(screen.getByText("6:1")).toBeDefined());
+    expect(initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps state setter, reducer dispatcher, and ref identities stable", async () => {
+    install();
+    const stateSetters: Array<ConditionalStateSetter<number>> = [];
+    const reducerDispatchers: Array<ConditionalReducerDispatcher<number>> = [];
+    const references: Array<{ current: number }> = [];
+
+    const Component = (): React.ReactNode => {
+      const [renderVersion, setRenderVersion] = React.useState(0);
+      const [, setCount] = useConditionalState("state", 0);
+      const [, dispatch] = useConditionalReducer(
+        "reducer",
+        (state: number, amount: number) => state + amount,
+        0,
+      );
+      const reference = useConditionalRef("ref", 0);
+      stateSetters.push(setCount);
+      reducerDispatchers.push(dispatch);
+      references.push(reference);
+      return (
+        <button onClick={() => setRenderVersion((value) => value + 1)}>{renderVersion}</button>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("0"));
+    await waitFor(() => expect(screen.getByText("1")).toBeDefined());
+    expect(stateSetters[1]).toBe(stateSetters[0]);
+    expect(reducerDispatchers[1]).toBe(reducerDispatchers[0]);
+    expect(references[1]).toBe(references[0]);
+  });
+
+  it("uses the latest reducer closure", async () => {
+    install();
+
+    const FactorCounter = ({ factor }: FactorCounterProperties): React.ReactNode => {
+      const [count, dispatch] = useConditionalReducer(
+        "count",
+        (state: number, amount: number) => state + amount * factor,
+        0,
+      );
+      return <button onClick={() => dispatch(1)}>count:{count}</button>;
+    };
+
+    const Component = (): React.ReactNode => {
+      const [factor, setFactor] = React.useState(1);
+      return (
+        <div>
+          <button onClick={() => setFactor(5)}>factor:{factor}</button>
+          <FactorCounter factor={factor} />
+        </div>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("factor:1"));
+    fireEvent.click(screen.getByText("count:0"));
+    await waitFor(() => expect(screen.getByText("count:5")).toBeDefined());
+  });
+
+  it("renders a queued reducer action even when it returns identical state", async () => {
+    install();
+    let renderCount = 0;
+
+    const Component = (): React.ReactNode => {
+      renderCount++;
+      const [value, dispatch] = useConditionalReducer("value", (state: number) => state, 1);
+      return <button onClick={() => dispatch(0)}>{value}</button>;
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("1"));
+    await Promise.resolve();
+    expect(renderCount).toBe(2);
+  });
+
+  it("ignores a captured reducer dispatcher after unmount", () => {
+    install();
+    const reduce = vi.fn((state: number, amount: number) => state + amount);
+    let capturedDispatch: ConditionalReducerDispatcher<number> | undefined;
+
+    const Component = (): React.ReactNode => {
+      const [, dispatch] = useConditionalReducer("value", reduce, 0);
+      capturedDispatch = dispatch;
+      return null;
+    };
+
+    const rendered = render(<Component />);
+    rendered.unmount();
+    capturedDispatch?.(1);
+    expect(reduce).not.toHaveBeenCalled();
+  });
+
+  it("stores a function as state through initializer and updater functions", async () => {
+    install();
+
+    const Component = (): React.ReactNode => {
+      const [getLabel, setGetLabel] = useConditionalState("callback", () => () => "first");
+      return <button onClick={() => setGetLabel(() => () => "second")}>{getLabel()}</button>;
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("first"));
+    await waitFor(() => expect(screen.getByText("second")).toBeDefined());
+  });
+
+  it("uses Object.is semantics for memo dependencies", () => {
+    install();
+    const createMemo = vi.fn((value: number) => String(value));
+
+    const Component = (): React.ReactNode => {
+      const [dependency, setDependency] = React.useState(Number.NaN);
+      const memoized = useConditionalMemo("memo", () => createMemo(dependency), [dependency]);
+      return (
+        <button
+          onClick={() => setDependency((value) => (Number.isNaN(value) ? Number.NaN : value))}
+        >
+          {memoized}
+        </button>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("NaN"));
+    expect(createMemo).toHaveBeenCalledTimes(1);
+  });
+
+  it("distinguishes positive and negative zero memo dependencies", async () => {
+    install();
+    const createMemo = vi.fn((value: number) => (Object.is(value, -0) ? "negative" : "positive"));
+
+    const Component = (): React.ReactNode => {
+      const [dependency, setDependency] = React.useState(0);
+      const memoized = useConditionalMemo("memo", () => createMemo(dependency), [dependency]);
+      return <button onClick={() => setDependency(-0)}>{memoized}</button>;
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("positive"));
+    await waitFor(() => expect(screen.getByText("negative")).toBeDefined());
+    expect(createMemo).toHaveBeenCalledTimes(2);
+  });
+
+  it("recomputes a memo with omitted dependencies on every render", async () => {
+    install();
+    const createMemo = vi.fn(() => "memoized");
+
+    const Component = (): React.ReactNode => {
+      const [renderVersion, setRenderVersion] = React.useState(0);
+      const memoized = useConditionalMemo("memo", createMemo);
+      return (
+        <button onClick={() => setRenderVersion((value) => value + 1)}>
+          {memoized}:{renderVersion}
+        </button>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("memoized:0"));
+    await waitFor(() => expect(screen.getByText("memoized:1")).toBeDefined());
+    expect(createMemo).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves callbacks until their dependencies change", async () => {
+    install();
+    const callbacks: Array<() => number> = [];
+
+    const Component = (): React.ReactNode => {
+      const [dependency, setDependency] = React.useState(0);
+      const [renderVersion, setRenderVersion] = React.useState(0);
+      const callback = useConditionalCallback("callback", () => dependency, [dependency]);
+      callbacks.push(callback);
+      return (
+        <div>
+          <button onClick={() => setRenderVersion((value) => value + 1)}>
+            render:{renderVersion}
+          </button>
+          <button onClick={() => setDependency((value) => value + 1)}>
+            dependency:{dependency}
+          </button>
+        </div>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("render:0"));
+    await waitFor(() => expect(screen.getByText("render:1")).toBeDefined());
+    expect(callbacks[1]).toBe(callbacks[0]);
+    fireEvent.click(screen.getByText("dependency:0"));
+    await waitFor(() => expect(screen.getByText("dependency:1")).toBeDefined());
+    expect(callbacks[2]).not.toBe(callbacks[1]);
+    expect(callbacks[2]?.()).toBe(1);
+  });
+
+  it("restarts an effect with omitted dependencies after every commit", async () => {
+    install();
+    const events: string[] = [];
+
+    const Component = (): React.ReactNode => {
+      const [version, setVersion] = React.useState(0);
+      useConditionalEffect("effect", () => {
+        events.push(`start:${version}`);
+        return () => events.push(`stop:${version}`);
+      });
+      return <button onClick={() => setVersion((value) => value + 1)}>{version}</button>;
+    };
+
+    render(<Component />);
+    await waitFor(() => expect(events).toEqual(["start:0"]));
+    fireEvent.click(screen.getByText("0"));
+    await waitFor(() => expect(events).toEqual(["start:0", "stop:0", "start:1"]));
+  });
+
+  it("restarts an effect when the dependency array length changes", async () => {
+    install();
+    const events: string[] = [];
+
+    const Component = (): React.ReactNode => {
+      const [isExpanded, setIsExpanded] = React.useState(false);
+      const dependencies = isExpanded ? [1, 2] : [1];
+      useConditionalEffect(
+        "effect",
+        () => {
+          events.push(`start:${dependencies.length}`);
+          return () => events.push(`stop:${dependencies.length}`);
+        },
+        dependencies,
+      );
+      return <button onClick={() => setIsExpanded(true)}>{dependencies.length}</button>;
+    };
+
+    render(<Component />);
+    await waitFor(() => expect(events).toEqual(["start:1"]));
+    fireEvent.click(screen.getByText("1"));
+    await waitFor(() => expect(events).toEqual(["start:1", "stop:1", "start:2"]));
+  });
+
+  it("cancels a queued effect when its branch disappears", async () => {
+    install();
+    const effect = vi.fn();
+
+    const Component = (): React.ReactNode => {
+      const [isVisible, setIsVisible] = React.useState(true);
+      if (isVisible) useConditionalEffect("effect", effect, []);
+      return <button onClick={() => setIsVisible(false)}>hide</button>;
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("hide"));
+    await Promise.resolve();
+    expect(effect).not.toHaveBeenCalled();
+  });
+
+  it("starts only the latest queued effect after a rapid dependency change", async () => {
+    install();
+    const events: string[] = [];
+
+    const VersionedEffect = ({ version }: VersionedEffectProperties): React.ReactNode => {
+      useConditionalEffect(
+        "effect",
+        () => {
+          events.push(`start:${version}`);
+        },
+        [version],
+      );
+      return <span>{version}</span>;
+    };
+
+    const rendered = render(<VersionedEffect version={0} />);
+    rendered.rerender(<VersionedEffect version={1} />);
+    await waitFor(() => expect(events).toEqual(["start:1"]));
+  });
+
+  it("ignores state updates triggered by cleanup during unmount", async () => {
+    install();
+    const update = vi.fn((value: number) => value + 1);
+
+    const Component = (): React.ReactNode => {
+      const [, setCount] = useConditionalState("count", 0);
+      useConditionalEffect("effect", () => () => setCount(update), []);
+      return null;
+    };
+
+    const rendered = render(<Component />);
+    await Promise.resolve();
+    rendered.unmount();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("keeps numeric, string, and symbol keys distinct", async () => {
+    install();
+    const symbolKey = Symbol("value");
+
+    const Component = (): React.ReactNode => {
+      const [numericValue, setNumericValue] = useConditionalState(1, 0);
+      const [stringValue, setStringValue] = useConditionalState("1", 10);
+      const [symbolValue, setSymbolValue] = useConditionalState(symbolKey, 100);
+      const incrementAll = (): void => {
+        setNumericValue((value) => value + 1);
+        setStringValue((value) => value + 1);
+        setSymbolValue((value) => value + 1);
+      };
+      return (
+        <button onClick={incrementAll}>
+          {numericValue}:{stringValue}:{symbolValue}
+        </button>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("0:10:100"));
+    await waitFor(() => expect(screen.getByText("1:11:101")).toBeDefined());
+  });
+
+  it("keeps state attached to keyed Fibers when siblings reorder", async () => {
+    install();
+
+    const KeyedCounter = ({ name }: KeyedCounterProperties): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      return (
+        <button onClick={() => setCount((value) => value + 1)}>
+          {name}:{count}
+        </button>
+      );
+    };
+
+    const Component = (): React.ReactNode => {
+      const [names, setNames] = React.useState(["first", "second", "third"]);
+      return (
+        <div>
+          <button onClick={() => setNames((values) => [...values].reverse())}>reverse</button>
+          {names.map((name) => (
+            <KeyedCounter key={name} name={name} />
+          ))}
+        </div>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("second:0"));
+    await waitFor(() => expect(screen.getByText("second:1")).toBeDefined());
+    fireEvent.click(screen.getByText("reverse"));
+    expect(screen.getByText("second:1")).toBeDefined();
+    expect(screen.getByText("first:0")).toBeDefined();
+    expect(screen.getByText("third:0")).toBeDefined();
+  });
+
+  it("separates repeated automatic keys by occurrence", async () => {
+    install({ getHookKey: () => "shared-callsite", interceptReactHooks: true });
+
+    const Component = (): React.ReactNode => {
+      const [first, setFirst] = React.useState(0);
+      const [second, setSecond] = React.useState(10);
+      return (
+        <div>
+          <button onClick={() => setFirst((value) => value + 1)}>first:{first}</button>
+          <button onClick={() => setSecond((value) => value + 1)}>second:{second}</button>
+        </div>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("first:0"));
+    fireEvent.click(screen.getByText("second:10"));
+    await waitFor(() => {
+      expect(screen.getByText("first:1")).toBeDefined();
+      expect(screen.getByText("second:11")).toBeDefined();
+    });
+  });
+
+  it("propagates errors from a custom automatic key resolver", () => {
+    install({
+      getHookKey: () => {
+        throw new Error("resolver failed");
+      },
+      interceptReactHooks: true,
+    });
+
+    const BrokenComponent = (): React.ReactNode => {
+      React.useState(0);
+      return null;
+    };
+
+    expect(() => render(<BrokenComponent />)).toThrowError("resolver failed");
+  });
+
+  it("forwards conditional useContext reads through the native dispatcher", () => {
+    install({ interceptReactHooks: true });
+    const LabelContext = React.createContext("default");
+
+    const Component = (): React.ReactNode => {
+      const [isVisible, setIsVisible] = React.useState(false);
+      const label = isVisible ? React.useContext(LabelContext) : "hidden";
+      return <button onClick={() => setIsVisible((value) => !value)}>{label}</button>;
+    };
+
+    render(
+      <LabelContext.Provider value="provided">
+        <Component />
+      </LabelContext.Provider>,
+    );
+    fireEvent.click(screen.getByText("hidden"));
+    expect(screen.getByText("provided")).toBeDefined();
+    fireEvent.click(screen.getByText("provided"));
+    expect(screen.getByText("hidden")).toBeDefined();
+  });
+
+  it("coexists with a native useId hook", async () => {
+    install({ interceptReactHooks: true });
+    const identifiers: string[] = [];
+
+    const Component = (): React.ReactNode => {
+      const identifier = React.useId();
+      const [count, setCount] = React.useState(0);
+      identifiers.push(identifier);
+      return (
+        <button onClick={() => setCount((value) => value + 1)}>
+          {identifier}:{count}
+        </button>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => expect(screen.getByRole("button").textContent).toContain(":1"));
+    expect(identifiers[1]).toBe(identifiers[0]);
+  });
+
+  it("keeps the committed effect active while an update is suspended", async () => {
+    install();
+    const deferred = createDeferred<void>();
+    const events: string[] = [];
+    let setVersion: ConditionalStateSetter<number> | undefined;
+    let didResolve = false;
+
+    const Component = (): React.ReactNode => {
+      const [version, updateVersion] = useConditionalState("version", 0);
+      setVersion = updateVersion;
+      useConditionalEffect(
+        "effect",
+        () => {
+          events.push(`start:${version}`);
+          return () => events.push(`stop:${version}`);
+        },
+        [version],
+      );
+      if (version === 1 && !didResolve) throw deferred.promise;
+      return <span>version:{version}</span>;
+    };
+
+    render(
+      <React.Suspense fallback={<span>loading</span>}>
+        <Component />
+      </React.Suspense>,
+    );
+    await waitFor(() => expect(events).toEqual(["start:0"]));
+
+    act(() => setVersion?.(1));
+    expect(events).toEqual(["start:0"]);
+
+    await act(async () => {
+      didResolve = true;
+      deferred.resolve();
+      await deferred.promise;
+    });
+
+    expect(screen.getByText("version:1")).toBeDefined();
+    await waitFor(() => expect(events).toEqual(["start:0", "stop:0", "start:1"]));
+  });
+});

--- a/packages/bippy/tests/conditional-hooks-stress.test.tsx
+++ b/packages/bippy/tests/conditional-hooks-stress.test.tsx
@@ -1,15 +1,4 @@
-import {
-  installConditionalHooks,
-  type ConditionalHooksOptions,
-  type ConditionalReducerDispatcher,
-  type ConditionalStateSetter,
-  useConditionalCallback,
-  useConditionalEffect,
-  useConditionalMemo,
-  useConditionalReducer,
-  useConditionalRef,
-  useConditionalState,
-} from "../src/index.js";
+import { installConditionalHooks, type ConditionalHooksOptions } from "../src/index.js";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -60,7 +49,7 @@ describe("conditional hook stress cases", () => {
 
     const Component = (): React.ReactNode => {
       const [isVisible, setIsVisible] = React.useState(true);
-      const content = isVisible ? useConditionalState("value", initialize)[0] : "hidden";
+      const content = isVisible ? React.useState(initialize)[0] : "hidden";
       return <button onClick={() => setIsVisible((value) => !value)}>{content}</button>;
     };
 
@@ -78,7 +67,7 @@ describe("conditional hook stress cases", () => {
 
     const Component = (): React.ReactNode => {
       const [renderVersion, setRenderVersion] = React.useState(0);
-      const [count] = useConditionalReducer("count", (state: number) => state, 3, initialize);
+      const [count] = React.useReducer((state: number) => state, 3, initialize);
       return (
         <button onClick={() => setRenderVersion((value) => value + 1)}>
           {count}:{renderVersion}
@@ -94,19 +83,15 @@ describe("conditional hook stress cases", () => {
 
   it("keeps state setter, reducer dispatcher, and ref identities stable", async () => {
     install();
-    const stateSetters: Array<ConditionalStateSetter<number>> = [];
-    const reducerDispatchers: Array<ConditionalReducerDispatcher<number>> = [];
+    const stateSetters: Array<React.Dispatch<React.SetStateAction<number>>> = [];
+    const reducerDispatchers: Array<(action: number) => void> = [];
     const references: Array<{ current: number }> = [];
 
     const Component = (): React.ReactNode => {
       const [renderVersion, setRenderVersion] = React.useState(0);
-      const [, setCount] = useConditionalState("state", 0);
-      const [, dispatch] = useConditionalReducer(
-        "reducer",
-        (state: number, amount: number) => state + amount,
-        0,
-      );
-      const reference = useConditionalRef("ref", 0);
+      const [, setCount] = React.useState(0);
+      const [, dispatch] = React.useReducer((state: number, amount: number) => state + amount, 0);
+      const reference = React.useRef(0);
       stateSetters.push(setCount);
       reducerDispatchers.push(dispatch);
       references.push(reference);
@@ -127,8 +112,7 @@ describe("conditional hook stress cases", () => {
     install();
 
     const FactorCounter = ({ factor }: FactorCounterProperties): React.ReactNode => {
-      const [count, dispatch] = useConditionalReducer(
-        "count",
+      const [count, dispatch] = React.useReducer(
         (state: number, amount: number) => state + amount * factor,
         0,
       );
@@ -157,7 +141,7 @@ describe("conditional hook stress cases", () => {
 
     const Component = (): React.ReactNode => {
       renderCount++;
-      const [value, dispatch] = useConditionalReducer("value", (state: number) => state, 1);
+      const [value, dispatch] = React.useReducer((state: number) => state, 1);
       return <button onClick={() => dispatch(0)}>{value}</button>;
     };
 
@@ -170,10 +154,10 @@ describe("conditional hook stress cases", () => {
   it("ignores a captured reducer dispatcher after unmount", () => {
     install();
     const reduce = vi.fn((state: number, amount: number) => state + amount);
-    let capturedDispatch: ConditionalReducerDispatcher<number> | undefined;
+    let capturedDispatch: ((action: number) => void) | undefined;
 
     const Component = (): React.ReactNode => {
-      const [, dispatch] = useConditionalReducer("value", reduce, 0);
+      const [, dispatch] = React.useReducer(reduce, 0);
       capturedDispatch = dispatch;
       return null;
     };
@@ -188,7 +172,7 @@ describe("conditional hook stress cases", () => {
     install();
 
     const Component = (): React.ReactNode => {
-      const [getLabel, setGetLabel] = useConditionalState("callback", () => () => "first");
+      const [getLabel, setGetLabel] = React.useState(() => () => "first");
       return <button onClick={() => setGetLabel(() => () => "second")}>{getLabel()}</button>;
     };
 
@@ -203,7 +187,7 @@ describe("conditional hook stress cases", () => {
 
     const Component = (): React.ReactNode => {
       const [dependency, setDependency] = React.useState(Number.NaN);
-      const memoized = useConditionalMemo("memo", () => createMemo(dependency), [dependency]);
+      const memoized = React.useMemo(() => createMemo(dependency), [dependency]);
       return (
         <button
           onClick={() => setDependency((value) => (Number.isNaN(value) ? Number.NaN : value))}
@@ -224,7 +208,7 @@ describe("conditional hook stress cases", () => {
 
     const Component = (): React.ReactNode => {
       const [dependency, setDependency] = React.useState(0);
-      const memoized = useConditionalMemo("memo", () => createMemo(dependency), [dependency]);
+      const memoized = React.useMemo(() => createMemo(dependency), [dependency]);
       return <button onClick={() => setDependency(-0)}>{memoized}</button>;
     };
 
@@ -240,7 +224,7 @@ describe("conditional hook stress cases", () => {
 
     const Component = (): React.ReactNode => {
       const [renderVersion, setRenderVersion] = React.useState(0);
-      const memoized = useConditionalMemo("memo", createMemo);
+      const memoized = React.useMemo(createMemo);
       return (
         <button onClick={() => setRenderVersion((value) => value + 1)}>
           {memoized}:{renderVersion}
@@ -261,7 +245,7 @@ describe("conditional hook stress cases", () => {
     const Component = (): React.ReactNode => {
       const [dependency, setDependency] = React.useState(0);
       const [renderVersion, setRenderVersion] = React.useState(0);
-      const callback = useConditionalCallback("callback", () => dependency, [dependency]);
+      const callback = React.useCallback(() => dependency, [dependency]);
       callbacks.push(callback);
       return (
         <div>
@@ -291,7 +275,7 @@ describe("conditional hook stress cases", () => {
 
     const Component = (): React.ReactNode => {
       const [version, setVersion] = React.useState(0);
-      useConditionalEffect("effect", () => {
+      React.useEffect(() => {
         events.push(`start:${version}`);
         return () => events.push(`stop:${version}`);
       });
@@ -311,14 +295,10 @@ describe("conditional hook stress cases", () => {
     const Component = (): React.ReactNode => {
       const [isExpanded, setIsExpanded] = React.useState(false);
       const dependencies = isExpanded ? [1, 2] : [1];
-      useConditionalEffect(
-        "effect",
-        () => {
-          events.push(`start:${dependencies.length}`);
-          return () => events.push(`stop:${dependencies.length}`);
-        },
-        dependencies,
-      );
+      React.useEffect(() => {
+        events.push(`start:${dependencies.length}`);
+        return () => events.push(`stop:${dependencies.length}`);
+      }, dependencies);
       return <button onClick={() => setIsExpanded(true)}>{dependencies.length}</button>;
     };
 
@@ -334,7 +314,7 @@ describe("conditional hook stress cases", () => {
 
     const Component = (): React.ReactNode => {
       const [isVisible, setIsVisible] = React.useState(true);
-      if (isVisible) useConditionalEffect("effect", effect, []);
+      if (isVisible) React.useEffect(effect, []);
       return <button onClick={() => setIsVisible(false)}>hide</button>;
     };
 
@@ -349,13 +329,9 @@ describe("conditional hook stress cases", () => {
     const events: string[] = [];
 
     const VersionedEffect = ({ version }: VersionedEffectProperties): React.ReactNode => {
-      useConditionalEffect(
-        "effect",
-        () => {
-          events.push(`start:${version}`);
-        },
-        [version],
-      );
+      React.useEffect(() => {
+        events.push(`start:${version}`);
+      }, [version]);
       return <span>{version}</span>;
     };
 
@@ -369,8 +345,8 @@ describe("conditional hook stress cases", () => {
     const update = vi.fn((value: number) => value + 1);
 
     const Component = (): React.ReactNode => {
-      const [, setCount] = useConditionalState("count", 0);
-      useConditionalEffect("effect", () => () => setCount(update), []);
+      const [, setCount] = React.useState(0);
+      React.useEffect(() => () => setCount(update), []);
       return null;
     };
 
@@ -380,14 +356,13 @@ describe("conditional hook stress cases", () => {
     expect(update).not.toHaveBeenCalled();
   });
 
-  it("keeps numeric, string, and symbol keys distinct", async () => {
+  it("keeps adjacent automatic hook callsites distinct", async () => {
     install();
-    const symbolKey = Symbol("value");
 
     const Component = (): React.ReactNode => {
-      const [numericValue, setNumericValue] = useConditionalState(1, 0);
-      const [stringValue, setStringValue] = useConditionalState("1", 10);
-      const [symbolValue, setSymbolValue] = useConditionalState(symbolKey, 100);
+      const [numericValue, setNumericValue] = React.useState(0);
+      const [stringValue, setStringValue] = React.useState(10);
+      const [symbolValue, setSymbolValue] = React.useState(100);
       const incrementAll = (): void => {
         setNumericValue((value) => value + 1);
         setStringValue((value) => value + 1);
@@ -409,7 +384,7 @@ describe("conditional hook stress cases", () => {
     install();
 
     const KeyedCounter = ({ name }: KeyedCounterProperties): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
+      const [count, setCount] = React.useState(0);
       return (
         <button onClick={() => setCount((value) => value + 1)}>
           {name}:{count}
@@ -439,7 +414,7 @@ describe("conditional hook stress cases", () => {
   });
 
   it("separates repeated automatic keys by occurrence", async () => {
-    install({ getHookKey: () => "shared-callsite", interceptReactHooks: true });
+    install({ getHookKey: () => "shared-callsite" });
 
     const Component = (): React.ReactNode => {
       const [first, setFirst] = React.useState(0);
@@ -466,7 +441,6 @@ describe("conditional hook stress cases", () => {
       getHookKey: () => {
         throw new Error("resolver failed");
       },
-      interceptReactHooks: true,
     });
 
     const BrokenComponent = (): React.ReactNode => {
@@ -478,7 +452,7 @@ describe("conditional hook stress cases", () => {
   });
 
   it("forwards conditional useContext reads through the native dispatcher", () => {
-    install({ interceptReactHooks: true });
+    install();
     const LabelContext = React.createContext("default");
 
     const Component = (): React.ReactNode => {
@@ -499,7 +473,7 @@ describe("conditional hook stress cases", () => {
   });
 
   it("coexists with a native useId hook", async () => {
-    install({ interceptReactHooks: true });
+    install();
     const identifiers: string[] = [];
 
     const Component = (): React.ReactNode => {
@@ -523,20 +497,16 @@ describe("conditional hook stress cases", () => {
     install();
     const deferred = createDeferred<void>();
     const events: string[] = [];
-    let setVersion: ConditionalStateSetter<number> | undefined;
+    let setVersion: React.Dispatch<React.SetStateAction<number>> | undefined;
     let didResolve = false;
 
     const Component = (): React.ReactNode => {
-      const [version, updateVersion] = useConditionalState("version", 0);
+      const [version, updateVersion] = React.useState(0);
       setVersion = updateVersion;
-      useConditionalEffect(
-        "effect",
-        () => {
-          events.push(`start:${version}`);
-          return () => events.push(`stop:${version}`);
-        },
-        [version],
-      );
+      React.useEffect(() => {
+        events.push(`start:${version}`);
+        return () => events.push(`stop:${version}`);
+      }, [version]);
       if (version === 1 && !didResolve) throw deferred.promise;
       return <span>version:{version}</span>;
     };

--- a/packages/bippy/tests/conditional-hooks.test.tsx
+++ b/packages/bippy/tests/conditional-hooks.test.tsx
@@ -1,12 +1,4 @@
-import {
-  installConditionalHooks,
-  type ConditionalHooksOptions,
-  useConditionalEffect,
-  useConditionalMemo,
-  useConditionalReducer,
-  useConditionalRef,
-  useConditionalState,
-} from "../src/index.js";
+import { installConditionalHooks, type ConditionalHooksOptions } from "../src/index.js";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -30,7 +22,7 @@ afterEach(() => {
 
 describe("conditional hooks", () => {
   it("makes ordinary React hooks conditional through the dispatcher proxy", async () => {
-    install({ interceptReactHooks: true });
+    install();
     const events: string[] = [];
 
     const Component = (): React.ReactNode => {
@@ -66,7 +58,7 @@ describe("conditional hooks", () => {
   });
 
   it("reuses intercepted callsite keys across Strict Mode render replays", async () => {
-    install({ interceptReactHooks: true });
+    install();
     const initializeState = vi.fn(() => 0);
 
     const Component = (): React.ReactNode => {
@@ -84,7 +76,7 @@ describe("conditional hooks", () => {
     await waitFor(() => expect(screen.getByText("1")).toBeDefined());
   });
 
-  it("retains keyed state while its branch is disabled", async () => {
+  it("retains conditional state while its branch is disabled", async () => {
     install();
 
     const Component = (): React.ReactNode => {
@@ -92,7 +84,7 @@ describe("conditional hooks", () => {
       let conditionalContent: React.ReactNode = <span data-testid="value">disabled</span>;
 
       if (isEnabled) {
-        const [count, setCount] = useConditionalState("count", 0);
+        const [count, setCount] = React.useState(0);
         conditionalContent = (
           <button data-testid="value" onClick={() => setCount((value) => value + 1)}>
             {count}
@@ -119,11 +111,11 @@ describe("conditional hooks", () => {
     expect(screen.getByTestId("value").textContent).toBe("1");
   });
 
-  it("isolates identical keys between component instances", async () => {
+  it("isolates identical callsites between component instances", async () => {
     install();
 
     const Counter = ({ name }: CounterProperties): React.ReactNode => {
-      const [count, setCount] = useConditionalState("count", 0);
+      const [count, setCount] = React.useState(0);
       return (
         <button onClick={() => setCount((value) => value + 1)}>
           {name}:{count}
@@ -147,14 +139,13 @@ describe("conditional hooks", () => {
     const createMemo = vi.fn((value: number) => value * 2);
 
     const Component = (): React.ReactNode => {
-      const [count, dispatch] = useConditionalReducer(
-        "reducer",
+      const [count, dispatch] = React.useReducer(
         (state: number, amount: number) => state + amount,
         1,
       );
-      const renderCount = useConditionalRef("render-count", 0);
+      const renderCount = React.useRef(0);
       renderCount.current++;
-      const doubled = useConditionalMemo("memo", () => createMemo(count), [count]);
+      const doubled = React.useMemo(() => createMemo(count), [count]);
       return (
         <button onClick={() => dispatch(2)}>
           {count}:{doubled}:{renderCount.current}
@@ -176,14 +167,10 @@ describe("conditional hooks", () => {
     const Component = (): React.ReactNode => {
       const [isEnabled, setIsEnabled] = React.useState(false);
       if (isEnabled) {
-        useConditionalEffect(
-          "subscription",
-          () => {
-            events.push("start");
-            return () => events.push("stop");
-          },
-          [],
-        );
+        React.useEffect(() => {
+          events.push("start");
+          return () => events.push("stop");
+        }, []);
       }
       return <button onClick={() => setIsEnabled((value) => !value)}>toggle</button>;
     };

--- a/packages/bippy/tests/conditional-hooks.test.tsx
+++ b/packages/bippy/tests/conditional-hooks.test.tsx
@@ -1,0 +1,197 @@
+import {
+  installConditionalHooks,
+  type ConditionalHooksOptions,
+  useConditionalEffect,
+  useConditionalMemo,
+  useConditionalReducer,
+  useConditionalRef,
+  useConditionalState,
+} from "../src/index.js";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const installations: Array<ReturnType<typeof installConditionalHooks>> = [];
+
+interface CounterProperties {
+  name: string;
+}
+
+const install = (options?: ConditionalHooksOptions): ReturnType<typeof installConditionalHooks> => {
+  const installation = installConditionalHooks(options);
+  installations.push(installation);
+  return installation;
+};
+
+afterEach(() => {
+  cleanup();
+  for (const installation of installations.splice(0)) installation();
+});
+
+describe("conditional hooks", () => {
+  it("makes ordinary React hooks conditional through the dispatcher proxy", async () => {
+    install({ interceptReactHooks: true });
+    const events: string[] = [];
+
+    const Component = (): React.ReactNode => {
+      const [isEnabled, setIsEnabled] = React.useState(false);
+      let conditionalContent: React.ReactNode = "disabled";
+      if (isEnabled) {
+        const [count, setCount] = React.useState(0);
+        React.useEffect(() => {
+          events.push("start");
+          return () => events.push("stop");
+        }, []);
+        conditionalContent = (
+          <button onClick={() => setCount((value) => value + 1)}>{count}</button>
+        );
+      }
+      return (
+        <div>
+          <button onClick={() => setIsEnabled((value) => !value)}>toggle</button>
+          <span data-testid="content">{conditionalContent}</span>
+        </div>
+      );
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("toggle"));
+    await waitFor(() => expect(events).toEqual(["start"]));
+    fireEvent.click(screen.getByText("0"));
+    await waitFor(() => expect(screen.getByText("1")).toBeDefined());
+    fireEvent.click(screen.getByText("toggle"));
+    expect(events).toEqual(["start", "stop"]);
+    fireEvent.click(screen.getByText("toggle"));
+    await waitFor(() => expect(screen.getByText("1")).toBeDefined());
+  });
+
+  it("reuses intercepted callsite keys across Strict Mode render replays", async () => {
+    install({ interceptReactHooks: true });
+    const initializeState = vi.fn(() => 0);
+
+    const Component = (): React.ReactNode => {
+      const [count, setCount] = React.useState(initializeState);
+      return <button onClick={() => setCount((value) => value + 1)}>{count}</button>;
+    };
+
+    render(
+      <React.StrictMode>
+        <Component />
+      </React.StrictMode>,
+    );
+    expect(initializeState).toHaveBeenCalledTimes(2);
+    fireEvent.click(screen.getByText("0"));
+    await waitFor(() => expect(screen.getByText("1")).toBeDefined());
+  });
+
+  it("retains keyed state while its branch is disabled", async () => {
+    install();
+
+    const Component = (): React.ReactNode => {
+      const [isEnabled, setIsEnabled] = React.useState(false);
+      let conditionalContent: React.ReactNode = <span data-testid="value">disabled</span>;
+
+      if (isEnabled) {
+        const [count, setCount] = useConditionalState("count", 0);
+        conditionalContent = (
+          <button data-testid="value" onClick={() => setCount((value) => value + 1)}>
+            {count}
+          </button>
+        );
+      }
+
+      return (
+        <div>
+          <button onClick={() => setIsEnabled((value) => !value)}>toggle</button>
+          {conditionalContent}
+        </div>
+      );
+    };
+
+    render(<Component />);
+    expect(screen.getByTestId("value").textContent).toBe("disabled");
+    fireEvent.click(screen.getByText("toggle"));
+    expect(screen.getByTestId("value").textContent).toBe("0");
+    fireEvent.click(screen.getByTestId("value"));
+    await waitFor(() => expect(screen.getByTestId("value").textContent).toBe("1"));
+    fireEvent.click(screen.getByText("toggle"));
+    fireEvent.click(screen.getByText("toggle"));
+    expect(screen.getByTestId("value").textContent).toBe("1");
+  });
+
+  it("isolates identical keys between component instances", async () => {
+    install();
+
+    const Counter = ({ name }: CounterProperties): React.ReactNode => {
+      const [count, setCount] = useConditionalState("count", 0);
+      return (
+        <button onClick={() => setCount((value) => value + 1)}>
+          {name}:{count}
+        </button>
+      );
+    };
+
+    render(
+      <>
+        <Counter name="first" />
+        <Counter name="second" />
+      </>,
+    );
+    fireEvent.click(screen.getByText("first:0"));
+    await waitFor(() => expect(screen.getByText("first:1")).toBeDefined());
+    expect(screen.getByText("second:0")).toBeDefined();
+  });
+
+  it("supports reducer, ref, and memo cells in a conditional branch", async () => {
+    install();
+    const createMemo = vi.fn((value: number) => value * 2);
+
+    const Component = (): React.ReactNode => {
+      const [count, dispatch] = useConditionalReducer(
+        "reducer",
+        (state: number, amount: number) => state + amount,
+        1,
+      );
+      const renderCount = useConditionalRef("render-count", 0);
+      renderCount.current++;
+      const doubled = useConditionalMemo("memo", () => createMemo(count), [count]);
+      return (
+        <button onClick={() => dispatch(2)}>
+          {count}:{doubled}:{renderCount.current}
+        </button>
+      );
+    };
+
+    render(<Component />);
+    expect(screen.getByRole("button").textContent).toBe("1:2:1");
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => expect(screen.getByRole("button").textContent).toBe("3:6:2"));
+    expect(createMemo).toHaveBeenCalledTimes(2);
+  });
+
+  it("runs and cleans up effects as branches appear and disappear", async () => {
+    install();
+    const events: string[] = [];
+
+    const Component = (): React.ReactNode => {
+      const [isEnabled, setIsEnabled] = React.useState(false);
+      if (isEnabled) {
+        useConditionalEffect(
+          "subscription",
+          () => {
+            events.push("start");
+            return () => events.push("stop");
+          },
+          [],
+        );
+      }
+      return <button onClick={() => setIsEnabled((value) => !value)}>toggle</button>;
+    };
+
+    render(<Component />);
+    fireEvent.click(screen.getByText("toggle"));
+    await waitFor(() => expect(events).toEqual(["start"]));
+    fireEvent.click(screen.getByText("toggle"));
+    expect(events).toEqual(["start", "stop"]);
+  });
+});

--- a/packages/bippy/vite.config.ts
+++ b/packages/bippy/vite.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
       entry: {
         index: "./src/index.ts",
         core: "./src/core.ts",
+        "conditional-hooks": "./src/conditional-hooks.ts",
         source: "./src/source/index.ts",
         "react-refresh": "./src/react-refresh/index.ts",
         "install-hook-only": "./src/install-hook-only.ts",

--- a/packages/conditional-hooks-playground/.gitignore
+++ b/packages/conditional-hooks-playground/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/conditional-hooks-playground/index.html
+++ b/packages/conditional-hooks-playground/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0a0a0b" />
+    <title>Conditional Hooks Lab</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/conditional-hooks-playground/index.html
+++ b/packages/conditional-hooks-playground/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#0a0a0b" />
-    <title>Conditional Hooks Lab</title>
+    <meta name="theme-color" content="#fbfaf8" />
+    <title>Conditional Hooks — bippy</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/conditional-hooks-playground/package.json
+++ b/packages/conditional-hooks-playground/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@bippy/conditional-hooks-playground",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build",
+    "preview": "vp preview"
+  },
+  "dependencies": {
+    "bippy": "workspace:*",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.4",
+    "@types/react-dom": "^19.0.2",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.3",
+    "vite-plus": "latest"
+  }
+}

--- a/packages/conditional-hooks-playground/src/app.tsx
+++ b/packages/conditional-hooks-playground/src/app.tsx
@@ -9,7 +9,7 @@ interface ApplicationProperties {
   installation: ConditionalHooksInstallation;
 }
 
-interface ConditionalPanelProperties {
+interface ConditionalDemoProperties {
   onEvent: (message: string) => void;
 }
 
@@ -18,6 +18,46 @@ interface EventEntry {
   message: string;
   time: string;
 }
+
+const DEMO_SOURCE_LINES = [
+  "const ConditionalCounter = () => {",
+  "  const [enabled, setEnabled] = React.useState(false)",
+  "",
+  "  let panel = <p>The branch is off.</p>",
+  "",
+  "  if (enabled) {",
+  "    const [count, setCount] = React.useState(0)",
+  "    const [step, changeStep] = React.useReducer(",
+  "      (current, direction) => Math.max(1, current + direction),",
+  "      1,",
+  "    )",
+  "    const renders = React.useRef(0)",
+  "    const result = React.useMemo(() => count * step, [count, step])",
+  "",
+  "    React.useEffect(() => {",
+  '      const timer = setInterval(() => console.log("tick"), 1000)',
+  "      return () => clearInterval(timer)",
+  "    }, [])",
+  "",
+  "    renders.current++",
+  "    panel = (",
+  "      <div>",
+  "        <p>{count} × {step} = {result}</p>",
+  "        <button onClick={() => setCount(count + step)}>add</button>",
+  "        <button onClick={() => changeStep(1)}>step +</button>",
+  "        <small>render {renders.current}</small>",
+  "      </div>",
+  "    )",
+  "  }",
+  "",
+  "  return (",
+  "    <>",
+  "      <button onClick={() => setEnabled(!enabled)}>toggle</button>",
+  "      {panel}",
+  "    </>",
+  "  )",
+  "}",
+];
 
 let eventIdentifier = 0;
 
@@ -28,30 +68,27 @@ const formatTime = (): string =>
     second: "2-digit",
   }).format(new Date());
 
-const ConditionalPanel = ({ onEvent }: ConditionalPanelProperties): React.ReactNode => {
-  const [isBranchEnabled, setIsBranchEnabled] = React.useState(false);
+const ConditionalDemo = ({ onEvent }: ConditionalDemoProperties): React.ReactNode => {
+  const [isEnabled, setIsEnabled] = React.useState(false);
   const [activationCount, setActivationCount] = React.useState(0);
 
-  const toggleBranch = (): void => {
-    setIsBranchEnabled((isEnabled) => {
-      const nextIsEnabled = !isEnabled;
-      if (nextIsEnabled) setActivationCount((count) => count + 1);
-      onEvent(nextIsEnabled ? "Branch entered" : "Branch exited");
+  const toggleDemo = (): void => {
+    setIsEnabled((currentIsEnabled) => {
+      const nextIsEnabled = !currentIsEnabled;
+      if (nextIsEnabled) setActivationCount((currentCount) => currentCount + 1);
+      onEvent(nextIsEnabled ? "entered the conditional branch" : "left the conditional branch");
       return nextIsEnabled;
     });
   };
 
-  let branchContent: React.ReactNode = (
-    <div className="empty-state">
-      <div className="empty-orbit">
-        <span />
-      </div>
-      <strong>The hook branch is dormant</strong>
-      <p>Enable it to call six ordinary React hooks from inside an if statement.</p>
+  let demoContent: React.ReactNode = (
+    <div className="branch-off">
+      <strong>The conditional block is not running.</strong>
+      <span>Lines 6–29 are currently skipped.</span>
     </div>
   );
 
-  if (isBranchEnabled) {
+  if (isEnabled) {
     const [count, setCount] = React.useState(0);
     const [step, changeStep] = React.useReducer(
       (currentStep: number, direction: number) => Math.max(1, currentStep + direction),
@@ -64,89 +101,83 @@ const ConditionalPanel = ({ onEvent }: ConditionalPanelProperties): React.ReactN
     renderCount.current++;
 
     React.useLayoutEffect(() => {
-      onEvent("Conditional layout effect mounted");
-      return () => onEvent("Conditional layout effect cleaned up");
+      onEvent("layout effect mounted");
+      return () => onEvent("layout effect cleaned up");
     }, []);
 
     React.useEffect(() => {
-      onEvent("Conditional interval started");
+      onEvent("effect timer started");
       const intervalIdentifier = window.setInterval(() => {
-        setHeartbeat((value) => value + 1);
+        setHeartbeat((currentHeartbeat) => currentHeartbeat + 1);
       }, 1000);
       return () => {
         window.clearInterval(intervalIdentifier);
-        onEvent("Conditional interval stopped");
+        onEvent("effect timer stopped");
       };
     }, []);
 
-    branchContent = (
-      <div className="active-branch">
-        <div className="metrics-grid">
-          <article>
-            <span>Counter</span>
-            <strong>{count}</strong>
-          </article>
-          <article>
-            <span>Step</span>
-            <strong>{step}</strong>
-          </article>
-          <article>
-            <span>Count × step</span>
-            <strong>{computedValue}</strong>
-          </article>
-          <article>
-            <span>Render pass</span>
-            <strong>{renderCount.current}</strong>
-          </article>
+    demoContent = (
+      <div className="branch-on">
+        <div className="equation">
+          <strong>{count}</strong>
+          <span>×</span>
+          <strong>{step}</strong>
+          <span>=</span>
+          <strong>{computedValue}</strong>
         </div>
 
-        <div className="controls-row">
+        <div className="button-row">
           <button className="primary-button" onClick={() => setCount((value) => value + step)}>
-            Add {step}
+            add {step}
           </button>
-          <button className="secondary-button" onClick={() => changeStep(-1)}>
-            Step −
-          </button>
-          <button className="secondary-button" onClick={() => changeStep(1)}>
-            Step +
-          </button>
-          <button className="ghost-button" onClick={() => setCount(0)}>
-            Reset
-          </button>
+          <button onClick={() => changeStep(-1)}>step −</button>
+          <button onClick={() => changeStep(1)}>step +</button>
+          <button onClick={() => setCount(0)}>reset count</button>
         </div>
 
-        <div className="heartbeat-row">
-          <span className="heartbeat-dot" />
-          Effect heartbeat <strong>{heartbeat}</strong>
+        <div className="runtime-row">
+          <span>
+            <i className="status-dot" />
+            effect tick {heartbeat}
+          </span>
+          <span>render {renderCount.current}</span>
         </div>
       </div>
     );
   }
 
   return (
-    <section className="lab-card">
-      <div className="card-heading">
+    <section className="demo-section">
+      <div className="section-heading">
         <div>
-          <span className="eyebrow">Live Fiber experiment</span>
-          <h2>Conditional branch</h2>
+          <span className="section-number">02</span>
+          <h2>Run the component</h2>
+        </div>
+        <span>{activationCount} branch activations</span>
+      </div>
+
+      <ol className="instructions">
+        <li>Turn the branch on.</li>
+        <li>Change the count and step.</li>
+        <li>Turn it off, then on again. The state comes back.</li>
+      </ol>
+
+      <div className="toggle-row">
+        <div>
+          <strong>Run lines 6–29</strong>
+          <span>{isEnabled ? "The conditional hooks are mounted." : "The hooks are skipped."}</span>
         </div>
         <button
-          className={isBranchEnabled ? "toggle enabled" : "toggle"}
-          aria-pressed={isBranchEnabled}
-          onClick={toggleBranch}
+          className={isEnabled ? "switch enabled" : "switch"}
+          aria-label="Toggle conditional hook branch"
+          aria-pressed={isEnabled}
+          onClick={toggleDemo}
         >
           <span />
-          {isBranchEnabled ? "Enabled" : "Disabled"}
         </button>
       </div>
 
-      <div className="branch-stage">{branchContent}</div>
-
-      <footer className="card-footer">
-        <span>Branch activations</span>
-        <strong>{activationCount}</strong>
-        <span className="retention-note">State survives while disabled</span>
-      </footer>
+      <div className={isEnabled ? "demo-surface enabled" : "demo-surface"}>{demoContent}</div>
     </section>
   );
 };
@@ -161,82 +192,101 @@ const Application = ({ installation }: ApplicationProperties): React.ReactNode =
         message,
         time: formatTime(),
       },
-      ...currentEvents.slice(0, 7),
+      ...currentEvents.slice(0, 5),
     ]);
   }, []);
 
   return (
     <main className="page-shell">
-      <header className="hero">
-        <div className="status-pill">
-          <span />
-          {installation.supportedRenderers} development renderer connected
+      <header className="intro">
+        <div className="brand-row">
+          <span className="brand-mark">b</span>
+          <strong>bippy</strong>
+          <span className="connection-status">
+            <span className="status-dot" />
+            {installation.supportedRenderers} renderer connected
+          </span>
         </div>
-        <h1>
-          Conditional hooks,
-          <br />
-          <em>actually running.</em>
-        </h1>
+        <h1>Conditional hooks, explained</h1>
         <p>
-          Bippy proxies React’s active dispatcher, keys ordinary hooks by callsite, and stores their
-          state beside the current Fiber instead of consuming React’s positional hook list.
+          React normally requires every hook to run in the same order. This experiment lets the
+          highlighted hooks exist only while the <code>if</code> branch is enabled.
         </p>
+        <div className="comparison-row">
+          <span>Normal React</span>
+          <strong>conditional hooks break</strong>
+          <span>With this runtime</span>
+          <strong>each callsite keeps its own state</strong>
+        </div>
       </header>
 
-      <div className="workspace-grid">
-        <ConditionalPanel onEvent={addEvent} />
+      <section className="source-section">
+        <div className="section-heading">
+          <div>
+            <span className="section-number">01</span>
+            <h2>Read the full component</h2>
+          </div>
+          <span>conditional-counter.tsx</span>
+        </div>
+        <p className="section-description">
+          The highlighted block violates the Rules of Hooks on purpose. It contains state, a
+          reducer, a ref, a memo, and an effect.
+        </p>
+        <pre className="source-code" aria-label="Full conditional counter source code">
+          <code>
+            {DEMO_SOURCE_LINES.map((sourceLine, sourceLineIndex) => {
+              const lineNumber = sourceLineIndex + 1;
+              const isConditionalLine = lineNumber >= 6 && lineNumber <= 29;
+              return (
+                <span
+                  className={isConditionalLine ? "source-line highlighted" : "source-line"}
+                  key={lineNumber}
+                >
+                  <span className="line-number">{lineNumber}</span>
+                  <span>{sourceLine || " "}</span>
+                </span>
+              );
+            })}
+          </code>
+        </pre>
+        <div className="legend">
+          <span className="legend-swatch" />
+          This entire block appears and disappears between renders.
+        </div>
+      </section>
 
-        <aside className="side-stack">
-          <section className="code-card">
-            <div className="window-bar">
-              <span />
-              <span />
-              <span />
-              <small>component.tsx</small>
-            </div>
-            <pre>
-              <code>
-                <span className="syntax-purple">if</span> (enabled) {`{`}
-                {"\n"} <span className="syntax-purple">const</span> [count, setCount] ={"\n"} React.
-                <span className="syntax-blue">useState</span>(0)
-                {"\n\n"} React.<span className="syntax-blue">useEffect</span>(() ={">"} {`{`}
-                {"\n"} <span className="syntax-purple">return</span> subscribe()
-                {"\n"} {`}`}, [])
-                {"\n"}
-                {`}`}
-              </code>
-            </pre>
-          </section>
+      <ConditionalDemo onEvent={addEvent} />
 
-          <section className="events-card">
-            <div className="events-heading">
-              <div>
-                <span className="eyebrow">Commit activity</span>
-                <h3>Effect log</h3>
+      <section className="log-section">
+        <div className="section-heading">
+          <div>
+            <span className="section-number">03</span>
+            <h2>Watch React commit it</h2>
+          </div>
+          <span>live effect log</span>
+        </div>
+        <p className="section-description">
+          Entering starts the effects. Leaving cleans them up. Re-entering restores the previous
+          count and step instead of creating new state.
+        </p>
+        <div className="event-list" aria-live="polite">
+          {events.length === 0 ? (
+            <p className="empty-log">Toggle the branch to see commit activity.</p>
+          ) : (
+            events.map((event) => (
+              <div className="event-row" key={event.id}>
+                <span>{event.message}</span>
+                <time>{event.time}</time>
               </div>
-              <span className="live-badge">Live</span>
-            </div>
-            <div className="event-list">
-              {events.length === 0 ? (
-                <p className="no-events">Toggle the branch to begin.</p>
-              ) : (
-                events.map((event) => (
-                  <div className="event-row" key={event.id}>
-                    <span className="event-marker" />
-                    <span>{event.message}</span>
-                    <time>{event.time}</time>
-                  </div>
-                ))
-              )}
-            </div>
-          </section>
-        </aside>
-      </div>
+            ))
+          )}
+        </div>
+      </section>
 
-      <footer className="page-footer">
-        <span>Development builds only</span>
-        <span>Stack-keyed callsites</span>
-        <span>Absolutely unsupported</span>
+      <footer>
+        <span>runtime experiment</span>
+        <span>development build</span>
+        <a href="https://github.com/aidenybai/bippy">GitHub</a>
       </footer>
     </main>
   );

--- a/packages/conditional-hooks-playground/src/app.tsx
+++ b/packages/conditional-hooks-playground/src/app.tsx
@@ -1,0 +1,253 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+import type { ConditionalHooksInstallation } from "bippy/conditional-hooks";
+
+import "./styles.css";
+
+interface ApplicationProperties {
+  installation: ConditionalHooksInstallation;
+}
+
+interface ConditionalPanelProperties {
+  onEvent: (message: string) => void;
+}
+
+interface EventEntry {
+  id: number;
+  message: string;
+  time: string;
+}
+
+let eventIdentifier = 0;
+
+const formatTime = (): string =>
+  new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(new Date());
+
+const ConditionalPanel = ({ onEvent }: ConditionalPanelProperties): React.ReactNode => {
+  const [isBranchEnabled, setIsBranchEnabled] = React.useState(false);
+  const [activationCount, setActivationCount] = React.useState(0);
+
+  const toggleBranch = (): void => {
+    setIsBranchEnabled((isEnabled) => {
+      const nextIsEnabled = !isEnabled;
+      if (nextIsEnabled) setActivationCount((count) => count + 1);
+      onEvent(nextIsEnabled ? "Branch entered" : "Branch exited");
+      return nextIsEnabled;
+    });
+  };
+
+  let branchContent: React.ReactNode = (
+    <div className="empty-state">
+      <div className="empty-orbit">
+        <span />
+      </div>
+      <strong>The hook branch is dormant</strong>
+      <p>Enable it to call six ordinary React hooks from inside an if statement.</p>
+    </div>
+  );
+
+  if (isBranchEnabled) {
+    const [count, setCount] = React.useState(0);
+    const [step, changeStep] = React.useReducer(
+      (currentStep: number, direction: number) => Math.max(1, currentStep + direction),
+      1,
+    );
+    const renderCount = React.useRef(0);
+    const [heartbeat, setHeartbeat] = React.useState(0);
+    const computedValue = React.useMemo(() => count * step, [count, step]);
+
+    renderCount.current++;
+
+    React.useLayoutEffect(() => {
+      onEvent("Conditional layout effect mounted");
+      return () => onEvent("Conditional layout effect cleaned up");
+    }, []);
+
+    React.useEffect(() => {
+      onEvent("Conditional interval started");
+      const intervalIdentifier = window.setInterval(() => {
+        setHeartbeat((value) => value + 1);
+      }, 1000);
+      return () => {
+        window.clearInterval(intervalIdentifier);
+        onEvent("Conditional interval stopped");
+      };
+    }, []);
+
+    branchContent = (
+      <div className="active-branch">
+        <div className="metrics-grid">
+          <article>
+            <span>Counter</span>
+            <strong>{count}</strong>
+          </article>
+          <article>
+            <span>Step</span>
+            <strong>{step}</strong>
+          </article>
+          <article>
+            <span>Count × step</span>
+            <strong>{computedValue}</strong>
+          </article>
+          <article>
+            <span>Render pass</span>
+            <strong>{renderCount.current}</strong>
+          </article>
+        </div>
+
+        <div className="controls-row">
+          <button className="primary-button" onClick={() => setCount((value) => value + step)}>
+            Add {step}
+          </button>
+          <button className="secondary-button" onClick={() => changeStep(-1)}>
+            Step −
+          </button>
+          <button className="secondary-button" onClick={() => changeStep(1)}>
+            Step +
+          </button>
+          <button className="ghost-button" onClick={() => setCount(0)}>
+            Reset
+          </button>
+        </div>
+
+        <div className="heartbeat-row">
+          <span className="heartbeat-dot" />
+          Effect heartbeat <strong>{heartbeat}</strong>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <section className="lab-card">
+      <div className="card-heading">
+        <div>
+          <span className="eyebrow">Live Fiber experiment</span>
+          <h2>Conditional branch</h2>
+        </div>
+        <button
+          className={isBranchEnabled ? "toggle enabled" : "toggle"}
+          aria-pressed={isBranchEnabled}
+          onClick={toggleBranch}
+        >
+          <span />
+          {isBranchEnabled ? "Enabled" : "Disabled"}
+        </button>
+      </div>
+
+      <div className="branch-stage">{branchContent}</div>
+
+      <footer className="card-footer">
+        <span>Branch activations</span>
+        <strong>{activationCount}</strong>
+        <span className="retention-note">State survives while disabled</span>
+      </footer>
+    </section>
+  );
+};
+
+const Application = ({ installation }: ApplicationProperties): React.ReactNode => {
+  const [events, setEvents] = React.useState<EventEntry[]>([]);
+
+  const addEvent = React.useCallback((message: string): void => {
+    setEvents((currentEvents) => [
+      {
+        id: ++eventIdentifier,
+        message,
+        time: formatTime(),
+      },
+      ...currentEvents.slice(0, 7),
+    ]);
+  }, []);
+
+  return (
+    <main className="page-shell">
+      <header className="hero">
+        <div className="status-pill">
+          <span />
+          {installation.supportedRenderers} development renderer connected
+        </div>
+        <h1>
+          Conditional hooks,
+          <br />
+          <em>actually running.</em>
+        </h1>
+        <p>
+          Bippy proxies React’s active dispatcher, keys ordinary hooks by callsite, and stores their
+          state beside the current Fiber instead of consuming React’s positional hook list.
+        </p>
+      </header>
+
+      <div className="workspace-grid">
+        <ConditionalPanel onEvent={addEvent} />
+
+        <aside className="side-stack">
+          <section className="code-card">
+            <div className="window-bar">
+              <span />
+              <span />
+              <span />
+              <small>component.tsx</small>
+            </div>
+            <pre>
+              <code>
+                <span className="syntax-purple">if</span> (enabled) {`{`}
+                {"\n"} <span className="syntax-purple">const</span> [count, setCount] ={"\n"} React.
+                <span className="syntax-blue">useState</span>(0)
+                {"\n\n"} React.<span className="syntax-blue">useEffect</span>(() ={">"} {`{`}
+                {"\n"} <span className="syntax-purple">return</span> subscribe()
+                {"\n"} {`}`}, [])
+                {"\n"}
+                {`}`}
+              </code>
+            </pre>
+          </section>
+
+          <section className="events-card">
+            <div className="events-heading">
+              <div>
+                <span className="eyebrow">Commit activity</span>
+                <h3>Effect log</h3>
+              </div>
+              <span className="live-badge">Live</span>
+            </div>
+            <div className="event-list">
+              {events.length === 0 ? (
+                <p className="no-events">Toggle the branch to begin.</p>
+              ) : (
+                events.map((event) => (
+                  <div className="event-row" key={event.id}>
+                    <span className="event-marker" />
+                    <span>{event.message}</span>
+                    <time>{event.time}</time>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        </aside>
+      </div>
+
+      <footer className="page-footer">
+        <span>Development builds only</span>
+        <span>Stack-keyed callsites</span>
+        <span>Absolutely unsupported</span>
+      </footer>
+    </main>
+  );
+};
+
+export const startApplication = (installation: ConditionalHooksInstallation): void => {
+  const rootElement = document.querySelector("#root");
+  if (!rootElement) throw new Error("Missing root element.");
+  createRoot(rootElement).render(
+    <React.StrictMode>
+      <Application installation={installation} />
+    </React.StrictMode>,
+  );
+};

--- a/packages/conditional-hooks-playground/src/main.ts
+++ b/packages/conditional-hooks-playground/src/main.ts
@@ -1,8 +1,6 @@
 import { installConditionalHooks } from "bippy/conditional-hooks";
 
-const conditionalHooksInstallation = installConditionalHooks({
-  interceptReactHooks: true,
-});
+const conditionalHooksInstallation = installConditionalHooks();
 
 const { startApplication } = await import("./app.js");
 

--- a/packages/conditional-hooks-playground/src/main.ts
+++ b/packages/conditional-hooks-playground/src/main.ts
@@ -1,0 +1,9 @@
+import { installConditionalHooks } from "bippy/conditional-hooks";
+
+const conditionalHooksInstallation = installConditionalHooks({
+  interceptReactHooks: true,
+});
+
+const { startApplication } = await import("./app.js");
+
+startApplication(conditionalHooksInstallation);

--- a/packages/conditional-hooks-playground/src/styles.css
+++ b/packages/conditional-hooks-playground/src/styles.css
@@ -1,9 +1,13 @@
-@import url("https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700&display=swap");
-
 :root {
-  color: #f3f0ea;
-  background: #09090b;
-  font-family: "Manrope", sans-serif;
+  color: #1a1a1a;
+  background: #fbfaf8;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
 }
@@ -13,494 +17,505 @@
 }
 
 body {
-  margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background:
-    radial-gradient(circle at 10% 0%, rgba(116, 81, 255, 0.14), transparent 28rem),
-    radial-gradient(circle at 88% 22%, rgba(52, 211, 153, 0.08), transparent 25rem), #09090b;
+  margin: 0;
+  background: #fbfaf8;
 }
 
 button {
+  color: inherit;
   font: inherit;
 }
 
 .page-shell {
-  width: min(1180px, calc(100% - 40px));
+  width: min(760px, calc(100% - 32px));
   margin: 0 auto;
-  padding: 72px 0 40px;
+  padding: 40px 0 48px;
 }
 
-.hero {
-  max-width: 820px;
-  margin-bottom: 48px;
+.intro {
+  width: min(100%, 560px);
+  margin-bottom: 52px;
 }
 
-.status-pill,
-.live-badge {
+.brand-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 18px;
+}
+
+.brand-mark {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: 7px;
+  background: #1a1a1a;
+  color: white;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.connection-status {
   display: inline-flex;
   align-items: center;
-  gap: 9px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.035);
-  color: #aaa7a1;
-  font:
-    500 12px/1 "DM Mono",
-    monospace;
-  letter-spacing: 0.02em;
-  padding: 10px 13px;
-}
-
-.status-pill span,
-.live-badge::before {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: #4ade80;
-  box-shadow: 0 0 0 4px rgba(74, 222, 128, 0.11);
-  content: "";
-}
-
-.hero h1 {
-  margin: 27px 0 20px;
-  font-size: clamp(48px, 8vw, 92px);
-  line-height: 0.96;
-  letter-spacing: -0.065em;
-}
-
-.hero h1 em {
-  color: #9b87f5;
-  font-style: normal;
+  gap: 6px;
+  margin-left: auto;
+  color: #858585;
+  font-size: 11px;
   font-weight: 500;
 }
 
-.hero p {
-  max-width: 720px;
+.status-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 50%;
+  background: #4dab67;
+}
+
+.intro h1 {
+  margin: 28px 0 7px;
+  font-size: 28px;
+  line-height: 1.25;
+  letter-spacing: -0.035em;
+}
+
+.intro p {
   margin: 0;
-  color: #96938e;
-  font-size: 17px;
-  line-height: 1.7;
+  color: #707070;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 1.55;
 }
 
-.workspace-grid {
+.intro code {
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: #efeeeb;
+  color: #353535;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 13px;
+}
+
+.comparison-row {
   display: grid;
-  grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.8fr);
-  gap: 18px;
-  align-items: stretch;
+  grid-template-columns: auto 1fr;
+  gap: 0;
+  margin-top: 24px;
+  border-top: 1px solid #dddddd;
 }
 
-.lab-card,
-.code-card,
-.events-card {
-  overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  border-radius: 22px;
-  background: rgba(19, 19, 22, 0.88);
-  box-shadow: 0 22px 80px rgba(0, 0, 0, 0.32);
-  backdrop-filter: blur(18px);
+.comparison-row span,
+.comparison-row strong {
+  padding: 9px 0;
+  border-bottom: 1px solid #eeeeee;
+  font-size: 12px;
 }
 
-.lab-card {
+.comparison-row span {
+  padding-right: 20px;
+  color: #8b8b8b;
+}
+
+.comparison-row strong {
+  color: #444444;
+  font-weight: 600;
+}
+
+.source-section,
+.demo-section,
+.log-section {
+  margin-top: 50px;
+}
+
+.section-heading {
   display: flex;
-  min-height: 590px;
-  flex-direction: column;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  padding-bottom: 11px;
+  border-bottom: 1px solid #dddddd;
 }
 
-.card-heading,
-.events-heading {
+.section-heading > div {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.section-heading h2 {
+  margin: 0;
+  color: #3f3f3f;
+  font-size: 18px;
+  letter-spacing: -0.015em;
+}
+
+.section-number,
+.section-heading > span {
+  color: #929292;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+}
+
+.section-description {
+  width: min(100%, 590px);
+  margin: 14px 0 18px;
+  color: #7b7b7b;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.source-code {
+  overflow: auto;
+  max-height: 560px;
+  margin: 0;
+  padding: 12px 0;
+  border-radius: 9px;
+  background: #202020;
+  box-shadow:
+    0 0 0 1px rgb(0 0 0 / 8%),
+    0 2px 8px rgb(0 0 0 / 8%);
+  color: #d8d8d8;
+  font:
+    12px/1.65 "SFMono-Regular",
+    Consolas,
+    monospace;
+  tab-size: 2;
+}
+
+.source-line {
+  display: grid;
+  min-width: 650px;
+  grid-template-columns: 42px 1fr;
+  padding-right: 18px;
+  white-space: pre;
+}
+
+.source-line.highlighted {
+  background: rgb(102 152 214 / 9%);
+}
+
+.source-line.highlighted .line-number {
+  color: #77aeea;
+}
+
+.line-number {
+  padding-right: 12px;
+  color: #666666;
+  text-align: right;
+  user-select: none;
+}
+
+.legend {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  color: #858585;
+  font-size: 11px;
+}
+
+.legend-swatch {
+  width: 14px;
+  height: 8px;
+  border-radius: 2px;
+  background: rgb(79 134 199 / 18%);
+}
+
+.instructions {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  margin: 18px 0;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid #e5e4e1;
+  border-radius: 9px;
+  background: #e5e4e1;
+  counter-reset: instructions;
+  list-style: none;
+}
+
+.instructions li {
+  min-height: 82px;
+  padding: 13px;
+  background: rgb(255 255 255 / 78%);
+  color: #686868;
+  counter-increment: instructions;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.instructions li::before {
+  display: block;
+  margin-bottom: 8px;
+  color: #a0a0a0;
+  content: counter(instructions, decimal-leading-zero);
+  font:
+    10px/1 "SFMono-Regular",
+    Consolas,
+    monospace;
+}
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 14px 0;
+}
+
+.toggle-row > div {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.toggle-row strong {
+  color: #353535;
+  font-size: 13px;
+}
+
+.toggle-row div > span {
+  color: #858585;
+  font-size: 13px;
+}
+
+.switch {
+  position: relative;
+  width: 38px;
+  height: 22px;
+  flex: none;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: #d4d3d0;
+  cursor: pointer;
+}
+
+.switch > span {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: white;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 14%);
+  transition: transform 140ms ease;
+}
+
+.switch.enabled {
+  background: #262626;
+}
+
+.switch.enabled > span {
+  transform: translateX(16px);
+}
+
+.switch:focus-visible,
+.button-row button:focus-visible {
+  outline: 2px solid #8ab9ef;
+  outline-offset: 2px;
+}
+
+.demo-surface {
+  display: grid;
+  min-height: 190px;
+  place-items: center;
+  border: 1px solid #eeeeee;
+  border-radius: 10px;
+  background: rgb(255 255 255 / 72%);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+}
+
+.demo-surface.enabled {
+  display: block;
+  padding: 24px;
+}
+
+.branch-off {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  text-align: center;
+}
+
+.branch-off strong {
+  color: #626262;
+  font-size: 13px;
+}
+
+.branch-off span,
+.empty-log {
+  color: #969696;
+  font-size: 12px;
+}
+
+.equation {
+  display: flex;
+  align-items: baseline;
+  gap: 13px;
+}
+
+.equation strong {
+  min-width: 46px;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 32px;
+  font-weight: 500;
+  text-align: center;
+}
+
+.equation span {
+  color: #a0a0a0;
+  font:
+    15px/1 "SFMono-Regular",
+    Consolas,
+    monospace;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 24px;
+}
+
+.button-row button {
+  padding: 8px 11px;
+  border: 0;
+  border-radius: 7px;
+  background: white;
+  box-shadow:
+    0 0 0 1px rgb(0 0 0 / 7%),
+    0 1px 3px rgb(0 0 0 / 8%);
+  color: #515151;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.button-row .primary-button {
+  background: #242424;
+  box-shadow: none;
+  color: white;
+}
+
+.button-row button:active {
+  transform: translateY(1px);
+}
+
+.runtime-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 20px;
-  padding: 26px 28px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  margin-top: 25px;
+  padding-top: 13px;
+  border-top: 1px solid #eeeeee;
+  color: #858585;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
 }
 
-.eyebrow {
-  display: block;
-  margin-bottom: 7px;
-  color: #77746f;
-  font:
-    500 10px/1 "DM Mono",
-    monospace;
-  letter-spacing: 0.13em;
-  text-transform: uppercase;
-}
-
-.card-heading h2,
-.events-heading h3 {
-  margin: 0;
-  font-size: 20px;
-  letter-spacing: -0.03em;
-}
-
-.toggle {
+.runtime-row > span {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  border-radius: 999px;
-  background: #202024;
-  color: #aaa7a1;
-  cursor: pointer;
-  padding: 9px 13px 9px 9px;
-  transition:
-    border-color 160ms ease,
-    background 160ms ease,
-    color 160ms ease;
-}
-
-.toggle span {
-  width: 18px;
-  height: 18px;
-  border: 5px solid #545159;
-  border-radius: 50%;
-  background: #18181b;
-}
-
-.toggle.enabled {
-  border-color: rgba(74, 222, 128, 0.28);
-  background: rgba(74, 222, 128, 0.1);
-  color: #b9f8ce;
-}
-
-.toggle.enabled span {
-  border-color: #4ade80;
-}
-
-.branch-stage {
-  display: grid;
-  flex: 1;
-  place-items: center;
-  padding: 30px;
-}
-
-.empty-state {
-  max-width: 350px;
-  color: #817e79;
-  text-align: center;
-}
-
-.empty-state strong {
-  display: block;
-  margin: 24px 0 8px;
-  color: #c8c5bf;
-  font-size: 18px;
-}
-
-.empty-state p {
-  margin: 0;
-  font-size: 14px;
-  line-height: 1.6;
-}
-
-.empty-orbit {
-  display: grid;
-  width: 78px;
-  height: 78px;
-  margin: 0 auto;
-  place-items: center;
-  border: 1px dashed #3d3b40;
-  border-radius: 50%;
-}
-
-.empty-orbit span {
-  width: 22px;
-  height: 22px;
-  border: 5px solid #55515d;
-  border-radius: 50%;
-}
-
-.active-branch {
-  width: 100%;
-}
-
-.metrics-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 12px;
-}
-
-.metrics-grid article {
-  min-height: 128px;
-  padding: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  border-radius: 16px;
-  background: #101012;
-}
-
-.metrics-grid span {
-  color: #77746f;
-  font-size: 12px;
-}
-
-.metrics-grid strong {
-  display: block;
-  margin-top: 24px;
-  color: #e9e5de;
-  font:
-    500 38px/1 "DM Mono",
-    monospace;
-  letter-spacing: -0.05em;
-}
-
-.controls-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 9px;
-  margin-top: 18px;
-}
-
-.controls-row button {
-  border-radius: 11px;
-  cursor: pointer;
-  padding: 11px 15px;
-}
-
-.primary-button {
-  border: 1px solid #9b87f5;
-  background: #9b87f5;
-  color: #100e17;
-  font-weight: 700;
-}
-
-.secondary-button {
-  border: 1px solid #343239;
-  background: #252429;
-  color: #dad6cf;
-}
-
-.ghost-button {
-  border: 1px solid transparent;
-  background: transparent;
-  color: #85817c;
-}
-
-.heartbeat-row {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  margin-top: 20px;
-  color: #807d77;
-  font:
-    400 12px/1 "DM Mono",
-    monospace;
-}
-
-.heartbeat-row strong {
-  color: #d3d0ca;
-}
-
-.heartbeat-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #4ade80;
-  box-shadow: 0 0 14px rgba(74, 222, 128, 0.8);
-}
-
-.card-footer {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 18px 28px;
-  border-top: 1px solid rgba(255, 255, 255, 0.07);
-  color: #77746f;
-  font-size: 12px;
-}
-
-.card-footer strong {
-  color: #e0ddd7;
-  font-family: "DM Mono", monospace;
-}
-
-.retention-note {
-  margin-left: auto;
-  color: #9b87f5;
-}
-
-.side-stack {
-  display: grid;
-  grid-template-rows: auto 1fr;
-  gap: 18px;
-}
-
-.window-bar {
-  display: flex;
-  align-items: center;
   gap: 7px;
-  padding: 15px 17px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
-}
-
-.window-bar > span {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #4b4850;
-}
-
-.window-bar > span:first-child {
-  background: #ff6b68;
-}
-
-.window-bar > span:nth-child(2) {
-  background: #f2c94c;
-}
-
-.window-bar > span:nth-child(3) {
-  background: #4ade80;
-}
-
-.window-bar small {
-  margin-left: auto;
-  color: #65625e;
-  font:
-    400 10px/1 "DM Mono",
-    monospace;
-}
-
-.code-card pre {
-  overflow-x: auto;
-  margin: 0;
-  padding: 24px;
-  color: #c9c5bf;
-  font:
-    400 12px/1.85 "DM Mono",
-    monospace;
-}
-
-.syntax-purple {
-  color: #c4a7ff;
-}
-
-.syntax-blue {
-  color: #75c8ff;
-}
-
-.events-card {
-  min-height: 300px;
-}
-
-.events-heading {
-  padding: 21px 23px;
-}
-
-.live-badge {
-  padding: 7px 9px;
-  font-size: 9px;
 }
 
 .event-list {
-  padding: 9px 22px 20px;
+  min-height: 64px;
+  margin-top: 4px;
 }
 
-.no-events {
-  padding: 22px 0;
-  color: #6f6c67;
-  font-size: 13px;
+.empty-log {
+  margin: 0;
+  padding: 17px 0;
 }
 
 .event-row {
-  display: grid;
-  grid-template-columns: 8px 1fr auto;
+  display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 12px 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.055);
-  color: #aaa7a1;
-  font-size: 11px;
-}
-
-.event-marker {
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: #9b87f5;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 10px 0;
+  border-bottom: 1px solid #eeeeee;
+  color: #5a5a5a;
+  font-size: 13px;
 }
 
 .event-row time {
-  color: #5f5c58;
+  flex: none;
+  color: #a0a0a0;
   font:
-    400 9px/1 "DM Mono",
+    10px/1 "SFMono-Regular",
+    Consolas,
     monospace;
 }
 
-.page-footer {
+footer {
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px 30px;
-  padding: 27px 3px 0;
-  color: #56534f;
-  font:
-    400 10px/1 "DM Mono",
-    monospace;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  align-items: center;
+  gap: 15px;
+  margin-top: 52px;
+  padding-top: 20px;
+  border-top: 1px solid #dddddd;
+  color: #969696;
+  font-size: 12px;
 }
 
-.page-footer span::before {
-  margin-right: 8px;
-  color: #77736f;
-  content: "✦";
+footer a {
+  margin-left: auto;
+  color: #707070;
+  text-decoration-color: #c4c4c4;
+  text-underline-offset: 3px;
 }
 
-@media (max-width: 860px) {
+@media (max-width: 640px) {
   .page-shell {
-    padding-top: 45px;
+    padding-top: 24px;
   }
 
-  .workspace-grid {
+  .connection-status {
+    max-width: 126px;
+    text-align: right;
+  }
+
+  .instructions {
     grid-template-columns: 1fr;
   }
 
-  .lab-card {
-    min-height: 560px;
-  }
-}
-
-@media (max-width: 560px) {
-  .page-shell {
-    width: min(100% - 24px, 1180px);
+  .instructions li {
+    min-height: 0;
   }
 
-  .hero h1 {
-    font-size: 48px;
-  }
-
-  .card-heading {
+  .section-heading {
     align-items: flex-start;
-    flex-direction: column;
   }
 
-  .metrics-grid {
-    grid-template-columns: 1fr 1fr;
+  .section-heading > div {
+    align-items: flex-start;
   }
 
-  .metrics-grid article {
-    min-height: 110px;
-    padding: 16px;
+  .section-heading > span {
+    max-width: 120px;
+    text-align: right;
   }
 
-  .metrics-grid strong {
-    font-size: 30px;
-  }
-
-  .branch-stage {
-    padding: 20px;
-  }
-
-  .retention-note {
-    display: none;
+  .source-code {
+    margin-right: -16px;
+    margin-left: -16px;
+    border-radius: 0;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    scroll-behavior: auto !important;
-    transition-duration: 0.01ms !important;
+  .switch > span {
+    transition: none;
   }
 }

--- a/packages/conditional-hooks-playground/src/styles.css
+++ b/packages/conditional-hooks-playground/src/styles.css
@@ -1,0 +1,506 @@
+@import url("https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700&display=swap");
+
+:root {
+  color: #f3f0ea;
+  background: #09090b;
+  font-family: "Manrope", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 10% 0%, rgba(116, 81, 255, 0.14), transparent 28rem),
+    radial-gradient(circle at 88% 22%, rgba(52, 211, 153, 0.08), transparent 25rem), #09090b;
+}
+
+button {
+  font: inherit;
+}
+
+.page-shell {
+  width: min(1180px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 72px 0 40px;
+}
+
+.hero {
+  max-width: 820px;
+  margin-bottom: 48px;
+}
+
+.status-pill,
+.live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.035);
+  color: #aaa7a1;
+  font:
+    500 12px/1 "DM Mono",
+    monospace;
+  letter-spacing: 0.02em;
+  padding: 10px 13px;
+}
+
+.status-pill span,
+.live-badge::before {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #4ade80;
+  box-shadow: 0 0 0 4px rgba(74, 222, 128, 0.11);
+  content: "";
+}
+
+.hero h1 {
+  margin: 27px 0 20px;
+  font-size: clamp(48px, 8vw, 92px);
+  line-height: 0.96;
+  letter-spacing: -0.065em;
+}
+
+.hero h1 em {
+  color: #9b87f5;
+  font-style: normal;
+  font-weight: 500;
+}
+
+.hero p {
+  max-width: 720px;
+  margin: 0;
+  color: #96938e;
+  font-size: 17px;
+  line-height: 1.7;
+}
+
+.workspace-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.8fr);
+  gap: 18px;
+  align-items: stretch;
+}
+
+.lab-card,
+.code-card,
+.events-card {
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 22px;
+  background: rgba(19, 19, 22, 0.88);
+  box-shadow: 0 22px 80px rgba(0, 0, 0, 0.32);
+  backdrop-filter: blur(18px);
+}
+
+.lab-card {
+  display: flex;
+  min-height: 590px;
+  flex-direction: column;
+}
+
+.card-heading,
+.events-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 26px 28px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.eyebrow {
+  display: block;
+  margin-bottom: 7px;
+  color: #77746f;
+  font:
+    500 10px/1 "DM Mono",
+    monospace;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.card-heading h2,
+.events-heading h3 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: -0.03em;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 999px;
+  background: #202024;
+  color: #aaa7a1;
+  cursor: pointer;
+  padding: 9px 13px 9px 9px;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    color 160ms ease;
+}
+
+.toggle span {
+  width: 18px;
+  height: 18px;
+  border: 5px solid #545159;
+  border-radius: 50%;
+  background: #18181b;
+}
+
+.toggle.enabled {
+  border-color: rgba(74, 222, 128, 0.28);
+  background: rgba(74, 222, 128, 0.1);
+  color: #b9f8ce;
+}
+
+.toggle.enabled span {
+  border-color: #4ade80;
+}
+
+.branch-stage {
+  display: grid;
+  flex: 1;
+  place-items: center;
+  padding: 30px;
+}
+
+.empty-state {
+  max-width: 350px;
+  color: #817e79;
+  text-align: center;
+}
+
+.empty-state strong {
+  display: block;
+  margin: 24px 0 8px;
+  color: #c8c5bf;
+  font-size: 18px;
+}
+
+.empty-state p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.empty-orbit {
+  display: grid;
+  width: 78px;
+  height: 78px;
+  margin: 0 auto;
+  place-items: center;
+  border: 1px dashed #3d3b40;
+  border-radius: 50%;
+}
+
+.empty-orbit span {
+  width: 22px;
+  height: 22px;
+  border: 5px solid #55515d;
+  border-radius: 50%;
+}
+
+.active-branch {
+  width: 100%;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.metrics-grid article {
+  min-height: 128px;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 16px;
+  background: #101012;
+}
+
+.metrics-grid span {
+  color: #77746f;
+  font-size: 12px;
+}
+
+.metrics-grid strong {
+  display: block;
+  margin-top: 24px;
+  color: #e9e5de;
+  font:
+    500 38px/1 "DM Mono",
+    monospace;
+  letter-spacing: -0.05em;
+}
+
+.controls-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+  margin-top: 18px;
+}
+
+.controls-row button {
+  border-radius: 11px;
+  cursor: pointer;
+  padding: 11px 15px;
+}
+
+.primary-button {
+  border: 1px solid #9b87f5;
+  background: #9b87f5;
+  color: #100e17;
+  font-weight: 700;
+}
+
+.secondary-button {
+  border: 1px solid #343239;
+  background: #252429;
+  color: #dad6cf;
+}
+
+.ghost-button {
+  border: 1px solid transparent;
+  background: transparent;
+  color: #85817c;
+}
+
+.heartbeat-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-top: 20px;
+  color: #807d77;
+  font:
+    400 12px/1 "DM Mono",
+    monospace;
+}
+
+.heartbeat-row strong {
+  color: #d3d0ca;
+}
+
+.heartbeat-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #4ade80;
+  box-shadow: 0 0 14px rgba(74, 222, 128, 0.8);
+}
+
+.card-footer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 18px 28px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  color: #77746f;
+  font-size: 12px;
+}
+
+.card-footer strong {
+  color: #e0ddd7;
+  font-family: "DM Mono", monospace;
+}
+
+.retention-note {
+  margin-left: auto;
+  color: #9b87f5;
+}
+
+.side-stack {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 18px;
+}
+
+.window-bar {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 15px 17px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.window-bar > span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #4b4850;
+}
+
+.window-bar > span:first-child {
+  background: #ff6b68;
+}
+
+.window-bar > span:nth-child(2) {
+  background: #f2c94c;
+}
+
+.window-bar > span:nth-child(3) {
+  background: #4ade80;
+}
+
+.window-bar small {
+  margin-left: auto;
+  color: #65625e;
+  font:
+    400 10px/1 "DM Mono",
+    monospace;
+}
+
+.code-card pre {
+  overflow-x: auto;
+  margin: 0;
+  padding: 24px;
+  color: #c9c5bf;
+  font:
+    400 12px/1.85 "DM Mono",
+    monospace;
+}
+
+.syntax-purple {
+  color: #c4a7ff;
+}
+
+.syntax-blue {
+  color: #75c8ff;
+}
+
+.events-card {
+  min-height: 300px;
+}
+
+.events-heading {
+  padding: 21px 23px;
+}
+
+.live-badge {
+  padding: 7px 9px;
+  font-size: 9px;
+}
+
+.event-list {
+  padding: 9px 22px 20px;
+}
+
+.no-events {
+  padding: 22px 0;
+  color: #6f6c67;
+  font-size: 13px;
+}
+
+.event-row {
+  display: grid;
+  grid-template-columns: 8px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+  color: #aaa7a1;
+  font-size: 11px;
+}
+
+.event-marker {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #9b87f5;
+}
+
+.event-row time {
+  color: #5f5c58;
+  font:
+    400 9px/1 "DM Mono",
+    monospace;
+}
+
+.page-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 30px;
+  padding: 27px 3px 0;
+  color: #56534f;
+  font:
+    400 10px/1 "DM Mono",
+    monospace;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.page-footer span::before {
+  margin-right: 8px;
+  color: #77736f;
+  content: "✦";
+}
+
+@media (max-width: 860px) {
+  .page-shell {
+    padding-top: 45px;
+  }
+
+  .workspace-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .lab-card {
+    min-height: 560px;
+  }
+}
+
+@media (max-width: 560px) {
+  .page-shell {
+    width: min(100% - 24px, 1180px);
+  }
+
+  .hero h1 {
+    font-size: 48px;
+  }
+
+  .card-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .metrics-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .metrics-grid article {
+    min-height: 110px;
+    padding: 16px;
+  }
+
+  .metrics-grid strong {
+    font-size: 30px;
+  }
+
+  .branch-stage {
+    padding: 20px;
+  }
+
+  .retention-note {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/packages/conditional-hooks-playground/tsconfig.json
+++ b/packages/conditional-hooks-playground/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ESNext"
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/packages/conditional-hooks-playground/vite.config.ts
+++ b/packages/conditional-hooks-playground/vite.config.ts
@@ -1,0 +1,9 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 4175,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,34 @@ importers:
         specifier: latest
         version: 0.1.15(@types/node@20.19.34)(esbuild@0.27.4)(happy-dom@15.11.7)(jiti@2.7.0)(publint@0.3.18)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
 
+  packages/conditional-hooks-playground:
+    dependencies:
+      bippy:
+        specifier: workspace:*
+        version: link:../bippy
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.4
+        version: 19.1.17
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.3(@types/react@19.1.17)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@7.3.6(@types/node@20.19.34)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vite-plus:
+        specifier: latest
+        version: 0.1.15(@types/node@20.19.34)(esbuild@0.27.4)(happy-dom@15.11.7)(jiti@2.7.0)(publint@0.3.18)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+
   packages/e2e:
     devDependencies:
       '@jest/globals':


### PR DESCRIPTION
## What this PR does

This PR makes ordinary React hooks work inside branches whose hook order changes between renders, without patching or forking React.

~~~tsx
const Counter = ({ enabled }: { enabled: boolean }) => {
  if (enabled) {
    const [count, setCount] = React.useState(0)

    React.useEffect(() => {
      console.log("mounted")
      return () => console.log("cleaned up")
    }, [])

    return <button onClick={() => setCount(count + 1)}>{count}</button>
  }

  return null
}
~~~

There is one consumer-facing model:

1. Call <code>installConditionalHooks()</code> before the application renders.
2. Continue using normal <code>React.useState</code>, <code>React.useReducer</code>, <code>React.useEffect</code>, and related APIs.
3. Put them inside branches if desired.

There are no public keyed-hook functions and no opt-in interception flag. Interception is automatic after installation. All callsite identity is derived internally.

> [!IMPORTANT]
> This only works with React development renderers. It relies on private renderer fields exposed to DevTools: <code>currentDispatcherRef</code>, <code>getCurrentFiber</code>, and <code>scheduleUpdate</code>. It is experimental, unsupported, and not production-safe.

## Complete runnable example

The installer must execute before the module that renders the React application.

### main.tsx

~~~tsx
import { installConditionalHooks } from "bippy/conditional-hooks"

installConditionalHooks()

const { startApplication } = await import("./app.js")

startApplication()
~~~

The dynamic import is intentional. It ensures Bippy is listening before ReactDOM injects its renderer and before the first component render.

### app.tsx

~~~tsx
import React from "react"
import { createRoot } from "react-dom/client"

interface ConditionalCounterProperties {
  enabled: boolean
}

const ConditionalCounter = ({
  enabled,
}: ConditionalCounterProperties): React.ReactNode => {
  let content: React.ReactNode = <p>The branch is disabled.</p>

  if (enabled) {
    const [count, setCount] = React.useState(0)

    const [step, changeStep] = React.useReducer(
      (currentStep: number, direction: number) =>
        Math.max(1, currentStep + direction),
      1,
    )

    const renderCount = React.useRef(0)

    const result = React.useMemo(
      () => count * step,
      [count, step],
    )

    renderCount.current++

    React.useLayoutEffect(() => {
      console.log("layout effect mounted")

      return () => {
        console.log("layout effect cleaned up")
      }
    }, [])

    React.useEffect(() => {
      const intervalIdentifier = window.setInterval(() => {
        console.log("effect tick")
      }, 1000)

      return () => {
        window.clearInterval(intervalIdentifier)
        console.log("effect cleaned up")
      }
    }, [])

    content = (
      <section>
        <p>
          {count} × {step} = {result}
        </p>

        <button
          onClick={() =>
            setCount((currentCount) => currentCount + step)
          }
        >
          add {step}
        </button>

        <button onClick={() => changeStep(-1)}>
          step −
        </button>

        <button onClick={() => changeStep(1)}>
          step +
        </button>

        <small>
          render {renderCount.current}
        </small>
      </section>
    )
  }

  return content
}

const Application = (): React.ReactNode => {
  const [isEnabled, setIsEnabled] = React.useState(false)

  return (
    <main>
      <button
        onClick={() =>
          setIsEnabled((currentValue) => !currentValue)
        }
      >
        {isEnabled ? "disable branch" : "enable branch"}
      </button>

      <ConditionalCounter enabled={isEnabled} />
    </main>
  )
}

export const startApplication = (): void => {
  const rootElement = document.querySelector("#root")

  if (!rootElement) {
    throw new Error("Missing root element.")
  }

  createRoot(rootElement).render(<Application />)
}
~~~

The observable behavior is:

~~~text
first render, enabled = false
  conditional hooks do not run

enable the branch
  state, reducer, ref, and memo cells are created
  layout and passive effects start

update count or step
  the owning component renders again
  existing cells are recovered automatically

disable the branch
  state-like cells remain stored
  conditional effects clean up

enable the branch again
  previous count and step return
  effects start again
~~~

## Try the playground

~~~bash
cd packages/conditional-hooks-playground
nr dev
~~~

The playground shows the full component, highlights the conditional block, and walks through the enable, update, disable, and re-enable sequence.

## How the implementation works

The implementation lives in <code>packages/bippy/src/conditional-hooks.ts</code>.

### 1. Observe React renderers

Bippy attaches through the same global hook used by React DevTools.

Installation handles renderers that already exist and renderers injected later:

~~~ts
export const installConditionalHooks = (
  options: ConditionalHooksOptions = {},
): ConditionalHooksInstallation => {
  const devtoolsHook = getRDTHook()

  for (const renderer of [
    ...knownRenderers,
    ...devtoolsHook.renderers.values(),
  ]) {
    installRenderer(renderer, options)
  }

  const unsubscribeRendererInject = onRendererInject((renderer) => {
    installRenderer(renderer, options)
  })

  const unsubscribeInstrumentation = instrument({
    name: "bippy-conditional-hooks",
    onCommitFiberRoot: (_rendererIdentifier, root) =>
      commitRoot(root),
    onCommitFiberUnmount: (_rendererIdentifier, fiber) =>
      unmountFiber(fiber),
  })

  return createInstallationDisposer(
    unsubscribeRendererInject,
    unsubscribeInstrumentation,
  )
}
~~~

A renderer is supported only when it exposes:

~~~ts
renderer.currentDispatcherRef
renderer.getCurrentFiber
renderer.scheduleUpdate
~~~

These are development-only DevTools integration fields. No React source or bundle is modified.

### 2. Intercept the active hook dispatcher

Before React renders a function component, it assigns the dispatcher used by calls such as <code>React.useState()</code>.

Bippy replaces the dispatcher property with a getter and setter:

~~~ts
Object.defineProperty(dispatcherRef, dispatcherKey, {
  configurable: true,
  enumerable: originalDescriptor?.enumerable ?? true,

  get: () => getRuntimeDispatcher(runtime),

  set: (dispatcher) => {
    handleDispatcherChange(runtime, dispatcher)
  },
})
~~~

The setter observes when React enters a render and captures the current Fiber:

~~~ts
const handleDispatcherChange = (
  runtime: ConditionalHookRuntime,
  dispatcher: ConditionalHookDispatcher | null,
): void => {
  runtime.currentDispatcher = dispatcher

  if (isContextOnlyDispatcher(dispatcher)) {
    runtime.activeFiber = null
    return
  }

  const fiber = runtime.renderer.getCurrentFiber?.()

  if (fiber) {
    beginRender(runtime, fiber)
  }
}
~~~

The getter returns a proxy around React's active dispatcher.

### 3. Redirect normal React hook calls

The proxy redirects supported hook methods into private cell readers:

~~~ts
const createDispatcherProxy = (
  runtime: ConditionalHookRuntime,
  dispatcher: ConditionalHookDispatcher,
): ConditionalHookDispatcher =>
  new Proxy(dispatcher, {
    get: (target, property, receiver) => {
      if (property === "useState") {
        return (initialState: unknown) =>
          readStateCell(
            getAutomaticHookKey(runtime, "useState"),
            initialState,
          )
      }

      if (property === "useReducer") {
        return (
          reducer: (state: unknown, action: unknown) => unknown,
          initialState: unknown,
          initialize?: (value: unknown) => unknown,
        ) =>
          readReducerCell(
            getAutomaticHookKey(runtime, "useReducer"),
            reducer,
            initialState,
            initialize,
          )
      }

      if (property === "useEffect") {
        return (
          create: () => void | (() => void),
          dependencies: readonly unknown[] | undefined,
        ) =>
          registerEffect(
            getAutomaticHookKey(runtime, "useEffect"),
            "effect",
            create,
            dependencies,
          )
      }

      return Reflect.get(target, property, receiver)
    },
  })
~~~

The application still calls <code>React.useState(0)</code>. React consults its active dispatcher, and the dispatcher proxy privately routes the call into Bippy.

This does not mutate the exported React object.

The automatically handled APIs are:

- <code>useState</code>
- <code>useReducer</code>
- <code>useRef</code>
- <code>useMemo</code>
- <code>useCallback</code>
- <code>useEffect</code>
- <code>useLayoutEffect</code>

<code>useContext</code> is forwarded to React's context reader. <code>useDebugValue</code> is accepted as a no-op. Other hooks continue through React's dispatcher unchanged.

### 4. Derive hook identity automatically

React normally identifies a hook by its position in the hook list. Bippy instead creates an internal identity from the application callsite.

The default resolver captures a stack and selects the first frame outside React, Bippy, and bundled React runtime files:

~~~ts
const defaultHookKeyResolver = (
  hookName: string,
  stack: string,
): PropertyKey => {
  const callsite = stack
    .split("\n")
    .map((line) => line.trim())
    .find((line) => isApplicationCallsite(line))

  if (!callsite) {
    throw new Error(
      "Could not derive an automatic hook callsite.",
    )
  }

  return hookName + ":" + callsite
}
~~~

A source line can execute repeatedly, such as in a loop. A render-local occurrence counter distinguishes those calls:

~~~ts
const getAutomaticHookKey = (
  runtime: ConditionalHookRuntime,
  hookName: string,
): PropertyKey => {
  const { frame } = getScope()
  const callsite = runtime.getHookKey(
    hookName,
    new Error().stack ?? "",
  )
  const occurrence = frame.callCounts.get(callsite) ?? 0

  frame.callCounts.set(callsite, occurrence + 1)

  return "react:" + String(callsite) + ":" + occurrence
}
~~~

Consumers do not pass these keys. They are an internal implementation detail.

### 5. Store cells beside the Fiber

React stores its positional hooks in <code>fiber.memoizedState</code>. This runtime deliberately does not add anything to that linked list.

Instead, each component Fiber owns a private scope:

~~~ts
interface ConditionalHookScope {
  cells: Map<PropertyKey, ConditionalHookCell>
  effects: Map<PropertyKey, ConditionalEffectCell>
  fiber: Fiber
  didCommit: boolean
  didUnmount: boolean
  renderer: ReactRenderer
}

const scopeByFiber = new WeakMap<Fiber, ConditionalHookScope>()
~~~

A state cell contains the state value and stable dispatch function:

~~~ts
interface ConditionalStateCell {
  kind: "state"
  value: unknown
  dispatch: (action: unknown) => void
}
~~~

A reducer cell additionally contains its current reducer and queued actions. Ref and memo cells contain their corresponding values and dependencies.

React swaps between a current Fiber and a work-in-progress alternate. Both Fiber objects are associated with the same scope:

~~~ts
const associateScopeWithFiber = (
  scope: ConditionalHookScope,
  fiber: Fiber,
): void => {
  scope.fiber = fiber
  scopeByFiber.set(fiber, scope)

  if (fiber.alternate) {
    scopeByFiber.set(fiber.alternate, scope)
  }
}
~~~

That preserves state across renders while keeping separate mounted component instances isolated.

### 6. Read or create a state cell

The private state path is:

~~~ts
const readStateCell = <State>(
  key: PropertyKey,
  initialState: State | (() => State),
): [State, React.Dispatch<React.SetStateAction<State>>] => {
  const { frame, scope } = getScope()

  let cell = frame.cells.get(key) ?? scope.cells.get(key)

  if (!cell) {
    const stateCell = {
      kind: "state",
      value:
        typeof initialState === "function"
          ? initialState()
          : initialState,

      dispatch: (action: unknown) => {
        if (scope.didUnmount) {
          return
        }

        const nextValue =
          typeof action === "function"
            ? action(stateCell.value)
            : action

        if (Object.is(stateCell.value, nextValue)) {
          return
        }

        stateCell.value = nextValue
        scheduleScopeUpdate(scope)
      },
    }

    cell = stateCell
    frame.cells.set(key, stateCell)
  }

  return [cell.value, cell.dispatch]
}
~~~

Consequences:

- The initializer runs only when an automatically derived callsite has no cell.
- Skipping a branch does not delete its state cell.
- Re-entering the branch recovers that cell.
- Equal updates do not schedule a render.
- A setter captured before unmount becomes inert.
- Render-phase updates are queued in the temporary render frame.

Reducers follow the same lookup model and replay pending actions with the reducer from the render processing them.

### 7. Schedule the owning component

Because these cells are outside React's normal hook queue, a setter must explicitly schedule the owning Fiber:

~~~ts
const scheduleScopeUpdate = (
  scope: ConditionalHookScope,
): void => {
  if (scope.didUnmount) {
    return
  }

  const currentFiber = getCurrentFiberBranch(scope.fiber)

  currentFiber.memoizedProps = {
    ...currentFiber.memoizedProps,
  }

  if (isMemoFiber(currentFiber)) {
    currentFiber.pendingProps = {
      ...currentFiber.pendingProps,
      __bippyConditionalHookUpdate: nextUpdateVersion(),
    }
  }

  scope.renderer.scheduleUpdate(currentFiber)
}
~~~

The props changes work around React bailouts and <code>React.memo</code>. They ensure React notices a side-table update even when ordinary props are referentially unchanged.

### 8. Keep renders transactional

Each render writes into a temporary frame:

~~~ts
interface ConditionalRenderFrame {
  callCounts: Map<PropertyKey, number>
  cells: Map<PropertyKey, ConditionalHookCell>
  effects: Map<PropertyKey, ConditionalEffectRegistration>
  renderPhaseUpdates: Map<PropertyKey, unknown[]>
  scope: ConditionalHookScope
}
~~~

Only a successful commit promotes the frame:

~~~ts
const commitRoot = (root: FiberRoot): void => {
  traverseFiber(root.current, (fiber) => {
    const frame = renderFrameByFiber.get(fiber)

    if (!frame) {
      return
    }

    renderFrameByFiber.delete(fiber)
    commitRenderFrame(frame)
  })

  updateHiddenTreeVisibility()
}
~~~

If React abandons a render because it suspends, throws, or is replaced by newer work, that frame is never promoted. Its temporary state and effects cannot leak into the committed tree.

### 9. Reconcile effects after commit

Each successful render records the conditional effects that actually ran. Commit compares the new registrations with the previous committed effects:

~~~ts
for (const [key, previousEffect] of scope.effects) {
  if (!frame.effects.has(key)) {
    runEffectCleanup(previousEffect)
    scope.effects.delete(key)
  }
}

for (const [key, nextEffect] of frame.effects) {
  const previousEffect = scope.effects.get(key)

  if (
    previousEffect &&
    areDependenciesEqual(
      previousEffect.dependencies,
      nextEffect.dependencies,
    )
  ) {
    continue
  }

  if (previousEffect) {
    runEffectCleanup(previousEffect)
  }

  const committedEffect = createEffectCell(nextEffect)
  scope.effects.set(key, committedEffect)
  startEffect(scope, key, committedEffect)
}
~~~

This gives the expected branch lifecycle:

~~~text
disabled → enabled
  create cells
  start effects

enabled → enabled, equal dependencies
  reuse cells
  retain effects

enabled → enabled, changed dependencies
  reuse cells
  clean up and restart changed effects

enabled → disabled
  retain state-like cells
  clean up effects missing from the render

component unmount
  clean up every effect
  delete the entire Fiber scope
~~~

The runtime also handles Strict Mode replay and hidden Suspense/Activity subtrees.

### Full event sequence

~~~text
React selects its render dispatcher
  ↓
the dispatcher setter captures the current Fiber
  ↓
Bippy creates a temporary render frame
  ↓
the component calls React.useState() inside a branch
  ↓
the dispatcher proxy derives callsite + occurrence
  ↓
the private state reader finds or creates the cell
  ↓
the button calls the cell's dispatch function
  ↓
dispatch updates the cell and schedules its Fiber
  ↓
React renders and commits
  ↓
Bippy promotes the frame and reconciles effects
~~~

## Public API

The public surface is intentionally small:

~~~ts
interface ConditionalHooksInstallation {
  readonly supportedRenderers: number
  (): void
}

interface ConditionalHooksOptions {
  getHookKey?: (
    hookName: string,
    stack: string,
  ) => PropertyKey
}

const installConditionalHooks = (
  options?: ConditionalHooksOptions,
): ConditionalHooksInstallation
~~~

Normal usage needs no options:

~~~ts
const dispose = installConditionalHooks()

// Later, if needed:
dispose()
~~~

<code>supportedRenderers</code> is a live count. The optional resolver customizes automatic callsite derivation globally; it does not add a per-hook keyed API.

## Test coverage

The 86 focused, stress, adversarial, and React-upstream-derived cases all exercise ordinary <code>React.use*</code> calls. They cover:

- branch entry, exit, and re-entry;
- state retention and component-instance isolation;
- reducers, refs, memoization, callbacks, and effects;
- functional and render-phase updates;
- Strict Mode render and effect replay;
- Suspense, aborted renders, errors, and retries;
- transitions, deferred values, external stores, and optimistic state;
- portals, nested roots, memoized components, and unmounts;
- effect ordering and hidden Activity trees;
- repeated automatic callsites in loops;
- stale setters and installation disposal.

Validation:

~~~text
vp check
vp run bippy#test
vp run bippy#build
vp run conditional-hooks-playground#build
git diff --check
~~~

Result: 642 tests passed, 1 expected failure, and 3 skipped.

## Known boundaries

- Development renderer only; the required helpers are absent from production renderer injection.
- Private React and DevTools internals may change between React releases.
- Bundlers and source transforms can rewrite stack-derived callsites. The optional global resolver can customize automatic callsite identity when needed.
- Linters still enforce the official Rules of Hooks and do not understand this experiment.
- Custom passive effects cannot be synchronously force-flushed before a later layout commit.
- Errors from custom passive effects cannot enter React's commit-phase error-boundary handling through this DevTools API.
- This is research code, not a recommended application architecture.