### PR TITLE
Simplify React internals defaults and error propagation

### DIFF
--- a/.changeset/clarify-react-internals.md
+++ b/.changeset/clarify-react-internals.md
@@ -2,4 +2,4 @@
 "bippy": minor
 ---
 
-Clarify React internals defaults and propagate callback failures without wrapping them.
+Clarify React internals defaults and propagate callback and DCE failures without wrapping them.

--- a/.changeset/clarify-react-internals.md
+++ b/.changeset/clarify-react-internals.md
@@ -1,5 +1,5 @@
 ---
-"bippy": patch
+"bippy": minor
 ---
 
-Clarify React internals defaults and runtime error messages.
+Clarify React internals defaults and propagate callback failures without wrapping them.

--- a/.changeset/clarify-react-internals.md
+++ b/.changeset/clarify-react-internals.md
@@ -1,0 +1,5 @@
+---
+"bippy": patch
+---
+
+Clarify React internals defaults and runtime error messages.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ const unsubscribe = instrument({
 unsubscribe();
 ```
 
-instrumentation, React DevTools, and hook-listener failures propagate synchronously as `BippyInstrumentationError`, `BippyReactDevToolsError`, or `BippyHookListenerError`. each error preserves the original failure in `cause`, and callback dispatch stops at the failure so the caller controls error handling. existing Bippy errors propagate without redundant wrapping. React DevTools hook installation, React build, hook-inspection, and source-map failures use the other exported `BippyError` subclasses.
+instrumentation, React DevTools, and hook-listener failures propagate unchanged. callback dispatch stops at the failure so the caller controls error handling. failures created by bippy, such as unsupported hooks and source-map timeouts, use the exported `BippyError` subclasses.
 
 ### getRDTHook
 

--- a/packages/bippy/scripts/react-internals-plugin.ts
+++ b/packages/bippy/scripts/react-internals-plugin.ts
@@ -177,7 +177,9 @@ const validateReactWorkTagVersionRanges = (versionRanges: ReactWorkTagVersionRan
     } else {
       const minimumVersion = versionRange.minimumVersion;
       if (!minimumVersion) {
-        throw new Error(`React work-tag range ${versionRange.version} is missing its minimum`);
+        throw new Error(
+          `React work-tag range ${versionRange.version} is missing its minimum version`,
+        );
       }
       const previousRange = versionRanges[rangeIndex - 1];
       const previousMinimumVersion = previousRange?.minimumVersion;
@@ -203,7 +205,7 @@ const validateReactWorkTagVersionRanges = (versionRanges: ReactWorkTagVersionRan
         (nextBoundaryComparison === 0 && nextRange.isMinimumExcluded !== true)
       ) {
         throw new Error(
-          `React work-tag version ${versionRange.version} overlaps the following range`,
+          `React work-tag version ${versionRange.version} overlaps the range starting at React ${nextRange.minimumVersion}`,
         );
       }
     }
@@ -251,7 +253,7 @@ const validateWorkTags = (
     )
   ) {
     throw new Error(
-      `react-devtools-core added a work-tag range after React ${latestBaseline.version}; add its version boundary before regenerating React internals`,
+      `react-devtools-core added a work-tag range after React ${latestBaseline.version}. Add its version boundary before regenerating React internals.`,
     );
   }
   return workTagNames;
@@ -334,7 +336,7 @@ const renderGeneratedModule = (
   const firstBaseline = baselines[0];
   const latestBaseline = baselines[baselines.length - 1];
   if (!firstBaseline || !latestBaseline) {
-    throw new Error("Cannot render React internals without work-tag tables");
+    throw new Error("React internals generation requires work-tag tables");
   }
   const workTagRanges = baselines
     .filter((baseline) => baseline.minimumVersion !== undefined)
@@ -375,6 +377,7 @@ const renderGeneratedModule = (
     "export type ReactWorkTagVersion = keyof typeof reactWorkTagsByVersion;",
     "",
     "export interface GetReactWorkTags {",
+    "  (): Readonly<ReactWorkTagMap>;",
     "  <Version extends ReactWorkTagVersion>(",
     "    reactVersion: Version,",
     "  ): Readonly<(typeof reactWorkTagsByVersion)[Version]>;",
@@ -404,10 +407,13 @@ const renderGeneratedModule = (
     ...workTagRanges,
     "];",
     "",
-    "export const getReactWorkTags: GetReactWorkTags = (reactVersion: string) => {",
+    `const defaultReactWorkTags = reactWorkTagsByVersion[${JSON.stringify(latestBaseline.version)}];`,
+    "",
+    "export const getReactWorkTags: GetReactWorkTags = (reactVersion?: string) => {",
+    "  if (reactVersion === undefined) return defaultReactWorkTags;",
     "  for (const range of reactWorkTagRanges) {",
     "    const comparison = compareSemver(reactVersion, range.minimumVersion);",
-    `    if (comparison === null) return reactWorkTagsByVersion[${JSON.stringify(latestBaseline.version)}];`,
+    "    if (comparison === null) return defaultReactWorkTags;",
     "    if (comparison === 1 || (comparison === 0 && !range.isMinimumExcluded)) {",
     "      return range.workTags;",
     "    }",

--- a/packages/bippy/src/core.ts
+++ b/packages/bippy/src/core.ts
@@ -12,8 +12,6 @@ import type {
   ReactRenderer,
 } from "./react-internals/index.js";
 
-import { BippyInstrumentationError, BippyReactDevToolsError, runWithBippyError } from "./errors.js";
-
 import {
   _onActiveListeners,
   BIPPY_INSTRUMENTATION_STRING,
@@ -38,13 +36,9 @@ export { getReactWorkTags, ReactSymbols } from "./react-internals/index.js";
 export type { ReactWorkTagMap, ReactWorkTagVersion } from "./react-internals/index.js";
 export {
   BippyError,
-  BippyHookInstallationError,
   BippyHookInspectionError,
-  BippyHookListenerError,
   BippyHookRenderError,
-  BippyInstrumentationError,
   BippyReactBuildError,
-  BippyReactDevToolsError,
   BippySourceMapError,
   BippyUnsupportedHookError,
 } from "./errors.js";
@@ -1036,21 +1030,6 @@ interface InstrumentationSubscription {
 
 const instrumentationSubscriptions = new Set<InstrumentationSubscription>();
 
-const runInstrumentationCallback = (
-  instrumentationName: string,
-  callbackName: string,
-  callback: () => unknown,
-): void => {
-  runWithBippyError(
-    callback,
-    (cause) => new BippyInstrumentationError(instrumentationName, callbackName, cause),
-  );
-};
-
-const runReactDevToolsCallback = (callbackName: string, callback: () => unknown): void => {
-  runWithBippyError(callback, (cause) => new BippyReactDevToolsError(callbackName, cause));
-};
-
 interface HookDispatchers {
   onCommitFiberRoot: ReactDevToolsGlobalHook["onCommitFiberRoot"];
   onCommitFiberUnmount: ReactDevToolsGlobalHook["onCommitFiberUnmount"];
@@ -1084,9 +1063,7 @@ const setHookEventDispatchers = (rdtHook: ReactDevToolsGlobalHook): void => {
       didError,
     ) => {
       if (prevOnCommitFiberRoot) {
-        runReactDevToolsCallback("onCommitFiberRoot", () =>
-          prevOnCommitFiberRoot.call(rdtHook, rendererID, root, priority, didError),
-        );
+        prevOnCommitFiberRoot.call(rdtHook, rendererID, root, priority, didError);
       }
       if (hookDispatchers.get(rdtHook)?.onCommitFiberRoot !== dispatchCommitFiberRoot) return;
       setReactWorkTagsForFiber(root.current, rdtHook.renderers.get(rendererID));
@@ -1104,11 +1081,7 @@ const setHookEventDispatchers = (rdtHook: ReactDevToolsGlobalHook): void => {
       }
       for (const { options } of instrumentationSubscriptions) {
         if (options.onCommitFiberRoot) {
-          runInstrumentationCallback(
-            options.name ?? BIPPY_INSTRUMENTATION_STRING,
-            "onCommitFiberRoot",
-            () => options.onCommitFiberRoot?.(rendererID, root, priority, didError),
-          );
+          options.onCommitFiberRoot(rendererID, root, priority, didError);
         }
       }
     };
@@ -1127,20 +1100,14 @@ const setHookEventDispatchers = (rdtHook: ReactDevToolsGlobalHook): void => {
     ) => {
       setReactWorkTagsForFiber(fiber, rdtHook.renderers.get(rendererID));
       if (prevOnCommitFiberUnmount) {
-        runReactDevToolsCallback("onCommitFiberUnmount", () =>
-          prevOnCommitFiberUnmount.call(rdtHook, rendererID, fiber),
-        );
+        prevOnCommitFiberUnmount.call(rdtHook, rendererID, fiber);
       }
       if (hookDispatchers.get(rdtHook)?.onCommitFiberUnmount !== dispatchCommitFiberUnmount) {
         return;
       }
       for (const { options } of instrumentationSubscriptions) {
         if (options.onCommitFiberUnmount) {
-          runInstrumentationCallback(
-            options.name ?? BIPPY_INSTRUMENTATION_STRING,
-            "onCommitFiberUnmount",
-            () => options.onCommitFiberUnmount?.(rendererID, fiber),
-          );
+          options.onCommitFiberUnmount(rendererID, fiber);
         }
       }
     };
@@ -1158,20 +1125,14 @@ const setHookEventDispatchers = (rdtHook: ReactDevToolsGlobalHook): void => {
       root,
     ) => {
       if (prevOnPostCommitFiberRoot) {
-        runReactDevToolsCallback("onPostCommitFiberRoot", () =>
-          prevOnPostCommitFiberRoot.call(rdtHook, rendererID, root),
-        );
+        prevOnPostCommitFiberRoot.call(rdtHook, rendererID, root);
       }
       if (hookDispatchers.get(rdtHook)?.onPostCommitFiberRoot !== dispatchPostCommitFiberRoot) {
         return;
       }
       for (const { options } of instrumentationSubscriptions) {
         if (options.onPostCommitFiberRoot) {
-          runInstrumentationCallback(
-            options.name ?? BIPPY_INSTRUMENTATION_STRING,
-            "onPostCommitFiberRoot",
-            () => options.onPostCommitFiberRoot?.(rendererID, root),
-          );
+          options.onPostCommitFiberRoot(rendererID, root);
         }
       }
     };
@@ -1190,18 +1151,12 @@ const setHookEventDispatchers = (rdtHook: ReactDevToolsGlobalHook): void => {
       children,
     ) => {
       if (prevOnScheduleFiberRoot) {
-        runReactDevToolsCallback("onScheduleFiberRoot", () =>
-          prevOnScheduleFiberRoot.call(rdtHook, rendererID, root, children),
-        );
+        prevOnScheduleFiberRoot.call(rdtHook, rendererID, root, children);
       }
       if (hookDispatchers.get(rdtHook)?.onScheduleFiberRoot !== dispatchScheduleFiberRoot) return;
       for (const { options } of instrumentationSubscriptions) {
         if (options.onScheduleFiberRoot) {
-          runInstrumentationCallback(
-            options.name ?? BIPPY_INSTRUMENTATION_STRING,
-            "onScheduleFiberRoot",
-            () => options.onScheduleFiberRoot?.(rendererID, root, children),
-          );
+          options.onScheduleFiberRoot(rendererID, root, children);
         }
       }
     };
@@ -1228,16 +1183,7 @@ const setHookEventDispatchers = (rdtHook: ReactDevToolsGlobalHook): void => {
  * unsubscribe();
  */
 export const instrument = (options: InstrumentationOptions): Unsubscribe => {
-  const onActiveListener = options.onActive;
-  const onActive = onActiveListener
-    ? () =>
-        runInstrumentationCallback(
-          options.name ?? BIPPY_INSTRUMENTATION_STRING,
-          "onActive",
-          onActiveListener,
-        )
-    : undefined;
-  const rdtHook = getRDTHook(onActive);
+  const rdtHook = getRDTHook(options.onActive);
 
   if (!didSubscribeToHookReplacements) {
     onRDTHookReplace(setHookEventDispatchers);
@@ -1251,7 +1197,7 @@ export const instrument = (options: InstrumentationOptions): Unsubscribe => {
   instrumentationSubscriptions.add(subscription);
 
   return createUnsubscribe(() => {
-    if (onActive) _onActiveListeners.delete(onActive);
+    if (options.onActive) _onActiveListeners.delete(options.onActive);
     instrumentationSubscriptions.delete(subscription);
   });
 };
@@ -1355,7 +1301,6 @@ export {
   isRealReactDevtools,
   onRendererInject,
   patchRDTHook,
-  safelyInstallRDTHook,
   version,
 } from "./rdt-hook.js";
 export type { Unsubscribe } from "./rdt-hook.js";

--- a/packages/bippy/src/core.ts
+++ b/packages/bippy/src/core.ts
@@ -38,7 +38,6 @@ export {
   BippyError,
   BippyHookInspectionError,
   BippyHookRenderError,
-  BippyReactBuildError,
   BippySourceMapError,
   BippyUnsupportedHookError,
 } from "./errors.js";

--- a/packages/bippy/src/core.ts
+++ b/packages/bippy/src/core.ts
@@ -49,9 +49,6 @@ export {
   BippyUnsupportedHookError,
 } from "./errors.js";
 
-const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
-
 const isComponentType = (value: unknown): value is React.ComponentType<unknown> =>
   typeof value === "function";
 
@@ -119,7 +116,10 @@ export const isValidFiber = (fiber: unknown): fiber is Fiber =>
   "flags" in fiber;
 
 const isFiberRoot = (fiberRoot: unknown): fiberRoot is FiberRoot =>
-  isObjectRecord(fiberRoot) && isValidFiber(fiberRoot.current);
+  typeof fiberRoot === "object" &&
+  fiberRoot !== null &&
+  "current" in fiberRoot &&
+  isValidFiber(fiberRoot.current);
 
 /**
  * Returns `true` if fiber is a host fiber. Host fibers are DOM nodes in react-dom, `View` in react-native, etc.
@@ -530,8 +530,8 @@ export const hasMemoCache = (fiber: Fiber): boolean => {
  */
 export const getType = (type: unknown): null | React.ComponentType<unknown> => {
   if (isComponentType(type)) return type;
-  if (!isObjectRecord(type)) return null;
-  return getType(type.type ?? type.render);
+  if (typeof type !== "object" || type === null) return null;
+  return getType(Reflect.get(type, "type") ?? Reflect.get(type, "render"));
 };
 
 /**
@@ -1264,30 +1264,35 @@ const isFiberPropertyKey = (key: string): boolean =>
   key.startsWith("__reactInternalInstance$") ||
   key.startsWith("__reactFiber");
 
-const getLegacyRootFiber = (hostInstance: Record<string, unknown>): Fiber | null => {
-  const reactRootContainer = hostInstance._reactRootContainer;
-  if (!isObjectRecord(reactRootContainer)) return null;
-  const internalRoot = reactRootContainer._internalRoot;
-  if (!isObjectRecord(internalRoot)) return null;
-  const current = internalRoot.current;
-  if (!isObjectRecord(current)) return null;
-  const child = current.child;
+const getLegacyRootFiber = (hostInstance: object): Fiber | null => {
+  const reactRootContainer = Reflect.get(hostInstance, "_reactRootContainer");
+  if (typeof reactRootContainer !== "object" || reactRootContainer === null) return null;
+  const internalRoot = Reflect.get(reactRootContainer, "_internalRoot");
+  if (typeof internalRoot !== "object" || internalRoot === null) return null;
+  const current = Reflect.get(internalRoot, "current");
+  if (typeof current !== "object" || current === null) return null;
+  const child = Reflect.get(current, "child");
   return isValidFiber(child) ? child : null;
 };
 
-const getInternalInstanceHandle = (hostInstance: Record<string, unknown>): Fiber | null => {
+const getInternalInstanceHandle = (hostInstance: object): Fiber | null => {
   const internalInstanceHandle =
-    hostInstance.__internalInstanceHandle ?? hostInstance._internalInstanceHandle;
+    Reflect.get(hostInstance, "__internalInstanceHandle") ??
+    Reflect.get(hostInstance, "_internalInstanceHandle");
   return isValidFiber(internalInstanceHandle) ? internalInstanceHandle : null;
 };
 
 const getPublicHostInstance = (stateNode: unknown): unknown => {
-  if (!isObjectRecord(stateNode)) return stateNode;
-  const canonical = stateNode.canonical;
-  if (isObjectRecord(canonical) && isObjectRecord(canonical.publicInstance)) {
-    return canonical.publicInstance;
+  if (typeof stateNode !== "object" || stateNode === null) return stateNode;
+  const canonical = Reflect.get(stateNode, "canonical");
+  if (typeof canonical === "object" && canonical !== null) {
+    const publicInstance = Reflect.get(canonical, "publicInstance");
+    if (typeof publicInstance === "object" && publicInstance !== null) {
+      return publicInstance;
+    }
   }
-  return typeof stateNode._nativeTag === "number" ? stateNode._nativeTag : stateNode;
+  const nativeTag = Reflect.get(stateNode, "_nativeTag");
+  return typeof nativeTag === "number" ? nativeTag : stateNode;
 };
 
 export const getFiberFromHostInstance = <T>(hostInstance: T): Fiber | null => {
@@ -1301,7 +1306,7 @@ export const getFiberFromHostInstance = <T>(hostInstance: T): Fiber | null => {
     }
   }
 
-  if (isObjectRecord(hostInstance)) {
+  if (typeof hostInstance === "object" && hostInstance !== null) {
     const legacyRootFiber = getLegacyRootFiber(hostInstance);
     if (legacyRootFiber) return legacyRootFiber;
 
@@ -1309,14 +1314,14 @@ export const getFiberFromHostInstance = <T>(hostInstance: T): Fiber | null => {
     if (internalInstanceHandle) return internalInstanceHandle;
 
     for (const knownKey of knownFiberPropertyKeys) {
-      const fiber = hostInstance[knownKey];
+      const fiber = Reflect.get(hostInstance, knownKey);
       if (isValidFiber(fiber)) return fiber;
     }
 
     for (const key of Object.keys(hostInstance)) {
       if (isFiberPropertyKey(key)) {
         knownFiberPropertyKeys.add(key);
-        const fiber = hostInstance[key];
+        const fiber = Reflect.get(hostInstance, key);
         if (isValidFiber(fiber)) return fiber;
       }
     }

--- a/packages/bippy/src/errors.ts
+++ b/packages/bippy/src/errors.ts
@@ -5,48 +5,6 @@ export class BippyError extends Error {
   }
 }
 
-export class BippyInstrumentationError extends BippyError {
-  readonly callbackName: string;
-  readonly instrumentationName: string;
-
-  constructor(instrumentationName: string, callbackName: string, cause: unknown) {
-    super(
-      `Bippy instrumentation “${instrumentationName}” callback “${callbackName}” failed`,
-      cause,
-    );
-    this.name = "BippyInstrumentationError";
-    this.callbackName = callbackName;
-    this.instrumentationName = instrumentationName;
-  }
-}
-
-export class BippyReactDevToolsError extends BippyError {
-  readonly callbackName: string;
-
-  constructor(callbackName: string, cause: unknown) {
-    super(`React DevTools callback “${callbackName}” failed`, cause);
-    this.name = "BippyReactDevToolsError";
-    this.callbackName = callbackName;
-  }
-}
-
-export class BippyHookListenerError extends BippyError {
-  readonly listenerName: string;
-
-  constructor(listenerName: string, cause: unknown) {
-    super(`Bippy hook listener “${listenerName}” failed`, cause);
-    this.name = "BippyHookListenerError";
-    this.listenerName = listenerName;
-  }
-}
-
-export class BippyHookInstallationError extends BippyError {
-  constructor(cause: unknown) {
-    super("Bippy couldn’t install the React DevTools hook", cause);
-    this.name = "BippyHookInstallationError";
-  }
-}
-
 export class BippyReactBuildError extends BippyError {
   constructor(message: string, cause?: unknown) {
     super(message, cause);
@@ -81,19 +39,3 @@ export class BippySourceMapError extends BippyError {
     this.name = "BippySourceMapError";
   }
 }
-
-interface BippyErrorFactory {
-  (cause: unknown): BippyError;
-}
-
-export const runWithBippyError = <Result>(
-  callback: () => Result,
-  createError: BippyErrorFactory,
-): Result => {
-  try {
-    return callback();
-  } catch (cause) {
-    if (cause instanceof BippyError) throw cause;
-    throw createError(cause);
-  }
-};

--- a/packages/bippy/src/errors.ts
+++ b/packages/bippy/src/errors.ts
@@ -11,7 +11,7 @@ export class BippyInstrumentationError extends BippyError {
 
   constructor(instrumentationName: string, callbackName: string, cause: unknown) {
     super(
-      `Bippy instrumentation "${instrumentationName}" callback "${callbackName}" failed`,
+      `Bippy instrumentation “${instrumentationName}” callback “${callbackName}” failed`,
       cause,
     );
     this.name = "BippyInstrumentationError";
@@ -24,7 +24,7 @@ export class BippyReactDevToolsError extends BippyError {
   readonly callbackName: string;
 
   constructor(callbackName: string, cause: unknown) {
-    super(`React DevTools callback "${callbackName}" failed`, cause);
+    super(`React DevTools callback “${callbackName}” failed`, cause);
     this.name = "BippyReactDevToolsError";
     this.callbackName = callbackName;
   }
@@ -34,7 +34,7 @@ export class BippyHookListenerError extends BippyError {
   readonly listenerName: string;
 
   constructor(listenerName: string, cause: unknown) {
-    super(`Bippy hook listener "${listenerName}" failed`, cause);
+    super(`Bippy hook listener “${listenerName}” failed`, cause);
     this.name = "BippyHookListenerError";
     this.listenerName = listenerName;
   }
@@ -42,7 +42,7 @@ export class BippyHookListenerError extends BippyError {
 
 export class BippyHookInstallationError extends BippyError {
   constructor(cause: unknown) {
-    super("Bippy could not install the React DevTools hook", cause);
+    super("Bippy couldn’t install the React DevTools hook", cause);
     this.name = "BippyHookInstallationError";
   }
 }

--- a/packages/bippy/src/errors.ts
+++ b/packages/bippy/src/errors.ts
@@ -5,13 +5,6 @@ export class BippyError extends Error {
   }
 }
 
-export class BippyReactBuildError extends BippyError {
-  constructor(message: string, cause?: unknown) {
-    super(message, cause);
-    this.name = "BippyReactBuildError";
-  }
-}
-
 export class BippyHookInspectionError extends BippyError {
   constructor(message: string, cause?: unknown) {
     super(message, cause);

--- a/packages/bippy/src/install-hook-only.ts
+++ b/packages/bippy/src/install-hook-only.ts
@@ -1,3 +1,3 @@
-import { safelyInstallRDTHook } from "./rdt-hook.js";
+import { getRDTHook } from "./rdt-hook.js";
 
-safelyInstallRDTHook();
+getRDTHook();

--- a/packages/bippy/src/rdt-hook.ts
+++ b/packages/bippy/src/rdt-hook.ts
@@ -1,6 +1,5 @@
 // This module must load before React so renderers can inject into the hook.
 
-import { BippyReactBuildError } from "./errors.js";
 import type { ReactDevToolsGlobalHook, ReactRenderer } from "./react-internals/index.js";
 
 export interface Unsubscribe extends Disposable {
@@ -32,13 +31,13 @@ export const createUnsubscribe = (unsubscribe: () => void): Unsubscribe =>
 const checkDCE = (functionToCheck: unknown): void => {
   try {
     const code = Function.prototype.toString.call(functionToCheck);
-    if (code.includes("^_^")) {
-      // HACK: React DevTools reports failed dead-code elimination asynchronously.
+    if (code.indexOf("^_^") > -1) {
       setTimeout(() => {
-        throw new BippyReactBuildError(
-          "React is running in production mode without dead-code elimination. " +
-            "Configure a production build: " +
-            "https://reactjs.org/link/perf-use-production-build",
+        throw new Error(
+          "React is running in production mode, but dead code " +
+            "elimination has not been applied. Read how to correctly " +
+            "configure React for production: " +
+            "https://react.dev/link/perf-use-production-build",
         );
       });
     }

--- a/packages/bippy/src/rdt-hook.ts
+++ b/packages/bippy/src/rdt-hook.ts
@@ -45,9 +45,8 @@ const checkDCE = (functionToCheck: unknown): void => {
       // HACK: React DevTools reports failed dead-code elimination asynchronously.
       setTimeout(() => {
         throw new BippyReactBuildError(
-          "React is running in production mode, but dead code " +
-            "elimination has not been applied. Read how to correctly " +
-            "configure React for production: " +
+          "React is running in production mode without dead-code elimination. " +
+            "Configure a production build: " +
             "https://reactjs.org/link/perf-use-production-build",
         );
       });

--- a/packages/bippy/src/rdt-hook.ts
+++ b/packages/bippy/src/rdt-hook.ts
@@ -1,11 +1,6 @@
 // This module must load before React so renderers can inject into the hook.
 
-import {
-  BippyHookInstallationError,
-  BippyHookListenerError,
-  BippyReactBuildError,
-  runWithBippyError,
-} from "./errors.js";
+import { BippyReactBuildError } from "./errors.js";
 import type { ReactDevToolsGlobalHook, ReactRenderer } from "./react-internals/index.js";
 
 export interface Unsubscribe extends Disposable {
@@ -33,10 +28,6 @@ const noOp = (): void => {};
 
 export const createUnsubscribe = (unsubscribe: () => void): Unsubscribe =>
   Object.assign(unsubscribe, { [Symbol.dispose]: unsubscribe });
-
-const runHookListener = (listenerName: string, callback: () => unknown): void => {
-  runWithBippyError(callback, (cause) => new BippyHookListenerError(listenerName, cause));
-};
 
 const checkDCE = (functionToCheck: unknown): void => {
   try {
@@ -75,19 +66,19 @@ const notifyingInjectByHook = new WeakMap<
 
 const notifyActiveListeners = (): void => {
   for (const listener of _onActiveListeners) {
-    runHookListener("onActive", listener);
+    listener();
   }
 };
 
 const notifyRendererInjectListeners = (renderer: ReactRenderer): void => {
   for (const listener of rendererInjectListeners) {
-    runHookListener("onRendererInject", () => listener(renderer));
+    listener(renderer);
   }
 };
 
 const notifyRDTHookReplaceListeners = (rdtHook: ReactDevToolsGlobalHook): void => {
   for (const listener of rdtHookReplaceListeners) {
-    runHookListener("onRDTHookReplace", () => listener(rdtHook));
+    listener(rdtHook);
   }
 };
 
@@ -256,7 +247,7 @@ export const patchRDTHook = (onActive?: ActiveListener): void => {
     };
   }
   if (!didNotifyActiveListeners && (renderers.size || rdtHook._instrumentationIsActive)) {
-    if (onActive) runHookListener("onActive", onActive);
+    onActive?.();
   }
 };
 
@@ -274,8 +265,4 @@ export const getRDTHook = (onActive?: ActiveListener): ReactDevToolsGlobalHook =
 
   patchRDTHook(onActive);
   return globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__ ?? installRDTHook(onActive);
-};
-
-export const safelyInstallRDTHook = (): void => {
-  runWithBippyError(getRDTHook, (cause) => new BippyHookInstallationError(cause));
 };

--- a/packages/bippy/src/react-internals/generated/react-work-tags.ts
+++ b/packages/bippy/src/react-internals/generated/react-work-tags.ts
@@ -254,6 +254,7 @@ const reactWorkTagsByVersion = defineReactWorkTags({
 export type ReactWorkTagVersion = keyof typeof reactWorkTagsByVersion;
 
 export interface GetReactWorkTags {
+  (): Readonly<ReactWorkTagMap>;
   <Version extends ReactWorkTagVersion>(
     reactVersion: Version,
   ): Readonly<(typeof reactWorkTagsByVersion)[Version]>;
@@ -302,10 +303,13 @@ const reactWorkTagRanges: ReactWorkTagRange[] = [
   },
 ];
 
-export const getReactWorkTags: GetReactWorkTags = (reactVersion: string) => {
+const defaultReactWorkTags = reactWorkTagsByVersion["17.0.2"];
+
+export const getReactWorkTags: GetReactWorkTags = (reactVersion?: string) => {
+  if (reactVersion === undefined) return defaultReactWorkTags;
   for (const range of reactWorkTagRanges) {
     const comparison = compareSemver(reactVersion, range.minimumVersion);
-    if (comparison === null) return reactWorkTagsByVersion["17.0.2"];
+    if (comparison === null) return defaultReactWorkTags;
     if (comparison === 1 || (comparison === 0 && !range.isMinimumExcluded)) {
       return range.workTags;
     }

--- a/packages/bippy/src/react-internals/index.ts
+++ b/packages/bippy/src/react-internals/index.ts
@@ -18,7 +18,7 @@ export type {
 } from "./generated/react-work-tags.js";
 export * from "./types.js";
 
-const defaultReactWorkTags = getReactWorkTags("");
+const defaultReactWorkTags = getReactWorkTags();
 const fiberReactWorkTags = new WeakMap<Fiber, Readonly<ReactWorkTagMap>>();
 
 export const getReactWorkTagsForRenderer = (
@@ -28,7 +28,7 @@ export const getReactWorkTagsForRenderer = (
   if (reconcilerVersion && compareSemver(reconcilerVersion, reconcilerVersion) === 0) {
     return getReactWorkTags(reconcilerVersion);
   }
-  return getReactWorkTags(renderer?.version ?? "");
+  return renderer?.version ? getReactWorkTags(renderer.version) : defaultReactWorkTags;
 };
 
 export const setReactWorkTagsForFiber = (fiber: Fiber, renderer?: ReactRenderer): void => {

--- a/packages/bippy/src/source/inspect-hooks.ts
+++ b/packages/bippy/src/source/inspect-hooks.ts
@@ -89,23 +89,26 @@ const nextHook = (): MemoizedState | null => {
   return hook;
 };
 
-const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
-
 const isInspectableThenable = (value: unknown): value is InspectableThenable =>
-  isObjectRecord(value) && typeof value.then === "function";
+  typeof value === "object" &&
+  value !== null &&
+  "then" in value &&
+  typeof value.then === "function";
 
 const isInspectableRef = (value: unknown): value is InspectableRef =>
-  isObjectRecord(value) && "current" in value;
+  typeof value === "object" && value !== null && "current" in value;
 
 const isReactContext = (value: unknown): value is ReactContext<unknown> =>
-  isObjectRecord(value) && "_currentValue" in value;
+  typeof value === "object" && value !== null && "_currentValue" in value;
 
 const isContextDependency = (value: unknown): value is ContextDependency<unknown> =>
-  isObjectRecord(value) && "context" in value && "next" in value;
+  typeof value === "object" && value !== null && "context" in value && "next" in value;
 
 const isForwardRefRenderType = (value: unknown): value is ForwardRefRenderType =>
-  isObjectRecord(value) && typeof value.render === "function";
+  typeof value === "object" &&
+  value !== null &&
+  "render" in value &&
+  typeof value.render === "function";
 
 const readContext = (context: InspectableReactContext): unknown => {
   if (currentFiber === null) return context._currentValue;
@@ -157,7 +160,7 @@ const pushHookLogEntry = (
 };
 
 const dispatcherUse = (usable: unknown): unknown => {
-  if (isObjectRecord(usable)) {
+  if (typeof usable === "object" && usable !== null) {
     if (isInspectableThenable(usable)) {
       const cachedThenable =
         currentThenableState !== null && currentThenableIndex < currentThenableState.length
@@ -176,7 +179,7 @@ const dispatcherUse = (usable: unknown): unknown => {
       pushHookLogEntry("Unresolved", thenable, "Use");
       throw SuspenseException;
     }
-    if (usable.$$typeof === REACT_CONTEXT_TYPE && "_currentValue" in usable) {
+    if ("$$typeof" in usable && usable.$$typeof === REACT_CONTEXT_TYPE && isReactContext(usable)) {
       const context: InspectableReactContext = {
         _currentValue: usable._currentValue,
         displayName: typeof usable.displayName === "string" ? usable.displayName : undefined,
@@ -720,7 +723,10 @@ const setupContexts = (contextMap: Map<ReactContext<unknown>, unknown>, fiber: F
   while (current) {
     if (current.tag === getReactWorkTagsForFiber(current).ContextProvider) {
       const providerType = current.type;
-      const nestedContext = isObjectRecord(providerType) ? providerType._context : undefined;
+      const nestedContext =
+        typeof providerType === "object" && providerType !== null && "_context" in providerType
+          ? providerType._context
+          : undefined;
       const context = isReactContext(nestedContext)
         ? nestedContext
         : isReactContext(providerType)
@@ -755,13 +761,14 @@ const resolveDefaultProps = (
     component &&
     typeof component === "object" &&
     "defaultProps" in component &&
-    isObjectRecord(component.defaultProps)
+    typeof component.defaultProps === "object" &&
+    component.defaultProps !== null
   ) {
     const props = { ...baseProps };
     const defaultProps = component.defaultProps;
-    for (const propName in defaultProps) {
+    for (const [propName, value] of Object.entries(defaultProps)) {
       if (props[propName] === undefined) {
-        props[propName] = defaultProps[propName];
+        props[propName] = value;
       }
     }
     return props;
@@ -829,15 +836,26 @@ const resolveContextDependency = (fiber: Fiber): void => {
     currentContextDependency = dependencies !== null ? dependencies.firstContext : null;
   } else if (Object.hasOwn(fiber, "dependencies_old")) {
     const dependencies: unknown = Reflect.get(fiber, "dependencies_old");
-    const firstContext = isObjectRecord(dependencies) ? dependencies.firstContext : null;
+    const firstContext =
+      typeof dependencies === "object" && dependencies !== null && "firstContext" in dependencies
+        ? dependencies.firstContext
+        : null;
     currentContextDependency = isContextDependency(firstContext) ? firstContext : null;
   } else if (Object.hasOwn(fiber, "dependencies_new")) {
     const dependencies: unknown = Reflect.get(fiber, "dependencies_new");
-    const firstContext = isObjectRecord(dependencies) ? dependencies.firstContext : null;
+    const firstContext =
+      typeof dependencies === "object" && dependencies !== null && "firstContext" in dependencies
+        ? dependencies.firstContext
+        : null;
     currentContextDependency = isContextDependency(firstContext) ? firstContext : null;
   } else if (Object.hasOwn(fiber, "contextDependencies")) {
     const contextDependencies: unknown = Reflect.get(fiber, "contextDependencies");
-    const firstContext = isObjectRecord(contextDependencies) ? contextDependencies.first : null;
+    const firstContext =
+      typeof contextDependencies === "object" &&
+      contextDependencies !== null &&
+      "first" in contextDependencies
+        ? contextDependencies.first
+        : null;
     currentContextDependency = isContextDependency(firstContext) ? firstContext : null;
   } else {
     throw new BippyHookInspectionError("Bippy doesn’t support this React version.");

--- a/packages/bippy/src/source/inspect-hooks.ts
+++ b/packages/bippy/src/source/inspect-hooks.ts
@@ -77,7 +77,7 @@ let currentThenableIndex = 0;
 let currentThenableState: unknown[] | null = null;
 
 const SuspenseException: unknown = new Error(
-  "Suspense Exception: This is not a real error! It's an implementation detail of `use` to interrupt the current render.",
+  "Suspense interrupted this render. This error is an internal implementation detail of `use`.",
 );
 
 const parseErrorStack = (error: Error): StackFrame[] =>
@@ -110,7 +110,7 @@ const isForwardRefRenderType = (value: unknown): value is ForwardRefRenderType =
 const readContext = (context: InspectableReactContext): unknown => {
   if (currentFiber === null) return context._currentValue;
   if (currentContextDependency === null) {
-    throw new BippyHookInspectionError("Context reads do not line up with context dependencies.");
+    throw new BippyHookInspectionError("Context reads don’t match context dependencies.");
   }
   if (Object.hasOwn(currentContextDependency, "memoizedValue")) {
     const value = currentContextDependency.memoizedValue;
@@ -186,7 +186,7 @@ const dispatcherUse = (usable: unknown): unknown => {
       return value;
     }
   }
-  throw new BippyHookInspectionError("An unsupported type was passed to use(): " + String(usable));
+  throw new BippyHookInspectionError("use() received an unsupported value: " + String(usable));
 };
 
 const dispatcherUseContext = (context: InspectableReactContext): unknown => {
@@ -442,7 +442,9 @@ const dispatcherProxy =
     : new Proxy(dispatcher, {
         get(target, propertyName: string) {
           if (Object.hasOwn(target, propertyName)) return Reflect.get(target, propertyName);
-          throw new BippyUnsupportedHookError("Missing method in Dispatcher: " + propertyName);
+          throw new BippyUnsupportedHookError(
+            "The React dispatcher is missing method " + propertyName,
+          );
         },
       });
 
@@ -742,7 +744,7 @@ const restoreContexts = (contextMap: Map<ReactContext<unknown>, unknown>): void 
 const handleRenderFunctionError = (error: unknown): void => {
   if (error === SuspenseException) return;
   if (error instanceof BippyUnsupportedHookError) throw error;
-  throw new BippyHookRenderError("Error rendering inspected component", error);
+  throw new BippyHookRenderError("Bippy couldn’t render the inspected component", error);
 };
 
 const resolveDefaultProps = (
@@ -815,7 +817,7 @@ const requireDispatcherRef = (): RendererDispatcherRef => {
   const dispatcherRef = getDispatcherRef();
   if (!dispatcherRef) {
     throw new BippyHookInspectionError(
-      "No React renderer found. Make sure React is loaded and bippy's hook is installed.",
+      "Bippy couldn’t find a React renderer. Load React and install Bippy’s hook.",
     );
   }
   return dispatcherRef;
@@ -838,7 +840,7 @@ const resolveContextDependency = (fiber: Fiber): void => {
     const firstContext = isObjectRecord(contextDependencies) ? contextDependencies.first : null;
     currentContextDependency = isContextDependency(firstContext) ? firstContext : null;
   } else {
-    throw new BippyHookInspectionError("Unsupported React version.");
+    throw new BippyHookInspectionError("Bippy doesn’t support this React version.");
   }
 };
 
@@ -851,9 +853,7 @@ export const getFiberHooks = (fiber: Fiber): HooksTree => {
     fiber.tag !== workTags.SimpleMemoComponent &&
     fiber.tag !== workTags.ForwardRef
   ) {
-    throw new BippyHookInspectionError(
-      "Unknown Fiber. Needs to be a function component to inspect hooks.",
-    );
+    throw new BippyHookInspectionError("Hook inspection requires a function component Fiber.");
   }
 
   getPrimitiveStackCache();

--- a/packages/bippy/src/source/owner-stack.ts
+++ b/packages/bippy/src/source/owner-stack.ts
@@ -411,7 +411,7 @@ export const getFallbackParentStack = (thisFiber: Fiber): string => {
     return componentStack;
   } catch (error) {
     if (error instanceof Error) {
-      return `\nError generating stack: ${error.message}\n${error.stack}`;
+      return `\nBippy couldn’t generate the stack: ${error.message}\n${error.stack}`;
     }
     return "";
   }

--- a/packages/bippy/src/source/symbolication.ts
+++ b/packages/bippy/src/source/symbolication.ts
@@ -223,16 +223,6 @@ const getSourceMapUrl = (url: string, content: string): null | string => {
   return resolveUrl(sourceMapUrl, url);
 };
 
-const isStringArray = (value: unknown): value is string[] =>
-  Array.isArray(value) && value.every((entry) => typeof entry === "string");
-
-const isSourcesContent = (value: unknown): value is Array<string | null> =>
-  Array.isArray(value) && value.every((entry) => typeof entry === "string" || entry === null);
-
-const isOptionalNumberArray = (value: unknown): value is number[] | undefined =>
-  value === undefined ||
-  (Array.isArray(value) && value.every((entry) => Number.isInteger(entry) && entry >= 0));
-
 const isStandardSourceMap = (value: unknown): value is StandardSourceMap => {
   if (typeof value !== "object" || value === null) return false;
   const version = Reflect.get(value, "version");
@@ -248,15 +238,22 @@ const isStandardSourceMap = (value: unknown): value is StandardSourceMap => {
     version !== 3 ||
     typeof mappings !== "string" ||
     (file !== undefined && typeof file !== "string") ||
-    (names !== undefined && !isStringArray(names)) ||
+    (names !== undefined &&
+      (!Array.isArray(names) || names.some((entry) => typeof entry !== "string"))) ||
     (sourceRoot !== undefined && typeof sourceRoot !== "string") ||
-    (sourcesContent !== undefined && !isSourcesContent(sourcesContent)) ||
-    !isOptionalNumberArray(ignoreList) ||
-    !isOptionalNumberArray(googleIgnoreList)
+    (sourcesContent !== undefined &&
+      (!Array.isArray(sourcesContent) ||
+        sourcesContent.some((entry) => typeof entry !== "string" && entry !== null))) ||
+    (ignoreList !== undefined &&
+      (!Array.isArray(ignoreList) ||
+        ignoreList.some((entry) => !Number.isInteger(entry) || entry < 0))) ||
+    (googleIgnoreList !== undefined &&
+      (!Array.isArray(googleIgnoreList) ||
+        googleIgnoreList.some((entry) => !Number.isInteger(entry) || entry < 0)))
   ) {
     return false;
   }
-  if (!isStringArray(sources)) return false;
+  if (!Array.isArray(sources) || sources.some((entry) => typeof entry !== "string")) return false;
   if (sourcesContent && sourcesContent.length !== sources.length) return false;
   const sourceCount = sources.length;
   return [...(ignoreList ?? []), ...(googleIgnoreList ?? [])].every(

--- a/packages/bippy/src/source/symbolication.ts
+++ b/packages/bippy/src/source/symbolication.ts
@@ -223,9 +223,6 @@ const getSourceMapUrl = (url: string, content: string): null | string => {
   return resolveUrl(sourceMapUrl, url);
 };
 
-const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
-
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((entry) => typeof entry === "string");
 
@@ -237,43 +234,61 @@ const isOptionalNumberArray = (value: unknown): value is number[] | undefined =>
   (Array.isArray(value) && value.every((entry) => Number.isInteger(entry) && entry >= 0));
 
 const isStandardSourceMap = (value: unknown): value is StandardSourceMap => {
-  if (!isObjectRecord(value)) return false;
+  if (typeof value !== "object" || value === null) return false;
+  const version = Reflect.get(value, "version");
+  const mappings = Reflect.get(value, "mappings");
+  const file = Reflect.get(value, "file");
+  const names = Reflect.get(value, "names");
+  const sourceRoot = Reflect.get(value, "sourceRoot");
+  const sources = Reflect.get(value, "sources");
+  const sourcesContent = Reflect.get(value, "sourcesContent");
+  const ignoreList = Reflect.get(value, "ignoreList");
+  const googleIgnoreList = Reflect.get(value, "x_google_ignoreList");
   if (
-    value.version !== 3 ||
-    typeof value.mappings !== "string" ||
-    (value.file !== undefined && typeof value.file !== "string") ||
-    (value.names !== undefined && !isStringArray(value.names)) ||
-    (value.sourceRoot !== undefined && typeof value.sourceRoot !== "string") ||
-    (value.sourcesContent !== undefined && !isSourcesContent(value.sourcesContent)) ||
-    !isOptionalNumberArray(value.ignoreList) ||
-    !isOptionalNumberArray(value.x_google_ignoreList)
+    version !== 3 ||
+    typeof mappings !== "string" ||
+    (file !== undefined && typeof file !== "string") ||
+    (names !== undefined && !isStringArray(names)) ||
+    (sourceRoot !== undefined && typeof sourceRoot !== "string") ||
+    (sourcesContent !== undefined && !isSourcesContent(sourcesContent)) ||
+    !isOptionalNumberArray(ignoreList) ||
+    !isOptionalNumberArray(googleIgnoreList)
   ) {
     return false;
   }
-  if (!isStringArray(value.sources)) return false;
-  if (value.sourcesContent && value.sourcesContent.length !== value.sources.length) return false;
-  const sourceCount = value.sources.length;
-  return [...(value.ignoreList ?? []), ...(value.x_google_ignoreList ?? [])].every(
+  if (!isStringArray(sources)) return false;
+  if (sourcesContent && sourcesContent.length !== sources.length) return false;
+  const sourceCount = sources.length;
+  return [...(ignoreList ?? []), ...(googleIgnoreList ?? [])].every(
     (sourceIndex) => sourceIndex < sourceCount,
   );
 };
 
 const isIndexSourceMap = (value: unknown): value is IndexSourceMap => {
-  if (!isObjectRecord(value) || value.version !== 3 || !Array.isArray(value.sections)) {
+  if (typeof value !== "object" || value === null) return false;
+  const version = Reflect.get(value, "version");
+  const sections = Reflect.get(value, "sections");
+  if (version !== 3 || !Array.isArray(sections)) {
     return false;
   }
-  return value.sections.every((section) => {
-    if (!isObjectRecord(section) || !isObjectRecord(section.offset)) return false;
-    const hasMap = isStandardSourceMap(section.map);
-    const hasUrl = typeof section.url === "string" && section.url.length > 0;
+  return sections.every((section: unknown) => {
+    if (typeof section !== "object" || section === null) return false;
+    const map = Reflect.get(section, "map");
+    const url = Reflect.get(section, "url");
+    const offset = Reflect.get(section, "offset");
+    if (typeof offset !== "object" || offset === null) return false;
+    const offsetColumn = Reflect.get(offset, "column");
+    const offsetLine = Reflect.get(offset, "line");
+    const hasMap = isStandardSourceMap(map);
+    const hasUrl = typeof url === "string" && url.length > 0;
     return (
       hasMap !== hasUrl &&
-      typeof section.offset.column === "number" &&
-      Number.isInteger(section.offset.column) &&
-      section.offset.column >= 0 &&
-      typeof section.offset.line === "number" &&
-      Number.isInteger(section.offset.line) &&
-      section.offset.line >= 0
+      typeof offsetColumn === "number" &&
+      Number.isInteger(offsetColumn) &&
+      offsetColumn >= 0 &&
+      typeof offsetLine === "number" &&
+      Number.isInteger(offsetLine) &&
+      offsetLine >= 0
     );
   });
 };

--- a/packages/bippy/tests/errors.test.ts
+++ b/packages/bippy/tests/errors.test.ts
@@ -1,86 +1,22 @@
 import { expect, it } from "vite-plus/test";
 import {
   BippyError,
-  BippyHookInstallationError,
   BippyHookInspectionError,
-  BippyHookListenerError,
   BippyHookRenderError,
-  BippyInstrumentationError,
   BippyReactBuildError,
-  BippyReactDevToolsError,
   BippySourceMapError,
   BippyUnsupportedHookError,
-  runWithBippyError,
 } from "../src/errors.js";
 
-it("creates stable named Bippy errors with their original cause", () => {
+it("creates stable named Bippy errors", () => {
   const cause = new Error("original failure");
-  const instrumentationError = new BippyInstrumentationError(
-    "test-instrumentation",
-    "onCommitFiberRoot",
-    cause,
-  );
-  const reactDevToolsError = new BippyReactDevToolsError("onCommitFiberRoot", cause);
-  const hookListenerError = new BippyHookListenerError("onRendererInject", cause);
+  const hookRenderError = new BippyHookRenderError("render failure", cause);
 
-  expect(instrumentationError).toBeInstanceOf(BippyError);
-  expect(instrumentationError.name).toBe("BippyInstrumentationError");
-  expect(instrumentationError.callbackName).toBe("onCommitFiberRoot");
-  expect(instrumentationError.instrumentationName).toBe("test-instrumentation");
-  expect(instrumentationError.cause).toBe(cause);
-  expect(reactDevToolsError.name).toBe("BippyReactDevToolsError");
-  expect(reactDevToolsError.cause).toBe(cause);
-  expect(hookListenerError.name).toBe("BippyHookListenerError");
-  expect(hookListenerError.cause).toBe(cause);
-  expect(new BippyHookInstallationError(cause).name).toBe("BippyHookInstallationError");
+  expect(hookRenderError).toBeInstanceOf(BippyError);
+  expect(hookRenderError.name).toBe("BippyHookRenderError");
+  expect(hookRenderError.cause).toBe(cause);
   expect(new BippyReactBuildError("build failure").name).toBe("BippyReactBuildError");
   expect(new BippyHookInspectionError("inspection failure").name).toBe("BippyHookInspectionError");
-  expect(new BippyHookRenderError("render failure").name).toBe("BippyHookRenderError");
   expect(new BippyUnsupportedHookError("unsupported hook").name).toBe("BippyUnsupportedHookError");
   expect(new BippySourceMapError("source-map failure").name).toBe("BippySourceMapError");
-});
-
-it("synchronously propagates callback failures as named Bippy errors", () => {
-  const cause = new Error("listener failure");
-  let propagatedError: unknown;
-  try {
-    runWithBippyError(
-      () => {
-        throw cause;
-      },
-      (cause) => new BippyInstrumentationError("test-instrumentation", "onActive", cause),
-    );
-  } catch (error) {
-    propagatedError = error;
-  }
-  expect(propagatedError).toBeInstanceOf(BippyInstrumentationError);
-  if (!(propagatedError instanceof BippyInstrumentationError)) {
-    throw new Error("Expected a BippyInstrumentationError");
-  }
-  expect(propagatedError.cause).toBe(cause);
-});
-
-it("returns successful callback values unchanged", () => {
-  expect(
-    runWithBippyError(
-      () => 42,
-      (cause) => new BippyError("failure", cause),
-    ),
-  ).toBe(42);
-});
-
-it("does not obscure an existing Bippy error", () => {
-  const existingError = new BippyInstrumentationError(
-    "test-instrumentation",
-    "onActive",
-    new Error("listener failure"),
-  );
-  expect(() =>
-    runWithBippyError(
-      () => {
-        throw existingError;
-      },
-      (cause) => new BippyHookListenerError("onActive", cause),
-    ),
-  ).toThrow(existingError);
 });

--- a/packages/bippy/tests/errors.test.ts
+++ b/packages/bippy/tests/errors.test.ts
@@ -3,7 +3,6 @@ import {
   BippyError,
   BippyHookInspectionError,
   BippyHookRenderError,
-  BippyReactBuildError,
   BippySourceMapError,
   BippyUnsupportedHookError,
 } from "../src/errors.js";
@@ -15,7 +14,6 @@ it("creates stable named Bippy errors", () => {
   expect(hookRenderError).toBeInstanceOf(BippyError);
   expect(hookRenderError.name).toBe("BippyHookRenderError");
   expect(hookRenderError.cause).toBe(cause);
-  expect(new BippyReactBuildError("build failure").name).toBe("BippyReactBuildError");
   expect(new BippyHookInspectionError("inspection failure").name).toBe("BippyHookInspectionError");
   expect(new BippyUnsupportedHookError("unsupported hook").name).toBe("BippyUnsupportedHookError");
   expect(new BippySourceMapError("source-map failure").name).toBe("BippySourceMapError");

--- a/packages/bippy/tests/inspect-hooks-dispatcher-ref.test.ts
+++ b/packages/bippy/tests/inspect-hooks-dispatcher-ref.test.ts
@@ -23,7 +23,7 @@ describe("getFiberHooks dispatcher discovery", () => {
   it("throws when no react renderer is registered", () => {
     const fiber = createFakeFiber(() => null);
     expect(() => getFiberHooks(fiber)).toThrowError(
-      "No React renderer found. Make sure React is loaded and bippy's hook is installed.",
+      "Bippy couldn’t find a React renderer. Load React and install Bippy’s hook.",
     );
   });
 

--- a/packages/bippy/tests/inspect-hooks-exotic.test.tsx
+++ b/packages/bippy/tests/inspect-hooks-exotic.test.tsx
@@ -426,7 +426,9 @@ describe("dispatcher-only hooks", () => {
       return null;
     };
     const fiber = createInspectableFiber({ type: BogusHookComponent });
-    expect(() => getFiberHooks(fiber)).toThrowError("Missing method in Dispatcher: useBogusHook");
+    expect(() => getFiberHooks(fiber)).toThrowError(
+      "The React dispatcher is missing method useBogusHook",
+    );
   });
 });
 
@@ -634,6 +636,6 @@ describe("resolveContextDependency version support", () => {
 
   it("throws for unsupported react versions", () => {
     const fiber = createInspectableFiber({ type: NoopComponent }, {});
-    expect(() => getFiberHooks(fiber)).toThrowError("Unsupported React version.");
+    expect(() => getFiberHooks(fiber)).toThrowError("Bippy doesn’t support this React version.");
   });
 });

--- a/packages/bippy/tests/inspect-hooks.test.tsx
+++ b/packages/bippy/tests/inspect-hooks.test.tsx
@@ -232,7 +232,7 @@ describe("getFiberHooks", () => {
     render(<StateComponent />);
 
     expect(() => getFiberHooks(fiber!)).toThrow(
-      "Unknown Fiber. Needs to be a function component to inspect hooks.",
+      "Hook inspection requires a function component Fiber.",
     );
   });
 
@@ -577,7 +577,7 @@ describe("getFiberHooks additional hook types", () => {
       expect(() => getFiberHooks(fiber!)).toThrowError(
         expect.objectContaining({
           name: "BippyHookRenderError",
-          message: "Error rendering inspected component",
+          message: "Bippy couldn’t render the inspected component",
         }),
       );
     } finally {

--- a/packages/bippy/tests/instrument.test.tsx
+++ b/packages/bippy/tests/instrument.test.tsx
@@ -2,14 +2,7 @@ import "../src/index.js"; // KEEP THIS LINE ON TOP
 
 import { expect, it, vi } from "vite-plus/test";
 import type { FiberRoot, ReactDevToolsGlobalHook } from "../src/react-internals/index.js";
-import {
-  _fiberRoots,
-  BippyInstrumentationError,
-  BippyReactDevToolsError,
-  getRDTHook,
-  instrument,
-  isInstrumentationActive,
-} from "../src/index.js";
+import { _fiberRoots, getRDTHook, instrument, isInstrumentationActive } from "../src/index.js";
 import React from "react";
 import { render } from "@testing-library/react";
 
@@ -153,14 +146,15 @@ it("propagates React DevTools callback failures", () => {
   if (rendererId === undefined) throw new Error("React DOM did not inject its renderer");
   const previousOnCommitFiberRoot = rdtHook.onCommitFiberRoot;
   const laterListener = vi.fn();
+  const devToolsError = new Error("DevTools failure");
   rdtHook.onCommitFiberRoot = () => {
-    throw new Error("DevTools failure");
+    throw devToolsError;
   };
   const unsubscribe = instrument({ onCommitFiberRoot: laterListener });
 
   try {
     expect(() => rdtHook.onCommitFiberRoot(rendererId, committedRoot, undefined, false)).toThrow(
-      BippyReactDevToolsError,
+      devToolsError,
     );
     expect(laterListener).not.toHaveBeenCalled();
   } finally {
@@ -184,17 +178,18 @@ it("propagates instrumentation callback failures and stops dispatch", () => {
   const rendererId = rdtHook.renderers.keys().next().value;
   if (rendererId === undefined) throw new Error("React DOM did not inject its renderer");
   const laterListener = vi.fn();
+  const instrumentationError = new Error("instrumentation failure");
   const unsubscribeThrowingListener = instrument({
     name: "throwing-instrumentation",
     onCommitFiberRoot: () => {
-      throw new Error("instrumentation failure");
+      throw instrumentationError;
     },
   });
   const unsubscribeLaterListener = instrument({ onCommitFiberRoot: laterListener });
 
   try {
     expect(() => rdtHook.onCommitFiberRoot(rendererId, committedRoot, undefined, false)).toThrow(
-      BippyInstrumentationError,
+      instrumentationError,
     );
     expect(laterListener).not.toHaveBeenCalled();
   } finally {

--- a/packages/bippy/tests/owner-stack.test.ts
+++ b/packages/bippy/tests/owner-stack.test.ts
@@ -384,7 +384,7 @@ describe("getFallbackParentStack", () => {
       },
     });
     const stack = getFallbackParentStack(explodingFiber);
-    expect(stack).toContain("Error generating stack: fiber walk exploded");
+    expect(stack).toContain("Bippy couldn’t generate the stack: fiber walk exploded");
   });
 
   it("returns an empty string for non-error throws while walking", () => {

--- a/packages/bippy/tests/rdt-hook-install.test.ts
+++ b/packages/bippy/tests/rdt-hook-install.test.ts
@@ -51,7 +51,7 @@ it("checkDCE should schedule an error for badly built react", () => {
   vi.useFakeTimers();
   const productionMarkedFunction = () => "^_^";
   rdtHook.checkDCE(productionMarkedFunction);
-  expect(() => vi.runAllTimers()).toThrow(/dead code/);
+  expect(() => vi.runAllTimers()).toThrow(/dead-code/);
   rdtHook.checkDCE(() => "fine");
   expect(() => vi.runAllTimers()).not.toThrow();
   rdtHook.checkDCE(null);

--- a/packages/bippy/tests/rdt-hook-install.test.ts
+++ b/packages/bippy/tests/rdt-hook-install.test.ts
@@ -1,6 +1,5 @@
 // intentionally avoids importing ../index.js so this file controls hook installation
 import { expect, it, vi } from "vite-plus/test";
-import { BippyHookListenerError } from "../src/errors.js";
 import { ReactBuildType } from "../src/react-internals/index.js";
 import {
   _onActiveListeners,
@@ -91,19 +90,21 @@ it("assigning a new hook should merge existing renderers into it", () => {
 });
 
 it("propagates active and renderer-injection listener failures", () => {
+  const activeListenerError = new Error("active listener failure");
   const throwingActiveListener = () => {
-    throw new Error("active listener failure");
+    throw activeListenerError;
   };
-  expect(() => getRDTHook(throwingActiveListener)).toThrow(BippyHookListenerError);
+  expect(() => getRDTHook(throwingActiveListener)).toThrow(activeListenerError);
   _onActiveListeners.delete(throwingActiveListener);
 
   const laterListener = vi.fn();
+  const rendererListenerError = new Error("renderer listener failure");
   const unsubscribeThrowingListener = onRendererInject(() => {
-    throw new Error("renderer listener failure");
+    throw rendererListenerError;
   });
   const unsubscribeLaterListener = onRendererInject(laterListener);
   const renderer = createFakeRenderer();
-  expect(() => getRDTHook().inject(renderer)).toThrow(BippyHookListenerError);
+  expect(() => getRDTHook().inject(renderer)).toThrow(rendererListenerError);
   expect(laterListener).not.toHaveBeenCalled();
   unsubscribeThrowingListener();
   unsubscribeLaterListener();

--- a/packages/bippy/tests/rdt-hook-install.test.ts
+++ b/packages/bippy/tests/rdt-hook-install.test.ts
@@ -50,7 +50,7 @@ it("checkDCE should schedule an error for badly built react", () => {
   vi.useFakeTimers();
   const productionMarkedFunction = () => "^_^";
   rdtHook.checkDCE(productionMarkedFunction);
-  expect(() => vi.runAllTimers()).toThrow(/dead-code/);
+  expect(() => vi.runAllTimers()).toThrow(/dead code/);
   rdtHook.checkDCE(() => "fine");
   expect(() => vi.runAllTimers()).not.toThrow();
   rdtHook.checkDCE(null);

--- a/packages/bippy/tests/react-internals.test.ts
+++ b/packages/bippy/tests/react-internals.test.ts
@@ -23,6 +23,7 @@ it("selects React work tags by their version baseline", () => {
   expect(getReactWorkTags("18.3.1")).toBe(latestWorkTags);
   expect(getReactWorkTags("19.2.0-canary")).toBe(latestWorkTags);
   expect(getReactWorkTags("invalid")).toBe(latestWorkTags);
+  expect(getReactWorkTags()).toBe(latestWorkTags);
 });
 
 it("preserves AOT literal types for known React work-tag baselines", () => {
@@ -49,6 +50,7 @@ it("prefers the renderer reconciler version", () => {
   expect(getReactWorkTagsForRenderer({ ...rendererVersion, reconcilerVersion: "not-semver" })).toBe(
     getReactWorkTags("17.0.0-alpha"),
   );
+  expect(getReactWorkTagsForRenderer()).toBe(getReactWorkTags());
 });
 
 it("retains old renderer work tags after a Fiber is detached", () => {

--- a/packages/e2e/tests/web/rdt-hook.spec.ts
+++ b/packages/e2e/tests/web/rdt-hook.spec.ts
@@ -130,14 +130,12 @@ test.describe("installRDTHook", () => {
     expect(result.originalRestored).toBe(true);
   });
 
-  test("safelyInstallRDTHook is idempotent and leaves an installed hook in place", async ({
-    page,
-  }) => {
+  test("getRDTHook is idempotent", async ({ page }) => {
     const result = await page.evaluate(() => {
       const hookBefore = window.__BIPPY__.getRDTHook();
-      window.__BIPPY__.safelyInstallRDTHook();
+      const hookAfter = window.__BIPPY__.getRDTHook();
       return {
-        hookUnchanged: window.__BIPPY__.getRDTHook() === hookBefore,
+        hookUnchanged: hookAfter === hookBefore,
         stillActive: window.__BIPPY__.isInstrumentationActive(),
       };
     });

--- a/packages/next-playground/components/inspector.tsx
+++ b/packages/next-playground/components/inspector.tsx
@@ -35,7 +35,7 @@ export function Inspector() {
           try {
             console.log(await getSource(latestFiber));
           } catch (error) {
-            console.error("Error symbolicating stack:", error);
+            console.error("Bippy couldn’t symbolicate the stack:", error);
           }
         })();
       }


### PR DESCRIPTION
## Summary
- make default React work-tag selection explicit instead of passing an empty version sentinel
- propagate instrumentation, DevTools, hook-listener, and DCE failures unchanged
- remove generic object and collection guards in favor of validation at each usage boundary
- retain React DevTools' canonical DCE error wording and documentation link

## Breaking changes
- remove `runWithBippyError`, the callback-specific Bippy error classes, `BippyReactBuildError`, and `safelyInstallRDTHook`

## Test plan
- [x] `nr check`
- [x] `nr test` (563 passed, 2 skipped)
- [x] TypeScript checks for `packages/bippy` and `packages/e2e`
- [x] `nr build`
- [x] `nr check:react-internals` in `packages/bippy`