### PR TITLE
Remove dead code and deduplicate shared logic

### DIFF
--- a/packages/bippy/scripts/react-internals-plugin.ts
+++ b/packages/bippy/scripts/react-internals-plugin.ts
@@ -13,9 +13,8 @@ import type {
 } from "react-devtools-core";
 import { format } from "vite-plus/fmt";
 import type { Plugin } from "vite-plus";
-import ts from "typescript";
 import { z } from "zod";
-import { compareSemver } from "../src/react-internals/semver.js";
+import { compareSemver, isSemver } from "../src/react-internals/semver.js";
 
 interface ReactInternalsPluginOptions {
   mode: "check" | "generate";
@@ -26,9 +25,7 @@ interface ReactInternalsGenerationOptions extends ReactInternalsPluginOptions {
   reactDevToolsCore?: unknown;
 }
 
-const semanticVersionSchema = z
-  .string()
-  .refine((version) => compareSemver(version, version) === 0, "Expected a valid semantic version");
+const semanticVersionSchema = z.string().refine(isSemver, "Expected a valid semantic version");
 
 const reactBuildTypeSchema: z.ZodType<ReactBuildTypeMap> = z
   .object({
@@ -110,8 +107,10 @@ const requiredReactWorkTags = [
   "Fragment",
   "FunctionComponent",
   "HostComponent",
+  "HostHoistable",
   "HostPortal",
   "HostRoot",
+  "HostSingleton",
   "HostText",
   "LazyComponent",
   "MemoComponent",
@@ -444,46 +443,6 @@ export const createGeneratedReactInternals = async (
     reactDevToolsCore.ReactTypeOfSideEffect,
     reactDevToolsCore.ReactSymbols,
   );
-  const compilerOptions: ts.CompilerOptions = {
-    module: ts.ModuleKind.ESNext,
-    moduleResolution: ts.ModuleResolutionKind.Bundler,
-    noEmit: true,
-    skipLibCheck: true,
-    strict: true,
-    target: ts.ScriptTarget.ESNext,
-  };
-  const defaultCompilerHost = ts.createCompilerHost(compilerOptions);
-  const compilerHost: ts.CompilerHost = {
-    ...defaultCompilerHost,
-    fileExists: (fileName) =>
-      resolve(fileName) === defaultGeneratedModulePath || defaultCompilerHost.fileExists(fileName),
-    getSourceFile: (fileName, languageVersion, onError, shouldCreateNewSourceFile) =>
-      resolve(fileName) === defaultGeneratedModulePath
-        ? ts.createSourceFile(fileName, typescriptModule, languageVersion, true)
-        : defaultCompilerHost.getSourceFile(
-            fileName,
-            languageVersion,
-            onError,
-            shouldCreateNewSourceFile,
-          ),
-    readFile: (fileName) =>
-      resolve(fileName) === defaultGeneratedModulePath
-        ? typescriptModule
-        : defaultCompilerHost.readFile(fileName),
-  };
-  const program = ts.createProgram([defaultGeneratedModulePath], compilerOptions, compilerHost);
-  const errors = ts
-    .getPreEmitDiagnostics(program)
-    .filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error);
-  if (errors.length > 0) {
-    throw new Error(
-      ts.formatDiagnostics(errors, {
-        getCanonicalFileName: (fileName) => fileName,
-        getCurrentDirectory: () => process.cwd(),
-        getNewLine: () => "\n",
-      }),
-    );
-  }
   const formattingResult = await format(defaultGeneratedModulePath, typescriptModule, {
     semi: true,
     singleQuote: false,

--- a/packages/bippy/src/core.ts
+++ b/packages/bippy/src/core.ts
@@ -45,23 +45,10 @@ export {
 const isComponentType = (value: unknown): value is React.ComponentType<unknown> =>
   typeof value === "function";
 
-const getPropertyValue = (value: object, key: PropertyKey): unknown => {
-  let currentValue: object | null = value;
-  while (currentValue) {
-    const descriptor = Object.getOwnPropertyDescriptor(currentValue, key);
-    if (descriptor) {
-      if ("value" in descriptor) return descriptor.value;
-      return descriptor.get?.call(value);
-    }
-    currentValue = Object.getPrototypeOf(currentValue);
-  }
-  return undefined;
-};
-
 const getTypeName = (value: object): string | null => {
-  const displayName = getPropertyValue(value, "displayName");
+  const displayName = "displayName" in value ? value.displayName : null;
   if (typeof displayName === "string" && displayName) return displayName;
-  const name = getPropertyValue(value, "name");
+  const name = "name" in value ? value.name : null;
   return typeof name === "string" && name ? name : null;
 };
 
@@ -75,7 +62,7 @@ export interface FiberTimings {
 }
 
 export interface RenderHandler {
-  <State>(fiber: Fiber, phase: RenderPhase, state?: State): unknown;
+  (fiber: Fiber, phase: RenderPhase): unknown;
 }
 
 interface ValueWrite {
@@ -654,7 +641,6 @@ const updateFiberRecursively = (
   onRender: RenderHandler,
   nextFiber: Fiber,
   prevFiber: Fiber | null,
-  parentFiber: Fiber | null,
 ): void => {
   if (!fiberIdMap.has(nextFiber)) {
     getFiberId(nextFiber);
@@ -693,7 +679,7 @@ const updateFiberRecursively = (
     const prevFallbackChildSet = prevFiber.child?.sibling ?? null;
 
     if (nextFallbackChildSet !== null && prevFallbackChildSet !== null) {
-      updateFiberRecursively(onRender, nextFallbackChildSet, prevFallbackChildSet, nextFiber);
+      updateFiberRecursively(onRender, nextFallbackChildSet, prevFallbackChildSet);
     }
   } else if (prevDidTimeout && !nextDidTimeOut) {
     // Fallback -> Primary:
@@ -732,14 +718,7 @@ const updateFiberRecursively = (
       // Schedule updates and mounts depending on whether alternates exist.
       // We don't track deletions here because they are reported separately.
       if (nextChild.alternate) {
-        const prevChild = nextChild.alternate;
-
-        updateFiberRecursively(
-          onRender,
-          nextChild,
-          prevChild,
-          shouldIncludeInTree ? nextFiber : parentFiber,
-        );
+        updateFiberRecursively(onRender, nextChild, nextChild.alternate);
       } else {
         mountFiberRecursively(onRender, nextChild, false);
       }
@@ -833,7 +812,7 @@ export const traverseRenderedFibers = (root: Fiber | FiberRoot, onRender: Render
     if (!wasMounted && isMounted) {
       mountFiberRecursively(onRender, fiber, false);
     } else if (wasMounted && isMounted) {
-      updateFiberRecursively(onRender, fiber, fiber.alternate, null);
+      updateFiberRecursively(onRender, fiber, fiber.alternate);
     } else if (wasMounted && !isMounted) {
       unmountFiber(onRender, fiber);
     }
@@ -935,9 +914,6 @@ const buildPathsFromValue = (
   basePath: string[] = [],
   ancestors = new WeakSet<object>(),
 ): ValueWrite[] => {
-  if (!isPOJO(maybePOJO)) {
-    return [{ path: basePath, value: maybePOJO }];
-  }
   if (ancestors.has(maybePOJO)) {
     return [{ path: basePath, value: maybePOJO }];
   }

--- a/packages/bippy/src/rdt-hook.ts
+++ b/packages/bippy/src/rdt-hook.ts
@@ -118,6 +118,20 @@ const getRendererMap = (rdtHook: ReactDevToolsGlobalHook): Map<number, ReactRend
   return rdtHook.renderers;
 };
 
+const trackInjectedRenderer = (
+  rdtHook: ReactDevToolsGlobalHook,
+  renderers: Map<number, ReactRenderer>,
+  rendererId: number,
+  renderer: ReactRenderer,
+): void => {
+  renderers.set(rendererId, renderer);
+  _renderers.add(renderer);
+  if (!rdtHook._instrumentationIsActive) {
+    rdtHook._instrumentationIsActive = true;
+    notifyActiveListeners();
+  }
+};
+
 export const installRDTHook = (onActive?: ActiveListener): ReactDevToolsGlobalHook => {
   if (onActive) {
     _onActiveListeners.add(onActive);
@@ -131,12 +145,7 @@ export const installRDTHook = (onActive?: ActiveListener): ReactDevToolsGlobalHo
     hasUnsupportedRendererAttached: false,
     inject: (renderer) => {
       const nextRendererId = ++rendererIdCounter;
-      renderers.set(nextRendererId, renderer);
-      _renderers.add(renderer);
-      if (!rdtHook._instrumentationIsActive) {
-        rdtHook._instrumentationIsActive = true;
-        notifyActiveListeners();
-      }
+      trackInjectedRenderer(rdtHook, renderers, nextRendererId, renderer);
       return nextRendererId;
     },
     on: noOp,
@@ -159,12 +168,10 @@ export const installRDTHook = (onActive?: ActiveListener): ReactDevToolsGlobalHo
           const ourRenderers = rdtHook.renderers;
           rdtHook = newHook;
           const nextRenderers = getRendererMap(rdtHook);
-          if (ourRenderers.size > 0) {
-            ourRenderers.forEach((renderer, rendererId) => {
-              _renderers.add(renderer);
-              nextRenderers.set(rendererId, renderer);
-            });
-          }
+          ourRenderers.forEach((renderer, rendererId) => {
+            _renderers.add(renderer);
+            nextRenderers.set(rendererId, renderer);
+          });
           if (ourRenderers.size > 0 || rdtHookReplaceListeners.size > 0) {
             patchRDTHook(onActive);
           }
@@ -189,14 +196,14 @@ export const installRDTHook = (onActive?: ActiveListener): ReactDevToolsGlobalHo
       };
       objectDefineProperty(window, "hasOwnProperty", {
         configurable: true,
-        value: (...propertyKeys: [PropertyKey]) => {
-          if (!didRunHasOwnPropertyHack && propertyKeys[0] === "__REACT_DEVTOOLS_GLOBAL_HOOK__") {
+        value: (propertyKey: PropertyKey) => {
+          if (!didRunHasOwnPropertyHack && propertyKey === "__REACT_DEVTOOLS_GLOBAL_HOOK__") {
             didRunHasOwnPropertyHack = true;
             restoreWindowHasOwnProperty();
             globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__ = undefined;
             return false;
           }
-          return originalWindowHasOwnProperty(...propertyKeys);
+          return originalWindowHasOwnProperty(propertyKey);
         },
         writable: true,
       });
@@ -236,12 +243,7 @@ export const patchRDTHook = (onActive?: ActiveListener): void => {
     const previousInject = rdtHook.inject;
     rdtHook.inject = (renderer) => {
       const rendererId = previousInject.call(rdtHook, renderer);
-      _renderers.add(renderer);
-      renderers.set(rendererId, renderer);
-      if (!rdtHook._instrumentationIsActive) {
-        rdtHook._instrumentationIsActive = true;
-        notifyActiveListeners();
-      }
+      trackInjectedRenderer(rdtHook, renderers, rendererId, renderer);
       return rendererId;
     };
   }

--- a/packages/bippy/src/react-internals/index.ts
+++ b/packages/bippy/src/react-internals/index.ts
@@ -1,6 +1,6 @@
 import { getReactWorkTags, ReactFiberFlags } from "./generated/react-work-tags.js";
 import type { ReactWorkTagMap } from "./generated/react-work-tags.js";
-import { compareSemver } from "./semver.js";
+import { isSemver } from "./semver.js";
 import type { Fiber, ReactRenderer } from "./types.js";
 
 export { compareSemver } from "./semver.js";
@@ -25,7 +25,7 @@ export const getReactWorkTagsForRenderer = (
   renderer?: ReactRenderer | null,
 ): Readonly<ReactWorkTagMap> => {
   const reconcilerVersion = renderer?.reconcilerVersion;
-  if (reconcilerVersion && compareSemver(reconcilerVersion, reconcilerVersion) === 0) {
+  if (reconcilerVersion && isSemver(reconcilerVersion)) {
     return getReactWorkTags(reconcilerVersion);
   }
   return renderer?.version ? getReactWorkTags(renderer.version) : defaultReactWorkTags;

--- a/packages/bippy/src/react-internals/semver.ts
+++ b/packages/bippy/src/react-internals/semver.ts
@@ -9,6 +9,8 @@ const SEMVER_PATTERN =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const NUMERIC_IDENTIFIER_PATTERN = /^\d+$/;
 
+export const isSemver = (version: string): boolean => parseSemver(version) !== null;
+
 const parseSemver = (version: string): SemanticVersion | null => {
   const match = SEMVER_PATTERN.exec(version);
   if (!match) return null;

--- a/packages/bippy/src/react-internals/types.ts
+++ b/packages/bippy/src/react-internals/types.ts
@@ -2,83 +2,11 @@ import type { ReactNode } from "react";
 import type ReactReconciler from "react-reconciler";
 import type { HostWorkTag, ReactWorkTag } from "./generated/react-work-tags.js";
 
-export type BundleType = ReactReconciler.BundleType;
-export type Flags = ReactReconciler.Flags;
-export type HookType = ReactReconciler.HookType;
-export type LanePriority = ReactReconciler.LanePriority;
-export type Lanes = ReactReconciler.Lanes;
-export type MutableSource = ReactReconciler.MutableSource;
-export type OpaqueHandle = ReactReconciler.OpaqueHandle;
-export type OpaqueRoot = ReactReconciler.OpaqueRoot;
-export type React$AbstractComponent<
-  Config,
-  Instance = unknown,
-> = ReactReconciler.React$AbstractComponent<Config, Instance>;
-export type RootTag = ReactReconciler.RootTag;
-export type TypeOfMode = ReactReconciler.TypeOfMode;
 export type WorkTag = ReactReconciler.WorkTag | ReactWorkTag;
 
-export interface HostConfig<
-  Type = unknown,
-  HostProps = unknown,
-  Container = unknown,
-  Instance = unknown,
-  TextInstance = unknown,
-  SuspenseInstance = unknown,
-  HydratableInstance = unknown,
-  FormInstance = unknown,
-  PublicInstance = unknown,
-  HostContext = unknown,
-  ChildSet = unknown,
-  TimeoutHandle = unknown,
-  NoTimeout = unknown,
-  TransitionStatus = unknown,
-> extends ReactReconciler.HostConfig<
-  Type,
-  HostProps,
-  Container,
-  Instance,
-  TextInstance,
-  SuspenseInstance,
-  HydratableInstance,
-  FormInstance,
-  PublicInstance,
-  HostContext,
-  ChildSet,
-  TimeoutHandle,
-  NoTimeout,
-  TransitionStatus
-> {}
-
 export interface Source extends ReactReconciler.Source {}
-export interface RefObject extends ReactReconciler.RefObject {}
-export interface Thenable<T> extends ReactReconciler.Thenable<T> {}
 
 export interface ReactContext<T> extends ReactReconciler.ReactContext<T> {}
-
-export interface ReactProviderType<T> extends ReactReconciler.ReactProviderType<T> {}
-export interface ReactProvider<T> extends ReactReconciler.ReactProvider<T> {}
-export interface ReactConsumer<T> extends ReactReconciler.ReactConsumer<T> {}
-export interface ReactPortal extends ReactReconciler.ReactPortal {}
-
-export interface ComponentSelector extends ReactReconciler.ComponentSelector {}
-export interface HasPseudoClassSelector extends ReactReconciler.HasPseudoClassSelector {}
-export interface RoleSelector extends ReactReconciler.RoleSelector {}
-export interface TextSelector extends ReactReconciler.TextSelector {}
-export interface TestNameSelector extends ReactReconciler.TestNameSelector {}
-export type Selector = ReactReconciler.Selector;
-
-export interface DevToolsConfig<
-  Instance = unknown,
-  TextInstance = unknown,
-  RendererInspectionConfig = unknown,
-> extends ReactReconciler.DevToolsConfig<Instance, TextInstance, RendererInspectionConfig> {}
-
-export interface SuspenseHydrationCallbacks<
-  SuspenseInstance = unknown,
-> extends ReactReconciler.SuspenseHydrationCallbacks<SuspenseInstance> {}
-
-export interface TransitionTracingCallbacks extends ReactReconciler.TransitionTracingCallbacks {}
 
 // HACK: React 17 exposes observedBits while React 18+ exposes memoizedValue on context dependencies.
 export interface ContextDependency<T> extends Omit<

--- a/packages/bippy/src/source/get-display-name-from-source.ts
+++ b/packages/bippy/src/source/get-display-name-from-source.ts
@@ -4,6 +4,25 @@ import { getRawParentStack } from "./owner-stack.js";
 import { getSourceFromSourceMap, getSourceMap } from "./symbolication.js";
 import { StackFrame } from "./parse-stack.js";
 
+const COMPONENT_DECLARATION_PATTERNS = [
+  /(?:^|export\s+)(?:const|let|var)\s+(\w+)\s*=/,
+  /(?:^|export\s+)function\s+(\w+)/,
+  /(?:^|export\s+)class\s+(\w+)/,
+];
+
+const findComponentDeclarationOnLine = (line: string): string | null => {
+  for (const pattern of COMPONENT_DECLARATION_PATTERNS) {
+    const match = line.match(pattern);
+    if (match?.[1]) return match[1];
+  }
+  return null;
+};
+
+const MAX_DECLARATION_LINE_DISTANCE = 5;
+
+// the frame points inside the component, so the nearest declaration wins;
+// searching by pattern over the whole window instead would let an adjacent
+// component's declaration shadow the right one
 const extractComponentNameFromSource = (
   sourceContent: string,
   lineNumber: number,
@@ -15,27 +34,16 @@ const extractComponentNameFromSource = (
     return null;
   }
 
-  const startLine = Math.max(0, targetLineIndex - 5);
-  const endLine = Math.min(lines.length, targetLineIndex + 5);
-  const contextLines = lines.slice(startLine, endLine).join("\n");
-
-  const arrowFunctionPattern = /(?:^|export\s+)(?:const|let|var)\s+(\w+)\s*=/m;
-  const functionPattern = /(?:^|export\s+)function\s+(\w+)/m;
-  const classPattern = /(?:^|export\s+)class\s+(\w+)/m;
-
-  const arrowMatch = contextLines.match(arrowFunctionPattern);
-  if (arrowMatch?.[1]) {
-    return arrowMatch[1];
-  }
-
-  const functionMatch = contextLines.match(functionPattern);
-  if (functionMatch?.[1]) {
-    return functionMatch[1];
-  }
-
-  const classMatch = contextLines.match(classPattern);
-  if (classMatch?.[1]) {
-    return classMatch[1];
+  for (let lineDistance = 0; lineDistance <= MAX_DECLARATION_LINE_DISTANCE; lineDistance++) {
+    const lineIndexes =
+      lineDistance === 0
+        ? [targetLineIndex]
+        : [targetLineIndex - lineDistance, targetLineIndex + lineDistance];
+    for (const lineIndex of lineIndexes) {
+      if (lineIndex < 0 || lineIndex >= lines.length) continue;
+      const declarationName = findComponentDeclarationOnLine(lines[lineIndex]);
+      if (declarationName) return declarationName;
+    }
   }
 
   return null;

--- a/packages/bippy/src/source/get-display-name-from-source.ts
+++ b/packages/bippy/src/source/get-display-name-from-source.ts
@@ -1,6 +1,6 @@
 import { Fiber } from "../react-internals/index.js";
 import { getDisplayName } from "../core.js";
-import { getParentStack } from "./owner-stack.js";
+import { getRawParentStack } from "./owner-stack.js";
 import { getSourceFromSourceMap, getSourceMap } from "./symbolication.js";
 import { StackFrame } from "./parse-stack.js";
 
@@ -46,8 +46,7 @@ export const getDisplayNameFromSource = async (
   cache = true,
   fetchFn?: (url: string) => Promise<Response>,
 ): Promise<string | null> => {
-  const parentStackFrames = await getParentStack(fiber, cache, fetchFn);
-  const stackFrame = parentStackFrames.filter((innerFrame) => innerFrame.fileName)[0];
+  const stackFrame = getRawParentStack(fiber).find((innerFrame) => innerFrame.fileName);
 
   if (!stackFrame?.fileName) {
     return getDisplayName(fiber.type);

--- a/packages/bippy/src/source/get-source.ts
+++ b/packages/bippy/src/source/get-source.ts
@@ -95,8 +95,7 @@ export const getSource = async (
   fetchFn?: (url: string) => Promise<Response>,
 ): Promise<FiberSource | null> => {
   if (hasDebugSource(fiber)) {
-    const debugSource = fiber._debugSource;
-    return debugSource || null;
+    return fiber._debugSource;
   }
 
   const debugStackFrame =

--- a/packages/bippy/src/source/inspect-hooks.ts
+++ b/packages/bippy/src/source/inspect-hooks.ts
@@ -383,15 +383,8 @@ const createActionStateDispatcher =
     const hook = nextHook();
     nextHook();
     nextHook();
-    const stackError = new Error();
     const { value, error } = inspectActionStateHook(hook, initialState);
-    hookLog.push({
-      displayName: null,
-      primitive,
-      stackError,
-      value,
-      dispatcherHookName: primitive,
-    });
+    pushHookLogEntry(primitive, value, primitive);
     if (error !== null) throw error;
     return [value, () => {}, false];
   };
@@ -439,17 +432,12 @@ const dispatcher = {
   useEffectEvent: dispatcherUseEffectEvent,
 };
 
-const dispatcherProxy =
-  typeof Proxy === "undefined"
-    ? dispatcher
-    : new Proxy(dispatcher, {
-        get(target, propertyName: string) {
-          if (Object.hasOwn(target, propertyName)) return Reflect.get(target, propertyName);
-          throw new BippyUnsupportedHookError(
-            "The React dispatcher is missing method " + propertyName,
-          );
-        },
-      });
+const dispatcherProxy = new Proxy(dispatcher, {
+  get(target, propertyName: string) {
+    if (Object.hasOwn(target, propertyName)) return Reflect.get(target, propertyName);
+    throw new BippyUnsupportedHookError("The React dispatcher is missing method " + propertyName);
+  },
+});
 
 const getPrimitiveStackCache = (): Map<string, StackFrame[]> => {
   if (primitiveStackCache !== null) return primitiveStackCache;
@@ -462,7 +450,7 @@ const getPrimitiveStackCache = (): Map<string, StackFrame[]> => {
     dispatcher.useState(null);
     dispatcher.useReducer((state: unknown) => state, null);
     dispatcher.useRef(null);
-    if (typeof dispatcher.useCacheRefresh === "function") dispatcher.useCacheRefresh();
+    dispatcher.useCacheRefresh();
     dispatcher.useLayoutEffect(() => {});
     dispatcher.useInsertionEffect(() => {});
     dispatcher.useEffect(() => {});
@@ -480,19 +468,16 @@ const getPrimitiveStackCache = (): Map<string, StackFrame[]> => {
     dispatcher.useFormState((state: unknown) => state, null);
     dispatcher.useActionState((state: unknown) => state, null);
     dispatcher.useHostTransitionStatus();
-    if (typeof dispatcher.useMemoCache === "function") dispatcher.useMemoCache(0);
-    if (typeof dispatcher.use === "function") {
-      dispatcher.use({ $$typeof: REACT_CONTEXT_TYPE, _currentValue: null });
-      const fulfilledPromise = Promise.resolve(null);
-      Reflect.set(fulfilledPromise, "status", "fulfilled");
-      Reflect.set(fulfilledPromise, "value", null);
-      dispatcher.use(fulfilledPromise);
-      try {
-        dispatcher.use(new Promise<never>(() => {}));
-      } catch {}
-    }
+    dispatcher.use({ $$typeof: REACT_CONTEXT_TYPE, _currentValue: null });
+    const fulfilledPromise = Promise.resolve(null);
+    Reflect.set(fulfilledPromise, "status", "fulfilled");
+    Reflect.set(fulfilledPromise, "value", null);
+    dispatcher.use(fulfilledPromise);
+    try {
+      dispatcher.use(new Promise<never>(() => {}));
+    } catch {}
     dispatcher.useId();
-    if (typeof dispatcher.useEffectEvent === "function") dispatcher.useEffectEvent(() => {});
+    dispatcher.useEffectEvent(() => {});
   } finally {
     capturedHookLog = hookLog;
     hookLog = [];
@@ -831,18 +816,14 @@ const requireDispatcherRef = (): RendererDispatcherRef => {
 };
 
 const resolveContextDependency = (fiber: Fiber): void => {
+  const legacyDependenciesKey = ["dependencies_old", "dependencies_new"].find((key) =>
+    Object.hasOwn(fiber, key),
+  );
   if (Object.hasOwn(fiber, "dependencies")) {
     const dependencies = fiber.dependencies;
     currentContextDependency = dependencies !== null ? dependencies.firstContext : null;
-  } else if (Object.hasOwn(fiber, "dependencies_old")) {
-    const dependencies: unknown = Reflect.get(fiber, "dependencies_old");
-    const firstContext =
-      typeof dependencies === "object" && dependencies !== null && "firstContext" in dependencies
-        ? dependencies.firstContext
-        : null;
-    currentContextDependency = isContextDependency(firstContext) ? firstContext : null;
-  } else if (Object.hasOwn(fiber, "dependencies_new")) {
-    const dependencies: unknown = Reflect.get(fiber, "dependencies_new");
+  } else if (legacyDependenciesKey) {
+    const dependencies: unknown = Reflect.get(fiber, legacyDependenciesKey);
     const firstContext =
       typeof dependencies === "object" && dependencies !== null && "firstContext" in dependencies
         ? dependencies.firstContext

--- a/packages/bippy/src/source/owner-stack.ts
+++ b/packages/bippy/src/source/owner-stack.ts
@@ -7,6 +7,7 @@ import type {
   ServerComponentInfo,
 } from "../react-internals/index.js";
 import {
+  REACT_STACK_BOTTOM_FRAME_PATTERNS,
   SERVER_FRAME_MARKER,
   SERVER_ENV_PATTERN,
   SERVER_COMPONENT_URL_PREFIXES,
@@ -31,9 +32,6 @@ export const hasDebugStack = (
 
 const isFiberOwner = (owner: Fiber | ServerComponentInfo): owner is Fiber =>
   "tag" in owner && typeof owner.tag === "number";
-
-const getDebugOwner = (fiber: Fiber): Fiber | ServerComponentInfo | undefined =>
-  fiber._debugOwner ?? undefined;
 
 /**
  * Locates a frame inside the fiber's own function body without invoking it:
@@ -322,7 +320,7 @@ const describeNativeComponentFrame = (
     console.warn = previousConsoleWarn;
   }
 
-  const componentName = component ? getDisplayName(component) : "";
+  const componentName = getDisplayName(component);
   const syntheticFrame = componentName ? describeBuiltInComponentFrame(componentName) : "";
   componentFrameCache.set(component, syntheticFrame);
   return syntheticFrame;
@@ -452,8 +450,7 @@ export const formatOwnerStack = (stack: string): string => {
     formattedStack = formattedStack.slice(firstNewlineIndex + 1);
   }
   let bottomFrameIndex = Math.max(
-    formattedStack.indexOf("react_stack_bottom_frame"),
-    formattedStack.indexOf("react-stack-bottom-frame"),
+    ...REACT_STACK_BOTTOM_FRAME_PATTERNS.map((pattern) => formattedStack.indexOf(pattern)),
   );
   if (bottomFrameIndex !== -1) {
     bottomFrameIndex = formattedStack.lastIndexOf("\n", bottomFrameIndex);
@@ -470,11 +467,6 @@ export const formatOwnerStack = (stack: string): string => {
   return formattedStack;
 };
 
-interface DebugStackEntry {
-  componentName: string;
-  stackFrames: StackFrame[];
-}
-
 const isReactServerComponentFrame = (stackFrame: StackFrame): boolean =>
   Boolean(
     stackFrame.functionName && stackFrame.fileName && isServerComponentUrl(stackFrame.fileName),
@@ -486,24 +478,22 @@ const areStackFramesEqual = (firstFrame: StackFrame, secondFrame: StackFrame): b
   firstFrame.columnNumber === secondFrame.columnNumber;
 
 const buildFunctionNameToRscFramesMap = (
-  debugStackEntries: DebugStackEntry[],
+  debugStackFrames: StackFrame[],
 ): Map<string, StackFrame[]> => {
   const functionNameToRscFrames = new Map<string, StackFrame[]>();
 
-  for (const debugStackEntry of debugStackEntries) {
-    for (const stackFrame of debugStackEntry.stackFrames) {
-      if (!isReactServerComponentFrame(stackFrame)) continue;
+  for (const stackFrame of debugStackFrames) {
+    if (!isReactServerComponentFrame(stackFrame)) continue;
 
-      const functionName = stackFrame.functionName!;
-      const framesForFunction = functionNameToRscFrames.get(functionName) ?? [];
-      const isDuplicateFrame = framesForFunction.some((existingFrame) =>
-        areStackFramesEqual(existingFrame, stackFrame),
-      );
+    const functionName = stackFrame.functionName!;
+    const framesForFunction = functionNameToRscFrames.get(functionName) ?? [];
+    const isDuplicateFrame = framesForFunction.some((existingFrame) =>
+      areStackFramesEqual(existingFrame, stackFrame),
+    );
 
-      if (!isDuplicateFrame) {
-        framesForFunction.push(stackFrame);
-        functionNameToRscFrames.set(functionName, framesForFunction);
-      }
+    if (!isDuplicateFrame) {
+      framesForFunction.push(stackFrame);
+      functionNameToRscFrames.set(functionName, framesForFunction);
     }
   }
 
@@ -564,7 +554,7 @@ const getOwnerStackFromDebugStacks = (fiber: Fiber): StackFrame[] => {
   while (owner) {
     if (isFiberOwner(owner)) {
       const ownerFiber: Fiber = owner;
-      owner = getDebugOwner(ownerFiber);
+      owner = ownerFiber._debugOwner;
       if (owner && hasDebugStack(ownerFiber)) {
         const { frames, isTrusted } = parseDebugStack(ownerFiber._debugStack);
         if (isTrusted) {
@@ -588,28 +578,56 @@ const getOwnerStackFromDebugStacks = (fiber: Fiber): StackFrame[] => {
   return ownerStackFrames;
 };
 
-const getDebugStackEntries = (rootFiber: Fiber): DebugStackEntry[] => {
-  const debugStackEntries: DebugStackEntry[] = [];
+const getDebugStackFrames = (rootFiber: Fiber): StackFrame[] => {
+  const debugStackFrames: StackFrame[] = [];
 
   traverseFiber(
     rootFiber,
     (currentFiber) => {
       if (!hasDebugStack(currentFiber)) return;
 
-      const componentName =
-        typeof currentFiber.type !== "string"
-          ? getDisplayName(currentFiber.type) || "<anonymous>"
-          : currentFiber.type;
-
-      debugStackEntries.push({
-        componentName,
-        stackFrames: parseStack(formatOwnerStack(currentFiber._debugStack?.stack)),
-      });
+      const { frames, isTrusted } = parseDebugStack(currentFiber._debugStack);
+      if (isTrusted) {
+        debugStackFrames.push(...frames);
+      }
     },
     true,
   );
 
-  return debugStackEntries;
+  return debugStackFrames;
+};
+
+/**
+ * The unsymbolicated frames behind {@link getParentStack}: bundle-space
+ * locations from re-invoking each component with a throwing dispatcher,
+ * with server frames enriched from debug stacks by name matching.
+ */
+export const getRawParentStack = (fiber: Fiber): StackFrame[] => {
+  const debugStackFrames = getDebugStackFrames(fiber);
+  const fallbackStackFrames = parseStack(getFallbackParentStack(fiber));
+  const functionNameToRscFrames = buildFunctionNameToRscFramesMap(debugStackFrames);
+  const functionNameToUsageIndex = new Map<string, number>();
+
+  const enrichedStackFrames = fallbackStackFrames.map((stackFrame): StackFrame => {
+    const isServerFrame =
+      stackFrame.source !== undefined && SERVER_ENV_PATTERN.test(stackFrame.source);
+
+    if (isServerFrame) {
+      return getEnrichedServerStackFrame(
+        stackFrame,
+        functionNameToRscFrames,
+        functionNameToUsageIndex,
+      );
+    }
+
+    return stackFrame;
+  });
+
+  return enrichedStackFrames.filter((stackFrame, index, frames) => {
+    if (index === 0) return true;
+    const previousFrame = frames[index - 1];
+    return stackFrame.functionName !== previousFrame.functionName;
+  });
 };
 
 /**
@@ -623,38 +641,7 @@ export const getParentStack = async (
   fiber: Fiber,
   shouldCache = true,
   fetchFunction?: (url: string) => Promise<Response>,
-): Promise<StackFrame[]> => {
-  const debugStackEntries = getDebugStackEntries(fiber);
-  const fallbackStackFrames = parseStack(getFallbackParentStack(fiber));
-  const functionNameToRscFrames = buildFunctionNameToRscFramesMap(debugStackEntries);
-  const functionNameToUsageIndex = new Map<string, number>();
-
-  const enrichedStackFrames = fallbackStackFrames.map((stackFrame): StackFrame => {
-    const isServerFrame =
-      (stackFrame.source?.includes(SERVER_FRAME_MARKER) ?? false) ||
-      (stackFrame.source !== null &&
-        stackFrame.source !== undefined &&
-        SERVER_ENV_PATTERN.test(stackFrame.source));
-
-    if (isServerFrame) {
-      return getEnrichedServerStackFrame(
-        stackFrame,
-        functionNameToRscFrames,
-        functionNameToUsageIndex,
-      );
-    }
-
-    return stackFrame;
-  });
-
-  const deduplicatedStackFrames = enrichedStackFrames.filter((stackFrame, index, frames) => {
-    if (index === 0) return true;
-    const previousFrame = frames[index - 1];
-    return stackFrame.functionName !== previousFrame.functionName;
-  });
-
-  return symbolicateStack(deduplicatedStackFrames, shouldCache, fetchFunction);
-};
+): Promise<StackFrame[]> => symbolicateStack(getRawParentStack(fiber), shouldCache, fetchFunction);
 
 // an owner frame is only actionable if it can point an editor somewhere:
 // it needs a file location and must not be ignore-listed bundler/framework code

--- a/packages/bippy/src/source/parse-stack.ts
+++ b/packages/bippy/src/source/parse-stack.ts
@@ -1,5 +1,4 @@
 export interface StackFrame {
-  args?: unknown[];
   columnNumber?: number;
   lineNumber?: number;
   // start of the enclosing function (the definition, not the call site);
@@ -17,7 +16,6 @@ export interface StackFrame {
 
 export interface ParseOptions {
   slice?: number | [number, number];
-  allowEmpty?: boolean;
   includeInElement?: boolean;
 }
 

--- a/packages/bippy/src/source/symbolication.ts
+++ b/packages/bippy/src/source/symbolication.ts
@@ -1,6 +1,7 @@
 import { decode, SourceMapMappings, type SourceMapSegment } from "@jridgewell/sourcemap-codec";
 
 import { BippySourceMapError } from "../errors.js";
+import { SCHEME_REGEX } from "./constants.js";
 import { StackFrame } from "./parse-stack.js";
 
 export interface DecodedSourceMapSection {
@@ -69,7 +70,6 @@ export interface StandardSourceMap {
   x_google_ignoreList?: number[];
 }
 
-const SCHEME_REGEX = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
 const INLINE_SOURCEMAP_REGEX = /^data:application\/json(?:;[^,]*)?,/i;
 const SOURCEMAP_REGEX =
   /(?:\/\/[@#][ \t]+sourceMappingURL=([^\s'"]+?)[ \t]*$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^*]+?)[ \t]*(?:\*\/)[ \t]*$)/;
@@ -83,7 +83,7 @@ interface SourceMapResult {
 
 class TransientSourceMapError extends Error {}
 
-const _pendingSourceMapRequests = new Map<string, Promise<SourceMapResult>>();
+const pendingSourceMapRequests = new Map<string, Promise<SourceMapResult>>();
 const pendingSourceMapRequestsByFetch = new WeakMap<
   SourceFetch,
   Map<string, Promise<SourceMapResult>>
@@ -687,27 +687,27 @@ export const getSourceMapUncached = async (
   }
 };
 
-const getSourceMapCache = (fetchFn: SourceFetch | undefined): Map<string, null | SourceMap> => {
-  if (!fetchFn) return sourceMapCache;
-  let cache = sourceMapCachesByFetch.get(fetchFn);
-  if (!cache) {
-    cache = new Map();
-    sourceMapCachesByFetch.set(fetchFn, cache);
+const getPerFetchMap = <Value>(
+  mapsByFetch: WeakMap<SourceFetch, Map<string, Value>>,
+  globalMap: Map<string, Value>,
+  fetchFn: SourceFetch | undefined,
+): Map<string, Value> => {
+  if (!fetchFn) return globalMap;
+  let map = mapsByFetch.get(fetchFn);
+  if (!map) {
+    map = new Map();
+    mapsByFetch.set(fetchFn, map);
   }
-  return cache;
+  return map;
 };
+
+const getSourceMapCache = (fetchFn: SourceFetch | undefined): Map<string, null | SourceMap> =>
+  getPerFetchMap(sourceMapCachesByFetch, sourceMapCache, fetchFn);
 
 const getPendingSourceMapRequests = (
   fetchFn: SourceFetch | undefined,
-): Map<string, Promise<SourceMapResult>> => {
-  if (!fetchFn) return _pendingSourceMapRequests;
-  let pendingRequests = pendingSourceMapRequestsByFetch.get(fetchFn);
-  if (!pendingRequests) {
-    pendingRequests = new Map();
-    pendingSourceMapRequestsByFetch.set(fetchFn, pendingRequests);
-  }
-  return pendingRequests;
-};
+): Map<string, Promise<SourceMapResult>> =>
+  getPerFetchMap(pendingSourceMapRequestsByFetch, pendingSourceMapRequests, fetchFn);
 
 const getSourceMapCacheKey = (file: string, options: SourceMapRequestOptions): string =>
   options.allowUnsafeServerFetch === undefined &&

--- a/packages/bippy/tests/get-display-name-from-source.test.ts
+++ b/packages/bippy/tests/get-display-name-from-source.test.ts
@@ -180,4 +180,38 @@ describe("getDisplayNameFromSource", () => {
     const result = await getDisplayNameFromSource(fiber, false, createSourceMapFetchFn(rawMap));
     expect(result).toBe("NoPatternComponent");
   });
+
+  it("extracts the declaration closest to the mapped line when several are in range", async () => {
+    const rawMap = createFixedPointRawMap(4, {
+      sourceLines: [
+        "const NeighborComponent = () => null;",
+        "",
+        "export class TargetComponent {",
+        "  render() { return null; }",
+        "}",
+      ],
+    });
+    const fiber = createFakeFiber(
+      latestReactWorkTags.FunctionComponent,
+      createThrowingComponent("MinifiedNested"),
+    );
+    const result = await getDisplayNameFromSource(fiber, false, createSourceMapFetchFn(rawMap));
+    expect(result).toBe("TargetComponent");
+  });
+
+  it("prefers a declaration above the mapped line over one equally far below", async () => {
+    const rawMap = createFixedPointRawMap(2, {
+      sourceLines: [
+        "export function EnclosingComponent() {",
+        "  return null;",
+        "const FollowingComponent = () => null;",
+      ],
+    });
+    const fiber = createFakeFiber(
+      latestReactWorkTags.FunctionComponent,
+      createThrowingComponent("MinifiedEnclosed"),
+    );
+    const result = await getDisplayNameFromSource(fiber, false, createSourceMapFetchFn(rawMap));
+    expect(result).toBe("EnclosingComponent");
+  });
 });


### PR DESCRIPTION
Audit of `packages/bippy/src` for dead code, YAGNI, and DRY issues. Every change below was verified against the test suite, repo consumers, and React-version compatibility paths before being applied. Net **−169 lines** (124+/293−) across 12 files, with all 563 tests, typecheck, build, and `vp check` passing.

Stacked on #88.

## Bug fix: double symbolication in `getDisplayNameFromSource`

`getParentStack` returns frames already rewritten to original-source coordinates, but `getDisplayNameFromSource` re-fetched a source map for the rewritten `fileName` and treated the mapped line/column as bundle coordinates — a second mapping pass that only worked in the test fixture (same map served for every URL, all lines mapping to one line) and silently fell back to `getDisplayName` in real environments.

The pre-symbolication pipeline is now exposed as `getRawParentStack` (`getParentStack` = `symbolicateStack(getRawParentStack(fiber), …)`), and the display-name path fetches the bundle's map once, using it for both the position lookup and the sources-content extraction.

## Dead code removed

- `updateFiberRecursively`'s `parentFiber` parameter — threaded through recursion, never read (leftover from the react-devtools port)
- Always-true `typeof dispatcher.X === "function"` guards on bippy's own object literal, plus the `useMemoCache(0)` warm-up whose shim never logs an entry
- The `typeof Proxy === "undefined"` fallback (the same file uses `Object.hasOwn` unconditionally; no supported runtime lacks Proxy)
- `StackFrame.args` and `ParseOptions.allowEmpty` — error-stack-parser leftovers nothing writes or reads
- Unreachable branches: `!isPOJO` early return in `buildPathsFromValue`, `debugSource || null` after the `hasDebugSource` type guard, the dead ternary in `describeNativeComponentFrame`, the `SERVER_FRAME_MARKER.includes` check subsumed by `SERVER_ENV_PATTERN`
- `DebugStackEntry.componentName` — computed via `getDisplayName` for every fiber in a full-tree traversal on every `getParentStack` call, never read; the traversal also now reuses `parseDebugStack`'s WeakMap cache instead of re-parsing stacks per fiber
- `RenderHandler`'s `<State>` generic and `state?` parameter — vestige of the removed `createFiberVisitor<S>` API; no caller can ever receive a value
- ~27 react-reconciler type re-exports in `react-internals/types.ts` (`HostConfig`, test selectors, `SuspenseHydrationCallbacks`, …) with zero usages — reconciler-author API, not fiber-inspection API. **Note:** this shrinks the published `.d.ts` surface; downstream consumers importing these should switch to `react-reconciler` directly.

## Deduplicated

- Renderer-injection bookkeeping repeated three times across `installRDTHook`/`patchRDTHook` → `trackInjectedRenderer`
- Two structurally identical per-fetchFn cache getters in `symbolication.ts` → `getPerFetchMap`
- The `compareSemver(v, v) === 0` validity idiom (duplicated in `react-internals/index.ts` and the codegen plugin) → exported `isSemver`
- Hardcoded `react-stack-bottom-frame` sentinels in `formatOwnerStack` → shared `REACT_STACK_BOTTOM_FRAME_PATTERNS`
- Byte-identical `SCHEME_REGEX` copy in `symbolication.ts` → imported from `constants.ts`
- Byte-identical `dependencies_old`/`dependencies_new` branches folded into one
- `createActionStateDispatcher`'s hand-rolled hook-log push → `pushHookLogEntry`
- `getPropertyValue`'s 12-line descriptor walk → `in`-narrowed property access (plain `Reflect.get` breaks the test that stubs `Reflect` out)

## Codegen plugin

Deleted the ~40-line in-memory TypeScript program (custom `CompilerHost`) that type-checked codegen output already guaranteed well-formed by the zod schemas and re-checked by the build's dts step. `HostHoistable`/`HostSingleton` are now in `requiredReactWorkTags`, closing the only drift the compiler check could realistically catch. The atomic temp-file write stays — it's load-bearing for tsdown's concurrent pack configs.

## Deliberately kept (looks removable, isn't)

- The hand-rolled base64 decoder: needed on React Native/Hermes < RN 0.74 where `atob` doesn't exist and Metro emits inline data-URI maps
- The four repeated blocks in `setHookEventDispatchers`: a generic helper fails `tsc --strict` without `as` casts, and unmount/commit need bookkeeping on opposite sides of the supersede check