### PR TITLE
Add conditional hooks example

### DIFF
--- a/examples/conditional-hooks/README.md
+++ b/examples/conditional-hooks/README.md
@@ -1,0 +1,13 @@
+# Conditional hooks
+
+This example makes ordinary React client hooks independent of call order without changing Bippy's package code. A small Vite transform inserts `useConditionalHooks()` at the start of each function component. That bootstrap uses Bippy's exported `useFiber()` API and one stable React reducer before the example virtualizes later hook calls by Fiber and callsite.
+
+```bash
+pnpm --filter @bippy/example-conditional-hooks dev
+pnpm --filter @bippy/example-conditional-hooks build
+pnpm --filter @bippy/example-conditional-hooks preview
+```
+
+The dev server exercises React's development build. The build and preview commands exercise its production build.
+
+This is an experimental client-only example. It emulates hook state and effect lifecycles outside React's native positional hook list and is not intended for server rendering.

--- a/examples/conditional-hooks/index.html
+++ b/examples/conditional-hooks/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <title>Conditional hooks with Bippy</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/conditional-hooks/package.json
+++ b/examples/conditional-hooks/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@bippy/example-conditional-hooks",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vp build",
+    "dev": "vp dev",
+    "preview": "vp preview",
+    "test": "vp test --run",
+    "test:production": "NODE_ENV=production vp test --run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "bippy": "workspace:*",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/types": "^7.28.0",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "happy-dom": "^15.11.7",
+    "typescript": "^5.9.0",
+    "vite-plus": "latest"
+  }
+}

--- a/examples/conditional-hooks/src/app.tsx
+++ b/examples/conditional-hooks/src/app.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+interface CounterProps {
+  isEnabled: boolean;
+}
+
+const ConditionalCounter = ({ isEnabled }: CounterProps) => {
+  if (!isEnabled) {
+    return <p className="empty">The component returned before calling any demo hooks.</p>;
+  }
+
+  const [count, setCount] = useState(0);
+  const renderCount = useRef(0);
+  renderCount.current++;
+
+  const doubledCount = useMemo(() => count * 2, [count]);
+
+  useEffect(() => {
+    document.title = `Conditional count: ${count}`;
+    return () => {
+      document.title = "Conditional hooks with Bippy";
+    };
+  }, [count]);
+
+  return (
+    <div className="counter">
+      <button onClick={() => setCount((value) => value + 1)}>Count: {count}</button>
+      <span>Doubled: {doubledCount}</span>
+      <span>Renders: {renderCount.current}</span>
+    </div>
+  );
+};
+
+const App = () => {
+  const [isEnabled, setIsEnabled] = useState(false);
+
+  return (
+    <main>
+      <p className="eyebrow">Bippy experiment</p>
+      <h1>Conditional hooks without changing component code</h1>
+      <p className="lede">
+        The Vite plugin initializes each function component through Bippy. The hooks below can be
+        skipped and re-entered in both development and production builds.
+      </p>
+      <label className="toggle">
+        <input
+          checked={isEnabled}
+          onChange={(event) => setIsEnabled(event.currentTarget.checked)}
+          type="checkbox"
+        />
+        Call the conditional hooks
+      </label>
+      <ConditionalCounter isEnabled={isEnabled} />
+      <p className="note">
+        Increment the counter, disable the branch, then enable it again. Its state is preserved.
+      </p>
+    </main>
+  );
+};
+
+export default App;

--- a/examples/conditional-hooks/src/conditional-hooks.test.tsx
+++ b/examples/conditional-hooks/src/conditional-hooks.test.tsx
@@ -1,0 +1,73 @@
+import "bippy/install-hook-only";
+
+import { getRDTHook } from "bippy";
+import { createElement, useEffect, useState } from "react";
+import { expect, it } from "vite-plus/test";
+
+import { installConditionalHooks } from "./conditional-hooks";
+
+interface ConditionalCounterProps {
+  effectEvents: string[];
+  isEnabled: boolean;
+}
+
+const ConditionalCounter = ({ effectEvents, isEnabled }: ConditionalCounterProps) => {
+  if (!isEnabled) return <span>disabled</span>;
+
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    effectEvents.push(`start:${count}`);
+    return () => {
+      effectEvents.push(`stop:${count}`);
+    };
+  }, [count, effectEvents]);
+
+  return <button onClick={() => setCount((value) => value + 1)}>{count}</button>;
+};
+
+installConditionalHooks();
+getRDTHook().checkDCE = () => {};
+
+const waitForEffects = (): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+it("preserves conditional state and cleans up conditional effects", async () => {
+  const { createRoot } = await import("react-dom/client");
+  const { flushSync } = await import("react-dom");
+
+  const effectEvents: string[] = [];
+  const container = document.createElement("div");
+  const root = createRoot(container);
+
+  flushSync(() => {
+    root.render(createElement(ConditionalCounter, { effectEvents, isEnabled: false }));
+  });
+
+  expect(container.textContent).toBe("disabled");
+
+  flushSync(() => {
+    root.render(createElement(ConditionalCounter, { effectEvents, isEnabled: true }));
+  });
+  expect(container.querySelector("button")?.textContent).toBe("0");
+
+  flushSync(() => {
+    container.querySelector("button")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  expect(container.querySelector("button")?.textContent).toBe("1");
+
+  flushSync(() => {
+    root.render(createElement(ConditionalCounter, { effectEvents, isEnabled: false }));
+  });
+  await waitForEffects();
+  expect(container.textContent).toBe("disabled");
+  expect(effectEvents).toContain("stop:1");
+
+  flushSync(() => {
+    root.render(createElement(ConditionalCounter, { effectEvents, isEnabled: true }));
+  });
+  expect(container.querySelector("button")?.textContent).toBe("1");
+
+  flushSync(() => root.unmount());
+});

--- a/examples/conditional-hooks/src/conditional-hooks.ts
+++ b/examples/conditional-hooks/src/conditional-hooks.ts
@@ -1,0 +1,1505 @@
+import {
+  didFiberRender,
+  getRDTHook,
+  instrument,
+  onRendererInject,
+  traverseFiber,
+  useFiber,
+} from "bippy";
+import type { Fiber, FiberRoot, ReactRenderer, Unsubscribe } from "bippy";
+import { useReducer } from "react";
+
+interface ConditionalHookDispatcher {
+  readContext?: (...arguments_: unknown[]) => unknown;
+  use?: (...arguments_: unknown[]) => unknown;
+  useActionState?: (...arguments_: unknown[]) => unknown;
+  useCallback?: (...arguments_: unknown[]) => unknown;
+  useCacheRefresh?: (...arguments_: unknown[]) => unknown;
+  useContext?: (...arguments_: unknown[]) => unknown;
+  useDebugValue?: (...arguments_: unknown[]) => unknown;
+  useDeferredValue?: (...arguments_: unknown[]) => unknown;
+  useEffect?: (...arguments_: unknown[]) => unknown;
+  useEffectEvent?: (...arguments_: unknown[]) => unknown;
+  useFormState?: (...arguments_: unknown[]) => unknown;
+  useHostTransitionStatus?: (...arguments_: unknown[]) => unknown;
+  useId?: (...arguments_: unknown[]) => unknown;
+  useImperativeHandle?: (...arguments_: unknown[]) => unknown;
+  useInsertionEffect?: (...arguments_: unknown[]) => unknown;
+  useLayoutEffect?: (...arguments_: unknown[]) => unknown;
+  useMemo?: (...arguments_: unknown[]) => unknown;
+  useMemoCache?: (...arguments_: unknown[]) => unknown;
+  useOptimistic?: (...arguments_: unknown[]) => unknown;
+  useReducer?: (...arguments_: unknown[]) => unknown;
+  useRef?: (...arguments_: unknown[]) => unknown;
+  useState?: (...arguments_: unknown[]) => unknown;
+  useSyncExternalStore?: (...arguments_: unknown[]) => unknown;
+  useTransition?: (...arguments_: unknown[]) => unknown;
+}
+
+interface ConditionalHookDispatcherRef {
+  H?: unknown;
+  current?: unknown;
+}
+
+interface ConditionalHookRuntime {
+  activeFiber: Fiber | null;
+  currentDispatcher: ConditionalHookDispatcher | null;
+  dispatcherKey: "H" | "current";
+  dispatcherRef: ConditionalHookDispatcherRef;
+  getHookKey: ConditionalHookKeyResolver;
+  originalDescriptor: PropertyDescriptor | undefined;
+  proxyByDispatcher: WeakMap<object, ConditionalHookDispatcher>;
+  renderer: ReactRenderer;
+  scheduleUpdate: (() => void) | null;
+}
+
+interface ConditionalHookScope {
+  cells: Map<PropertyKey, ConditionalHookCell>;
+  didCommit: boolean;
+  didUnmount: boolean;
+  effects: Map<PropertyKey, ConditionalEffectCell>;
+  fiber: Fiber;
+  hookKinds: Map<PropertyKey, ConditionalHookKind>;
+  layoutEffectsDisconnected: boolean;
+  passiveEffectsDisconnected: boolean;
+  renderer: ReactRenderer;
+  scheduleUpdate: (() => void) | null;
+}
+
+interface ConditionalRenderFrame {
+  callCounts: Map<PropertyKey, number>;
+  cells: Map<PropertyKey, ConditionalHookCell>;
+  effects: Map<PropertyKey, ConditionalEffectRegistration>;
+  fiber: Fiber;
+  hookKinds: Map<PropertyKey, ConditionalHookKind>;
+  reducerActionCounts: Map<PropertyKey, number>;
+  reducerOverrides: Map<PropertyKey, (state: unknown, action: unknown) => unknown>;
+  replayedCells: Set<PropertyKey>;
+  renderPhaseUpdates: Map<PropertyKey, unknown[]>;
+  scope: ConditionalHookScope;
+}
+
+interface ConditionalVisibilityState {
+  layoutEffectsHidden: boolean;
+  passiveEffectsHidden: boolean;
+}
+
+interface ConditionalStateCell {
+  dispatch: (action: unknown) => void;
+  kind: "state";
+  value: unknown;
+}
+
+interface ConditionalReducerCell {
+  dispatch: (action: unknown) => void;
+  kind: "reducer";
+  pendingActions: unknown[];
+  reducer: (state: unknown, action: unknown) => unknown;
+  value: unknown;
+}
+
+interface ConditionalRefCell {
+  kind: "ref";
+  value: ConditionalRef<unknown>;
+}
+
+interface ConditionalMemoCell {
+  dependencies: readonly unknown[] | undefined;
+  kind: "memo";
+  value: unknown;
+}
+
+interface ConditionalValueCell {
+  kind: "deferred-value" | "id" | "memo-cache";
+  value: unknown;
+}
+
+interface ConditionalExternalStoreCell {
+  getSnapshot: () => unknown;
+  kind: "external-store";
+  value: unknown;
+}
+
+interface ConditionalOptimisticCell {
+  dispatch: (action: unknown) => void;
+  isPending: boolean;
+  kind: "optimistic";
+  reducer: (state: unknown, action: unknown) => unknown;
+  value: unknown;
+}
+
+interface ConditionalTransitionCell {
+  isPending: boolean;
+  kind: "transition";
+  startTransition: (callback: () => void) => void;
+}
+
+interface ConditionalActionStateCell {
+  action: (previousState: unknown, payload: unknown) => unknown;
+  dispatch: (payload: unknown) => void;
+  isPending: boolean;
+  kind: "action-state";
+  pendingAction: Promise<void>;
+  pendingActions: number;
+  value: unknown;
+}
+
+interface ConditionalEffectEventCell {
+  callback: (...arguments_: unknown[]) => unknown;
+  event: (...arguments_: unknown[]) => unknown;
+  kind: "effect-event";
+}
+
+interface ConditionalCacheRefreshCell {
+  kind: "cache-refresh";
+  refresh: () => void;
+}
+
+interface ConditionalEffectCell {
+  cleanup: (() => void) | undefined;
+  create: ConditionalEffectRegistration["create"];
+  dependencies: readonly unknown[] | undefined;
+  kind: ConditionalEffectKind;
+  version: number;
+}
+
+interface ConditionalEffectRegistration {
+  create: () => (() => void) | void;
+  dependencies: readonly unknown[] | undefined;
+  kind: ConditionalEffectKind;
+}
+
+interface ConditionalRef<Value> {
+  current: Value;
+}
+
+interface ConditionalStateSetter<State> {
+  (action: State | ((previousState: State) => State)): void;
+}
+
+interface ConditionalReducerDispatcher<Action> {
+  (action: Action): void;
+}
+
+export interface ConditionalHooksInstallation extends Unsubscribe {
+  readonly supportedRenderers: number;
+}
+
+export interface ConditionalHooksOptions {
+  getHookKey?: ConditionalHookKeyResolver;
+}
+
+export interface ConditionalHookKeyResolver {
+  (hookName: string, stack: string): PropertyKey;
+}
+
+const isConditionalHooksInstallation = (
+  value: Unsubscribe,
+): value is ConditionalHooksInstallation =>
+  typeof Reflect.get(value, "supportedRenderers") === "number";
+
+type ConditionalHookCell =
+  | ConditionalActionStateCell
+  | ConditionalCacheRefreshCell
+  | ConditionalEffectEventCell
+  | ConditionalExternalStoreCell
+  | ConditionalMemoCell
+  | ConditionalOptimisticCell
+  | ConditionalReducerCell
+  | ConditionalRefCell
+  | ConditionalStateCell
+  | ConditionalTransitionCell
+  | ConditionalValueCell;
+
+type ConditionalEffectKind = "effect" | "insertion-effect" | "layout-effect";
+
+type ConditionalHookKind =
+  | ConditionalHookCell["kind"]
+  | ConditionalEffectKind
+  | "imperative-handle";
+
+const runtimes = new Set<ConditionalHookRuntime>();
+const scopes = new Set<ConditionalHookScope>();
+const runtimeByDispatcherRef = new WeakMap<object, ConditionalHookRuntime>();
+const scopeByFiber = new WeakMap<Fiber, ConditionalHookScope>();
+const renderFrameByFiber = new WeakMap<Fiber, ConditionalRenderFrame>();
+const pendingPassiveEffects: Array<() => void> = [];
+
+let installation: ConditionalHooksInstallation | null = null;
+let renderingRuntime: ConditionalHookRuntime | null = null;
+let conditionalId = 0;
+let didSchedulePassiveEffects = false;
+let scheduledUpdateVersion = 0;
+
+const createUnsubscribe = (unsubscribe: () => void): Unsubscribe =>
+  Object.assign(unsubscribe, { [Symbol.dispose]: unsubscribe });
+
+const incrementVersion = (version: number): number => version + 1;
+
+const isContextOnlyDispatcher = (dispatcher: ConditionalHookDispatcher | null): boolean => {
+  if (!dispatcher) return true;
+  return (
+    typeof dispatcher.useState === "function" &&
+    dispatcher.useState === dispatcher.useReducer &&
+    dispatcher.useReducer === dispatcher.useRef &&
+    dispatcher.useRef === dispatcher.useEffect
+  );
+};
+
+const isConditionalHookDispatcher = (value: unknown): value is ConditionalHookDispatcher =>
+  typeof value === "object" && value !== null;
+
+const defaultHookKeyResolver: ConditionalHookKeyResolver = (hookName, stack) => {
+  const callsiteFrames: string[] = [];
+  for (const stackLine of stack.split("\n")) {
+    const line = stackLine.trim();
+    if (!line.startsWith("at ") && !line.includes("@")) continue;
+    const normalizedLine = line.replaceAll("\\", "/");
+    if (
+      normalizedLine.includes("node_modules/react-dom/") ||
+      normalizedLine.includes("node_modules/.vite/deps/react-dom") ||
+      normalizedLine.includes("react-dom-client.development.js") ||
+      normalizedLine.includes("react-dom-client.production.js") ||
+      normalizedLine.includes("react-native/Libraries/Renderer")
+    ) {
+      break;
+    }
+    if (
+      normalizedLine.includes("/src/conditional-hooks.ts") ||
+      normalizedLine.includes("/dist/conditional-hooks.") ||
+      normalizedLine.includes("node_modules/bippy/conditional-hooks") ||
+      normalizedLine.includes("node_modules/react/") ||
+      normalizedLine.includes("node_modules/.vite/deps/react") ||
+      normalizedLine.includes("react.development.js") ||
+      normalizedLine.includes("react.production.js")
+    ) {
+      continue;
+    }
+    callsiteFrames.push(normalizedLine);
+  }
+  if (callsiteFrames.length === 0) {
+    throw new Error(`Could not derive a callsite key for React.${hookName}().`);
+  }
+  return `${hookName}:${callsiteFrames.join("\n")}`;
+};
+
+const getAutomaticHookKey = (runtime: ConditionalHookRuntime, hookName: string): PropertyKey => {
+  prepareRuntime(runtime);
+  const { frame } = getScope();
+  const stack = new Error().stack ?? "";
+  const callsiteKey = runtime.getHookKey(hookName, stack);
+  const occurrence = frame.callCounts.get(callsiteKey) ?? 0;
+  frame.callCounts.set(callsiteKey, occurrence + 1);
+  return `react:${String(callsiteKey)}:${occurrence}`;
+};
+
+const prepareRuntime = (runtime: ConditionalHookRuntime): void => {
+  if (runtime.activeFiber) return;
+  throw new Error("The component was not initialized for conditional hooks.");
+};
+
+const getDependencies = (value: unknown): readonly unknown[] | undefined =>
+  Array.isArray(value) ? value : undefined;
+
+const createDispatcherProxy = (
+  runtime: ConditionalHookRuntime,
+  dispatcher: ConditionalHookDispatcher,
+): ConditionalHookDispatcher =>
+  new Proxy(dispatcher, {
+    get: (target, property, receiver) => {
+      if (!runtime.activeFiber) return Reflect.get(target, property, receiver);
+      if (property === "useState") {
+        return (initialState: unknown) =>
+          readStateCell(getAutomaticHookKey(runtime, "useState"), initialState);
+      }
+      if (property === "useReducer") {
+        return (reducer: unknown, initialState: unknown, initialize: unknown) => {
+          if (typeof reducer !== "function") throw new TypeError("useReducer requires a reducer.");
+          const initializer =
+            typeof initialize === "function" ? (value: unknown) => initialize(value) : undefined;
+          return readReducerCell(
+            getAutomaticHookKey(runtime, "useReducer"),
+            (state: unknown, action: unknown) => reducer(state, action),
+            initialState,
+            initializer,
+          );
+        };
+      }
+      if (property === "useRef") {
+        return (initialValue: unknown) =>
+          readRefCell(getAutomaticHookKey(runtime, "useRef"), initialValue);
+      }
+      if (property === "useMemo") {
+        return (create: unknown, dependencies: unknown) => {
+          if (typeof create !== "function") throw new TypeError("useMemo requires a function.");
+          return readMemoCell(
+            getAutomaticHookKey(runtime, "useMemo"),
+            () => create(),
+            getDependencies(dependencies),
+          );
+        };
+      }
+      if (property === "useCallback") {
+        return (callback: unknown, dependencies: unknown) => {
+          if (typeof callback !== "function") {
+            throw new TypeError("useCallback requires a function.");
+          }
+          return readMemoCell(
+            getAutomaticHookKey(runtime, "useCallback"),
+            () => callback,
+            getDependencies(dependencies),
+          );
+        };
+      }
+      if (
+        property === "useEffect" ||
+        property === "useInsertionEffect" ||
+        property === "useLayoutEffect"
+      ) {
+        return (create: unknown, dependencies: unknown) => {
+          if (typeof create !== "function") {
+            throw new TypeError(`${property} requires a function.`);
+          }
+          const effectKind =
+            property === "useEffect"
+              ? "effect"
+              : property === "useInsertionEffect"
+                ? "insertion-effect"
+                : "layout-effect";
+          registerEffect(
+            getAutomaticHookKey(runtime, property),
+            effectKind,
+            () => create(),
+            getDependencies(dependencies),
+          );
+        };
+      }
+      if (property === "useImperativeHandle") {
+        return (ref: unknown, create: unknown, dependencies: unknown) => {
+          if (typeof create !== "function") {
+            throw new TypeError("useImperativeHandle requires a function.");
+          }
+          const effectDependencies = getDependencies(dependencies);
+          registerEffect(
+            getAutomaticHookKey(runtime, "useImperativeHandle"),
+            "layout-effect",
+            () =>
+              setImperativeHandle(ref, (...arguments_) =>
+                Reflect.apply(create, undefined, arguments_),
+              ),
+            effectDependencies ? [...effectDependencies, ref] : undefined,
+            "imperative-handle",
+          );
+        };
+      }
+      if (property === "useDeferredValue") {
+        return (value: unknown) =>
+          readValueCell(getAutomaticHookKey(runtime, "useDeferredValue"), "deferred-value", value);
+      }
+      if (property === "useTransition") {
+        return () => readTransitionCell(getAutomaticHookKey(runtime, "useTransition"));
+      }
+      if (property === "useSyncExternalStore") {
+        return (subscribe: unknown, getSnapshot: unknown) => {
+          if (typeof subscribe !== "function" || typeof getSnapshot !== "function") {
+            throw new TypeError(
+              "useSyncExternalStore requires subscribe and getSnapshot functions.",
+            );
+          }
+          return readExternalStoreCell(
+            getAutomaticHookKey(runtime, "useSyncExternalStore"),
+            (onStoreChange) => Reflect.apply(subscribe, undefined, [onStoreChange]),
+            () => Reflect.apply(getSnapshot, undefined, []),
+          );
+        };
+      }
+      if (property === "useId") {
+        return () => readIdCell(getAutomaticHookKey(runtime, "useId"));
+      }
+      if (property === "useCacheRefresh") {
+        return () => readCacheRefreshCell(getAutomaticHookKey(runtime, "useCacheRefresh"));
+      }
+      if (property === "useOptimistic") {
+        return (passthrough: unknown, reducer: unknown) =>
+          readOptimisticCell(
+            getAutomaticHookKey(runtime, "useOptimistic"),
+            passthrough,
+            typeof reducer === "function"
+              ? (state: unknown, action: unknown): unknown =>
+                  Reflect.apply(reducer, undefined, [state, action])
+              : (_state: unknown, action: unknown): unknown => action,
+          );
+      }
+      if (property === "useActionState" || property === "useFormState") {
+        return (action: unknown, initialState: unknown) => {
+          if (typeof action !== "function") {
+            throw new TypeError(`${property} requires an action function.`);
+          }
+          return readActionStateCell(
+            getAutomaticHookKey(runtime, property),
+            (previousState, payload) => Reflect.apply(action, undefined, [previousState, payload]),
+            initialState,
+          );
+        };
+      }
+      if (property === "useEffectEvent") {
+        return (callback: unknown) => {
+          if (typeof callback !== "function") {
+            throw new TypeError("useEffectEvent requires a function.");
+          }
+          return readEffectEventCell(
+            getAutomaticHookKey(runtime, "useEffectEvent"),
+            (...arguments_) => Reflect.apply(callback, undefined, arguments_),
+          );
+        };
+      }
+      if (property === "useMemoCache") {
+        return (size: unknown) => {
+          if (typeof size !== "number") throw new TypeError("useMemoCache requires a size.");
+          return readMemoCacheCell(getAutomaticHookKey(runtime, "useMemoCache"), size);
+        };
+      }
+      if (property === "useContext" && typeof target.readContext === "function") {
+        return target.readContext;
+      }
+      if (property === "useDebugValue") return (): void => {};
+      return Reflect.get(target, property, receiver);
+    },
+  });
+
+const getRuntimeDispatcher = (
+  runtime: ConditionalHookRuntime,
+): ConditionalHookDispatcher | null => {
+  const dispatcher = runtime.currentDispatcher;
+  if (!dispatcher || isContextOnlyDispatcher(dispatcher)) {
+    return dispatcher;
+  }
+  renderingRuntime = runtime;
+  const existingProxy = runtime.proxyByDispatcher.get(dispatcher);
+  if (existingProxy) return existingProxy;
+  const proxy = createDispatcherProxy(runtime, dispatcher);
+  runtime.proxyByDispatcher.set(dispatcher, proxy);
+  return proxy;
+};
+
+const associateScopeWithFiber = (scope: ConditionalHookScope, fiber: Fiber): void => {
+  scope.fiber = fiber;
+  scopeByFiber.set(fiber, scope);
+  if (fiber.alternate) scopeByFiber.set(fiber.alternate, scope);
+};
+
+const beginRender = (runtime: ConditionalHookRuntime, fiber: Fiber): void => {
+  runtime.activeFiber = fiber;
+  const scope =
+    scopeByFiber.get(fiber) ?? (fiber.alternate ? scopeByFiber.get(fiber.alternate) : undefined);
+  if (!scope) return;
+  scope.scheduleUpdate = runtime.scheduleUpdate;
+  const previousFrame = renderFrameByFiber.get(fiber);
+  const shouldReplayStrictCells =
+    !scope.didCommit && (fiber.mode & 0b0001000) !== 0 && previousFrame !== undefined;
+  associateScopeWithFiber(scope, fiber);
+  renderFrameByFiber.set(fiber, {
+    callCounts: new Map(),
+    cells: shouldReplayStrictCells ? new Map(previousFrame.cells) : new Map(),
+    effects: new Map(),
+    fiber,
+    hookKinds: new Map(),
+    reducerActionCounts: new Map(),
+    reducerOverrides: new Map(),
+    replayedCells: shouldReplayStrictCells ? new Set(previousFrame.cells.keys()) : new Set(),
+    renderPhaseUpdates: new Map(),
+    scope,
+  });
+};
+
+const handleDispatcherChange = (
+  runtime: ConditionalHookRuntime,
+  dispatcher: ConditionalHookDispatcher | null,
+): void => {
+  runtime.currentDispatcher = dispatcher;
+  if (isContextOnlyDispatcher(dispatcher)) {
+    runtime.activeFiber = null;
+    if (renderingRuntime === runtime) renderingRuntime = null;
+    return;
+  }
+  runtime.activeFiber = null;
+  renderingRuntime = runtime;
+};
+
+const restoreRuntime = (runtime: ConditionalHookRuntime): void => {
+  const descriptor = runtime.originalDescriptor;
+  if (descriptor) {
+    Object.defineProperty(runtime.dispatcherRef, runtime.dispatcherKey, descriptor);
+    runtime.dispatcherRef[runtime.dispatcherKey] = runtime.currentDispatcher;
+  } else {
+    delete runtime.dispatcherRef[runtime.dispatcherKey];
+    runtime.dispatcherRef[runtime.dispatcherKey] = runtime.currentDispatcher;
+  }
+  runtimes.delete(runtime);
+  runtimeByDispatcherRef.delete(runtime.dispatcherRef);
+};
+
+const installRenderer = (renderer: ReactRenderer, options: ConditionalHooksOptions): boolean => {
+  const dispatcherRef = renderer.currentDispatcherRef;
+  if (!dispatcherRef || typeof dispatcherRef !== "object") return false;
+  if (runtimeByDispatcherRef.has(dispatcherRef)) return true;
+
+  const dispatcherKey = "H" in dispatcherRef ? "H" : "current";
+  const originalDescriptor = Object.getOwnPropertyDescriptor(dispatcherRef, dispatcherKey);
+  if (originalDescriptor?.configurable === false) return false;
+  const currentDispatcherValue = "H" in dispatcherRef ? dispatcherRef.H : dispatcherRef.current;
+
+  const runtime: ConditionalHookRuntime = {
+    activeFiber: null,
+    currentDispatcher: isConditionalHookDispatcher(currentDispatcherValue)
+      ? currentDispatcherValue
+      : null,
+    dispatcherKey,
+    dispatcherRef,
+    getHookKey: options.getHookKey ?? defaultHookKeyResolver,
+    originalDescriptor,
+    proxyByDispatcher: new WeakMap(),
+    renderer,
+    scheduleUpdate: null,
+  };
+
+  Object.defineProperty(dispatcherRef, dispatcherKey, {
+    configurable: true,
+    enumerable: originalDescriptor?.enumerable ?? true,
+    get: () => getRuntimeDispatcher(runtime),
+    set: (dispatcher: ConditionalHookDispatcher | null) => {
+      handleDispatcherChange(runtime, dispatcher);
+    },
+  });
+
+  runtimes.add(runtime);
+  runtimeByDispatcherRef.set(dispatcherRef, runtime);
+  return true;
+};
+
+const getActiveRuntime = (): { fiber: Fiber; runtime: ConditionalHookRuntime } => {
+  for (const runtime of runtimes) {
+    const fiber = runtime.activeFiber;
+    if (fiber) {
+      return { fiber, runtime };
+    }
+  }
+  throw new Error("Conditional hooks must be called from a transformed function component.");
+};
+
+const getScope = (): { frame: ConditionalRenderFrame; scope: ConditionalHookScope } => {
+  const { fiber, runtime } = getActiveRuntime();
+  let scope =
+    scopeByFiber.get(fiber) ?? (fiber.alternate ? scopeByFiber.get(fiber.alternate) : undefined);
+  if (!scope) {
+    scope = {
+      cells: new Map(),
+      didCommit: false,
+      didUnmount: false,
+      effects: new Map(),
+      fiber,
+      hookKinds: new Map(),
+      layoutEffectsDisconnected: false,
+      passiveEffectsDisconnected: false,
+      renderer: runtime.renderer,
+      scheduleUpdate: runtime.scheduleUpdate,
+    };
+    associateScopeWithFiber(scope, fiber);
+  }
+  let frame = renderFrameByFiber.get(fiber);
+  scope.scheduleUpdate = runtime.scheduleUpdate ?? scope.scheduleUpdate;
+  if (!frame || frame.scope !== scope) {
+    frame = {
+      callCounts: new Map(),
+      cells: new Map(),
+      effects: new Map(),
+      fiber,
+      hookKinds: new Map(),
+      reducerActionCounts: new Map(),
+      reducerOverrides: new Map(),
+      replayedCells: new Set(),
+      renderPhaseUpdates: new Map(),
+      scope,
+    };
+    renderFrameByFiber.set(fiber, frame);
+  }
+  return { frame, scope };
+};
+
+const registerHookKind = (
+  frame: ConditionalRenderFrame,
+  scope: ConditionalHookScope,
+  key: PropertyKey,
+  kind: ConditionalHookKind,
+): void => {
+  const previousKind = frame.hookKinds.get(key) ?? scope.hookKinds.get(key);
+  if (previousKind && previousKind !== kind) {
+    throw new Error(
+      `Conditional hook key ${String(key)} changed from ${previousKind} to ${kind}. Keys must identify one hook callsite.`,
+    );
+  }
+  frame.hookKinds.set(key, kind);
+};
+
+const scheduleScopeUpdate = (scope: ConditionalHookScope): void => {
+  if (scope.didUnmount) return;
+  if (scope.scheduleUpdate) {
+    scope.scheduleUpdate();
+    return;
+  }
+  const scheduleUpdate = scope.renderer.scheduleUpdate;
+  if (!scheduleUpdate) {
+    throw new Error("The active React renderer does not expose scheduleUpdate().");
+  }
+  // HACK: DevTools schedules a no-op lane, so cloning props bypasses React's bailout check.
+  const currentFiber = getCurrentFiberBranch(scope.fiber);
+  currentFiber.memoizedProps = { ...currentFiber.memoizedProps };
+  if (currentFiber.tag === 14 || currentFiber.tag === 15) {
+    const pendingProps = {
+      ...currentFiber.pendingProps,
+      __bippyConditionalHookUpdate: ++scheduledUpdateVersion,
+    };
+    currentFiber.pendingProps = pendingProps;
+    if (currentFiber.alternate) currentFiber.alternate.pendingProps = pendingProps;
+  }
+  scheduleUpdate(currentFiber);
+};
+
+const getCurrentFiberBranch = (fiber: Fiber): Fiber => {
+  let root = fiber;
+  while (root.return) root = root.return;
+  if (
+    typeof root.stateNode === "object" &&
+    root.stateNode !== null &&
+    Reflect.get(root.stateNode, "current") === root
+  ) {
+    return fiber;
+  }
+  return fiber.alternate ?? fiber;
+};
+
+const getRenderFrameForScope = (
+  scope: ConditionalHookScope,
+): ConditionalRenderFrame | undefined => {
+  for (const runtime of runtimes) {
+    const fiber = runtime.activeFiber;
+    if (!fiber) continue;
+    const activeScope =
+      scopeByFiber.get(fiber) ?? (fiber.alternate ? scopeByFiber.get(fiber.alternate) : undefined);
+    if (activeScope === scope) return renderFrameByFiber.get(fiber);
+  }
+  return undefined;
+};
+
+const enqueueRenderPhaseUpdate = (
+  frame: ConditionalRenderFrame,
+  key: PropertyKey,
+  action: unknown,
+): void => {
+  const updates = frame.renderPhaseUpdates.get(key);
+  if (updates) updates.push(action);
+  else frame.renderPhaseUpdates.set(key, [action]);
+};
+
+const areDependenciesEqual = (
+  previousDependencies: readonly unknown[] | undefined,
+  nextDependencies: readonly unknown[] | undefined,
+): boolean => {
+  if (!previousDependencies || !nextDependencies) return false;
+  if (previousDependencies.length !== nextDependencies.length) return false;
+  return previousDependencies.every((dependency, index) =>
+    Object.is(dependency, nextDependencies[index]),
+  );
+};
+
+const runEffectCleanup = (cell: ConditionalEffectCell): void => {
+  const cleanup = cell.cleanup;
+  cell.cleanup = undefined;
+  cleanup?.();
+};
+
+const flushPassiveEffects = (): void => {
+  didSchedulePassiveEffects = false;
+  for (const invoke of pendingPassiveEffects.splice(0)) invoke();
+};
+
+const schedulePassiveEffect = (invoke: () => void): void => {
+  pendingPassiveEffects.push(invoke);
+  if (didSchedulePassiveEffects) return;
+  didSchedulePassiveEffects = true;
+  queueMicrotask(flushPassiveEffects);
+};
+
+const startEffect = (
+  scope: ConditionalHookScope,
+  key: PropertyKey,
+  cell: ConditionalEffectCell,
+  create: ConditionalEffectRegistration["create"],
+): void => {
+  const version = ++cell.version;
+  const invoke = (): void => {
+    if (scope.didUnmount || scope.effects.get(key) !== cell || cell.version !== version) return;
+    cell.cleanup = create() || undefined;
+  };
+  if (cell.kind !== "effect") {
+    invoke();
+  } else {
+    schedulePassiveEffect(invoke);
+  }
+};
+
+const isStrictEffectsFiber = (fiber: Fiber): boolean => (fiber.mode & 0b0010000) !== 0;
+
+const getVisibilityState = (fiber: Fiber): ConditionalVisibilityState => {
+  let layoutEffectsHidden = false;
+  let passiveEffectsHidden = false;
+  let ancestor = fiber.return;
+  while (ancestor) {
+    if (ancestor.tag === 22 && ancestor.memoizedState !== null) {
+      layoutEffectsHidden = true;
+    }
+    if (ancestor.tag === 31 && ancestor.memoizedProps.mode === "hidden") {
+      layoutEffectsHidden = true;
+      passiveEffectsHidden = true;
+    }
+    ancestor = ancestor.return;
+  }
+  return { layoutEffectsHidden, passiveEffectsHidden };
+};
+
+const reconnectEffects = (scope: ConditionalHookScope, kind: ConditionalEffectKind): void => {
+  for (const [key, cell] of scope.effects) {
+    if (cell.kind === kind || (kind === "layout-effect" && cell.kind === "insertion-effect")) {
+      startEffect(scope, key, cell, cell.create);
+    }
+  }
+};
+
+const disconnectEffects = (scope: ConditionalHookScope, kind: ConditionalEffectKind): void => {
+  for (const cell of scope.effects.values()) {
+    if (cell.kind === kind || (kind === "layout-effect" && cell.kind === "insertion-effect")) {
+      runEffectCleanup(cell);
+    }
+  }
+};
+
+const updateScopeVisibility = (scope: ConditionalHookScope): void => {
+  associateScopeWithFiber(scope, getCurrentFiberBranch(scope.fiber));
+  const visibility = getVisibilityState(scope.fiber);
+  const shouldDisconnectLayoutEffects = visibility.layoutEffectsHidden;
+  const shouldDisconnectPassiveEffects = visibility.passiveEffectsHidden;
+
+  if (shouldDisconnectLayoutEffects !== scope.layoutEffectsDisconnected) {
+    scope.layoutEffectsDisconnected = shouldDisconnectLayoutEffects;
+    if (shouldDisconnectLayoutEffects) disconnectEffects(scope, "layout-effect");
+    else reconnectEffects(scope, "layout-effect");
+  }
+  if (shouldDisconnectPassiveEffects !== scope.passiveEffectsDisconnected) {
+    scope.passiveEffectsDisconnected = shouldDisconnectPassiveEffects;
+    if (shouldDisconnectPassiveEffects) disconnectEffects(scope, "effect");
+    else reconnectEffects(scope, "effect");
+  }
+};
+
+const applyRenderPhaseUpdates = (frame: ConditionalRenderFrame): boolean => {
+  let didStateChange = false;
+  for (const [key, actions] of frame.renderPhaseUpdates) {
+    const cell = frame.cells.get(key) ?? frame.scope.cells.get(key);
+    if (!cell || (cell.kind !== "state" && cell.kind !== "reducer")) continue;
+    let nextValue = cell.value;
+    for (const action of actions) {
+      if (cell.kind === "state") {
+        nextValue = typeof action === "function" ? action(nextValue) : action;
+      } else {
+        const reducer = frame.reducerOverrides.get(key) ?? cell.reducer;
+        nextValue = reducer(nextValue, action);
+      }
+    }
+    if (Object.is(cell.value, nextValue)) continue;
+    cell.value = nextValue;
+    didStateChange = true;
+  }
+  return didStateChange;
+};
+
+const commitRenderFrame = (
+  frame: ConditionalRenderFrame,
+  pendingInsertionEffects: Array<[ConditionalHookScope, PropertyKey, ConditionalEffectCell]>,
+  pendingLayoutEffects: Array<[ConditionalHookScope, PropertyKey, ConditionalEffectCell]>,
+  pendingStrictLayoutEffects: Array<[ConditionalHookScope, PropertyKey, ConditionalEffectCell]>,
+  pendingStrictPassiveEffects: Array<[ConditionalHookScope, PropertyKey, ConditionalEffectCell]>,
+): void => {
+  const { effects, scope } = frame;
+  scopes.add(scope);
+  associateScopeWithFiber(scope, frame.fiber);
+  for (const [key, kind] of frame.hookKinds) scope.hookKinds.set(key, kind);
+  for (const [key, cell] of frame.cells) {
+    const previousCell = scope.cells.get(key);
+    if (
+      previousCell?.kind === "reducer" &&
+      cell.kind === "reducer" &&
+      previousCell.dispatch === cell.dispatch
+    ) {
+      previousCell.value = cell.value;
+    } else {
+      scope.cells.set(key, cell);
+    }
+  }
+  for (const [key, reducer] of frame.reducerOverrides) {
+    const cell = scope.cells.get(key);
+    if (cell?.kind === "reducer") {
+      cell.reducer = reducer;
+      const actionCount = frame.reducerActionCounts.get(key) ?? 0;
+      if (actionCount > 0) cell.pendingActions.splice(0, actionCount);
+    }
+  }
+  const isInitialCommit = !scope.didCommit;
+  scope.didCommit = true;
+
+  if (applyRenderPhaseUpdates(frame)) {
+    queueMicrotask(() => scheduleScopeUpdate(scope));
+    return;
+  }
+
+  for (const [key, cell] of scope.effects) {
+    if (effects.has(key)) continue;
+    runEffectCleanup(cell);
+    scope.effects.delete(key);
+  }
+
+  const changedEffects: Array<[PropertyKey, ConditionalEffectCell]> = [];
+  for (const [key, registration] of effects) {
+    const previousCell = scope.effects.get(key);
+    if (
+      previousCell &&
+      previousCell.kind === registration.kind &&
+      areDependenciesEqual(previousCell.dependencies, registration.dependencies)
+    ) {
+      previousCell.create = registration.create;
+      continue;
+    }
+    if (previousCell) runEffectCleanup(previousCell);
+    const cell: ConditionalEffectCell = {
+      cleanup: undefined,
+      create: registration.create,
+      dependencies: registration.dependencies,
+      kind: registration.kind,
+      version: previousCell?.version ?? 0,
+    };
+    scope.effects.set(key, cell);
+    changedEffects.push([key, cell]);
+  }
+
+  const visibility = getVisibilityState(scope.fiber);
+  const areLayoutEffectsHidden = visibility.layoutEffectsHidden;
+  const arePassiveEffectsHidden = visibility.passiveEffectsHidden;
+  for (const [key, cell] of changedEffects) {
+    if (cell.kind !== "effect" && areLayoutEffectsHidden) continue;
+    if (cell.kind === "effect" && arePassiveEffectsHidden) continue;
+    if (cell.kind === "insertion-effect") {
+      pendingInsertionEffects.push([scope, key, cell]);
+    } else if (cell.kind === "layout-effect") {
+      pendingLayoutEffects.push([scope, key, cell]);
+    } else {
+      startEffect(scope, key, cell, cell.create);
+    }
+  }
+
+  if (isInitialCommit && isStrictEffectsFiber(frame.fiber)) {
+    const layoutEffects = areLayoutEffectsHidden
+      ? []
+      : changedEffects.filter(([, cell]) => cell.kind === "layout-effect");
+    for (const [key, cell] of layoutEffects) {
+      pendingStrictLayoutEffects.push([scope, key, cell]);
+    }
+    const passiveEffects = arePassiveEffectsHidden
+      ? []
+      : changedEffects.filter(([, cell]) => cell.kind === "effect");
+    for (const [key, cell] of passiveEffects) {
+      pendingStrictPassiveEffects.push([scope, key, cell]);
+    }
+  }
+};
+
+const commitRoot = (root: FiberRoot): void => {
+  flushPassiveEffects();
+  const pendingInsertionEffects: Array<[ConditionalHookScope, PropertyKey, ConditionalEffectCell]> =
+    [];
+  const pendingLayoutEffects: Array<[ConditionalHookScope, PropertyKey, ConditionalEffectCell]> =
+    [];
+  const pendingStrictLayoutEffects: Array<
+    [ConditionalHookScope, PropertyKey, ConditionalEffectCell]
+  > = [];
+  const pendingStrictPassiveEffects: Array<
+    [ConditionalHookScope, PropertyKey, ConditionalEffectCell]
+  > = [];
+  traverseFiber(root.current, (fiber) => {
+    let frame = renderFrameByFiber.get(fiber);
+    if (!frame) {
+      const scope =
+        scopeByFiber.get(fiber) ??
+        (fiber.alternate ? scopeByFiber.get(fiber.alternate) : undefined);
+      if (scope && didFiberRender(fiber)) {
+        frame = {
+          callCounts: new Map(),
+          cells: new Map(),
+          effects: new Map(),
+          fiber,
+          hookKinds: new Map(),
+          reducerActionCounts: new Map(),
+          reducerOverrides: new Map(),
+          replayedCells: new Set(),
+          renderPhaseUpdates: new Map(),
+          scope,
+        };
+      }
+    }
+    if (!frame) return;
+    renderFrameByFiber.delete(fiber);
+    commitRenderFrame(
+      frame,
+      pendingInsertionEffects,
+      pendingLayoutEffects,
+      pendingStrictLayoutEffects,
+      pendingStrictPassiveEffects,
+    );
+  });
+  for (const [scope, key, cell] of pendingInsertionEffects) {
+    startEffect(scope, key, cell, cell.create);
+  }
+  for (const [scope, key, cell] of pendingLayoutEffects) {
+    startEffect(scope, key, cell, cell.create);
+  }
+  if (pendingStrictLayoutEffects.length > 0 || pendingStrictPassiveEffects.length > 0) {
+    queueMicrotask(() => {
+      for (const [, , cell] of pendingStrictLayoutEffects) runEffectCleanup(cell);
+      for (const [, , cell] of pendingStrictPassiveEffects) runEffectCleanup(cell);
+      for (const [scope, key, cell] of pendingStrictLayoutEffects) {
+        startEffect(scope, key, cell, cell.create);
+      }
+      for (const [scope, key, cell] of pendingStrictPassiveEffects) {
+        startEffect(scope, key, cell, cell.create);
+      }
+    });
+  }
+  for (const scope of scopes) updateScopeVisibility(scope);
+};
+
+const disposeScope = (scope: ConditionalHookScope): void => {
+  if (scope.didUnmount) return;
+  scope.didUnmount = true;
+  for (const cell of scope.effects.values()) runEffectCleanup(cell);
+  scope.effects.clear();
+  scope.cells.clear();
+  scope.hookKinds.clear();
+  scopeByFiber.delete(scope.fiber);
+  renderFrameByFiber.delete(scope.fiber);
+  if (scope.fiber.alternate) {
+    scopeByFiber.delete(scope.fiber.alternate);
+    renderFrameByFiber.delete(scope.fiber.alternate);
+  }
+  scopes.delete(scope);
+};
+
+const unmountFiber = (fiber: Fiber): void => {
+  const scope =
+    scopeByFiber.get(fiber) ?? (fiber.alternate ? scopeByFiber.get(fiber.alternate) : undefined);
+  if (scope) disposeScope(scope);
+};
+
+const installAvailableRenderers = (options: ConditionalHooksOptions): void => {
+  for (const renderer of getRDTHook().renderers.values()) installRenderer(renderer, options);
+};
+
+export const installConditionalHooks = (
+  options: ConditionalHooksOptions = {},
+): ConditionalHooksInstallation => {
+  if (installation) {
+    installAvailableRenderers(options);
+    return installation;
+  }
+
+  const unsubscribeInstrumentation = instrument({
+    name: "bippy-conditional-hooks",
+    onActive: () => installAvailableRenderers(options),
+    onCommitFiberRoot: (_rendererId, root) => commitRoot(root),
+    onCommitFiberUnmount: (_rendererId, fiber) => unmountFiber(fiber),
+  });
+  const unsubscribeRendererInject = onRendererInject((renderer) =>
+    installRenderer(renderer, options),
+  );
+  installAvailableRenderers(options);
+
+  let didUnsubscribe = false;
+  const unsubscribe = createUnsubscribe(() => {
+    if (didUnsubscribe) return;
+    didUnsubscribe = true;
+    unsubscribeRendererInject();
+    unsubscribeInstrumentation();
+    for (const scope of scopes) disposeScope(scope);
+    for (const runtime of runtimes) restoreRuntime(runtime);
+    renderingRuntime = null;
+    if (installation === unsubscribe) installation = null;
+  });
+
+  Object.defineProperty(unsubscribe, "supportedRenderers", {
+    configurable: true,
+    get: () => runtimes.size,
+  });
+  if (!isConditionalHooksInstallation(unsubscribe)) {
+    throw new Error("Failed to install conditional hooks.");
+  }
+  installation = unsubscribe;
+  return unsubscribe;
+};
+
+export const useConditionalHooks = (): void => {
+  const fiber = useFiber();
+  const [, scheduleUpdate] = useReducer(incrementVersion, 0);
+  const runtime = renderingRuntime;
+  if (!fiber || !runtime) {
+    throw new Error("Conditional hooks require an installed client renderer.");
+  }
+  runtime.scheduleUpdate = () => scheduleUpdate();
+  beginRender(runtime, fiber);
+};
+
+const ensureInstalled = (): void => {
+  if (!installation) installConditionalHooks();
+};
+
+const readStateCell = <State>(
+  key: PropertyKey,
+  initialState: State | (() => State),
+): [State, ConditionalStateSetter<State>] => {
+  ensureInstalled();
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "state");
+  let cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (!cell) {
+    const stateCell: ConditionalStateCell = {
+      dispatch: (action) => {
+        if (scope.didUnmount) return;
+        const renderFrame = getRenderFrameForScope(scope);
+        if (renderFrame) {
+          enqueueRenderPhaseUpdate(renderFrame, key, action);
+          return;
+        }
+        if (scope.cells.get(key) !== stateCell) return;
+        const nextValue = typeof action === "function" ? action(stateCell.value) : action;
+        if (typeof action === "function" && (scope.fiber.mode & 0b0001000) !== 0) {
+          action(stateCell.value);
+        }
+        if (Object.is(stateCell.value, nextValue)) return;
+        stateCell.value = nextValue;
+        scheduleScopeUpdate(scope);
+      },
+      kind: "state",
+      value:
+        typeof initialState === "function"
+          ? Reflect.apply(initialState, undefined, [])
+          : initialState,
+    };
+    cell = stateCell;
+    frame.cells.set(key, cell);
+  } else if (frame.replayedCells.delete(key) && typeof initialState === "function") {
+    Reflect.apply(initialState, undefined, []);
+  }
+  if (cell.kind !== "state") throw new Error(`Conditional hook key ${String(key)} is not state.`);
+  return [cell.value, cell.dispatch] as [State, ConditionalStateSetter<State>];
+};
+
+const readReducerCell = <State, Action, InitialState>(
+  key: PropertyKey,
+  reducer: (state: State, action: Action) => State,
+  initialState: InitialState,
+  initialize?: (initialState: InitialState) => State,
+): [State, ConditionalReducerDispatcher<Action>] => {
+  ensureInstalled();
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "reducer");
+  let cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (!cell) {
+    const reducerCell: ConditionalReducerCell = {
+      dispatch: (action) => {
+        if (scope.didUnmount) return;
+        const renderFrame = getRenderFrameForScope(scope);
+        if (renderFrame) {
+          enqueueRenderPhaseUpdate(renderFrame, key, action);
+          return;
+        }
+        if (scope.cells.get(key) !== reducerCell) return;
+        reducerCell.pendingActions.push(action);
+        scheduleScopeUpdate(scope);
+      },
+      kind: "reducer",
+      pendingActions: [],
+      reducer: (state, action) => reducer(state as State, action as Action),
+      value: initialize ? initialize(initialState) : initialState,
+    };
+    cell = reducerCell;
+    frame.cells.set(key, cell);
+  } else if (frame.replayedCells.delete(key) && initialize) {
+    initialize(initialState);
+  }
+  if (cell.kind !== "reducer") {
+    throw new Error(`Conditional hook key ${String(key)} is not a reducer.`);
+  }
+  const currentReducer = (state: unknown, action: unknown): unknown =>
+    reducer(state as State, action as Action);
+  frame.reducerOverrides.set(key, currentReducer);
+  if (cell.pendingActions.length > 0) {
+    let nextValue = cell.value;
+    for (const action of cell.pendingActions) nextValue = currentReducer(nextValue, action);
+    const renderedCell: ConditionalReducerCell = {
+      ...cell,
+      value: nextValue,
+    };
+    frame.cells.set(key, renderedCell);
+    frame.reducerActionCounts.set(key, cell.pendingActions.length);
+    cell = renderedCell;
+  }
+  return [cell.value, cell.dispatch] as [State, ConditionalReducerDispatcher<Action>];
+};
+
+const readRefCell = <Value>(key: PropertyKey, initialValue: Value): ConditionalRef<Value> => {
+  ensureInstalled();
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "ref");
+  let cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (!cell) {
+    cell = {
+      kind: "ref",
+      value: { current: initialValue },
+    };
+    frame.cells.set(key, cell);
+  }
+  if (cell.kind !== "ref") throw new Error(`Conditional hook key ${String(key)} is not a ref.`);
+  return cell.value as ConditionalRef<Value>;
+};
+
+const readMemoCell = <Value>(
+  key: PropertyKey,
+  create: () => Value,
+  dependencies?: readonly unknown[],
+): Value => {
+  ensureInstalled();
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "memo");
+  const cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (cell?.kind === "memo" && frame.replayedCells.delete(key)) {
+    create();
+    return cell.value as Value;
+  }
+  if (cell?.kind === "memo" && areDependenciesEqual(cell.dependencies, dependencies)) {
+    return cell.value as Value;
+  }
+  if (cell && cell.kind !== "memo") {
+    throw new Error(`Conditional hook key ${String(key)} is not memoized.`);
+  }
+  const value = create();
+  frame.cells.set(key, {
+    dependencies,
+    kind: "memo",
+    value,
+  });
+  return value;
+};
+
+const readValueCell = <Value>(
+  key: PropertyKey,
+  kind: ConditionalValueCell["kind"],
+  value: Value,
+): Value => {
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, kind);
+  const cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (cell && cell.kind !== kind) {
+    throw new Error(`Conditional hook key ${String(key)} is not ${kind}.`);
+  }
+  if (!cell || !Object.is(cell.value, value)) {
+    frame.cells.set(key, { kind, value });
+  }
+  return value;
+};
+
+const readIdCell = (key: PropertyKey): string => {
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "id");
+  let cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (!cell) {
+    cell = { kind: "id", value: `:bippy-${(++conditionalId).toString(32)}:` };
+    frame.cells.set(key, cell);
+  }
+  if (cell.kind !== "id" || typeof cell.value !== "string") {
+    throw new Error(`Conditional hook key ${String(key)} is not an id.`);
+  }
+  return cell.value;
+};
+
+const readTransitionCell = (key: PropertyKey): [boolean, (callback: () => void) => void] => {
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "transition");
+  let cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (!cell) {
+    const transitionCell: ConditionalTransitionCell = {
+      isPending: false,
+      kind: "transition",
+      startTransition: (callback) => {
+        const currentCell = scope.cells.get(key);
+        if (scope.didUnmount || currentCell?.kind !== "transition") return;
+        currentCell.isPending = true;
+        scheduleScopeUpdate(scope);
+        try {
+          callback();
+        } finally {
+          queueMicrotask(() => {
+            const latestCell = scope.cells.get(key);
+            if (scope.didUnmount || latestCell?.kind !== "transition") return;
+            latestCell.isPending = false;
+            scheduleScopeUpdate(scope);
+          });
+        }
+      },
+    };
+    cell = transitionCell;
+    frame.cells.set(key, cell);
+  }
+  if (cell.kind !== "transition") {
+    throw new Error(`Conditional hook key ${String(key)} is not a transition.`);
+  }
+  return [cell.isPending, cell.startTransition];
+};
+
+const readExternalStoreCell = (
+  key: PropertyKey,
+  subscribe: (onStoreChange: () => void) => unknown,
+  getSnapshot: () => unknown,
+): unknown => {
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "external-store");
+  const value = getSnapshot();
+  const previousCell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (previousCell && previousCell.kind !== "external-store") {
+    throw new Error(`Conditional hook key ${String(key)} is not an external store.`);
+  }
+  frame.cells.set(key, { getSnapshot, kind: "external-store", value });
+  registerEffect(
+    key,
+    "effect",
+    () => {
+      const checkForUpdates = (): void => {
+        const cell = scope.cells.get(key);
+        if (scope.didUnmount || cell?.kind !== "external-store") return;
+        const nextValue = cell.getSnapshot();
+        if (Object.is(cell.value, nextValue)) return;
+        cell.value = nextValue;
+        scheduleScopeUpdate(scope);
+      };
+      checkForUpdates();
+      const unsubscribe = subscribe(checkForUpdates);
+      return typeof unsubscribe === "function"
+        ? () => {
+            Reflect.apply(unsubscribe, undefined, []);
+          }
+        : undefined;
+    },
+    [subscribe],
+    "external-store",
+  );
+  return value;
+};
+
+const readCacheRefreshCell = (key: PropertyKey): (() => void) => {
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "cache-refresh");
+  let cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (!cell) {
+    cell = {
+      kind: "cache-refresh",
+      refresh: () => scheduleScopeUpdate(scope),
+    };
+    frame.cells.set(key, cell);
+  }
+  if (cell.kind !== "cache-refresh") {
+    throw new Error(`Conditional hook key ${String(key)} is not a cache refresh.`);
+  }
+  return cell.refresh;
+};
+
+const readOptimisticCell = (
+  key: PropertyKey,
+  passthrough: unknown,
+  reducer: (state: unknown, action: unknown) => unknown,
+): [unknown, (action: unknown) => void] => {
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "optimistic");
+  let cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (!cell) {
+    const optimisticCell: ConditionalOptimisticCell = {
+      dispatch: (action) => {
+        const currentCell = scope.cells.get(key);
+        if (scope.didUnmount || currentCell?.kind !== "optimistic") return;
+        currentCell.value = currentCell.reducer(currentCell.value, action);
+        currentCell.isPending = true;
+        scheduleScopeUpdate(scope);
+      },
+      isPending: false,
+      kind: "optimistic",
+      reducer,
+      value: passthrough,
+    };
+    cell = optimisticCell;
+    frame.cells.set(key, cell);
+  }
+  if (cell.kind !== "optimistic") {
+    throw new Error(`Conditional hook key ${String(key)} is not optimistic state.`);
+  }
+  if (scope.cells.get(key) === cell && cell.isPending) {
+    cell = { ...cell, isPending: false, reducer };
+    frame.cells.set(key, cell);
+  } else if (!Object.is(cell.value, passthrough)) {
+    cell = { ...cell, reducer, value: passthrough };
+    frame.cells.set(key, cell);
+  } else {
+    cell.reducer = reducer;
+  }
+  return [cell.value, cell.dispatch];
+};
+
+const readActionStateCell = (
+  key: PropertyKey,
+  action: (previousState: unknown, payload: unknown) => unknown,
+  initialState: unknown,
+): [unknown, (payload: unknown) => void, boolean] => {
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "action-state");
+  let cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (!cell) {
+    const actionStateCell: ConditionalActionStateCell = {
+      action,
+      dispatch: (payload) => {
+        const currentCell = scope.cells.get(key);
+        if (scope.didUnmount || currentCell?.kind !== "action-state") return;
+        const dispatchedAction = currentCell.action;
+        currentCell.pendingActions++;
+        currentCell.isPending = true;
+        scheduleScopeUpdate(scope);
+        currentCell.pendingAction = currentCell.pendingAction
+          .catch(() => {})
+          .then(async () => {
+            const latestCell = scope.cells.get(key);
+            if (scope.didUnmount || latestCell?.kind !== "action-state") return;
+            latestCell.value = await dispatchedAction(latestCell.value, payload);
+          })
+          .finally(() => {
+            const latestCell = scope.cells.get(key);
+            if (scope.didUnmount || latestCell?.kind !== "action-state") return;
+            latestCell.pendingActions--;
+            latestCell.isPending = latestCell.pendingActions > 0;
+            scheduleScopeUpdate(scope);
+          });
+      },
+      isPending: false,
+      kind: "action-state",
+      pendingAction: Promise.resolve(),
+      pendingActions: 0,
+      value: initialState,
+    };
+    cell = actionStateCell;
+    frame.cells.set(key, cell);
+  }
+  if (cell.kind !== "action-state") {
+    throw new Error(`Conditional hook key ${String(key)} is not action state.`);
+  }
+  if (cell.action !== action) {
+    cell = { ...cell, action };
+    frame.cells.set(key, cell);
+  }
+  return [cell.value, cell.dispatch, cell.isPending];
+};
+
+const readEffectEventCell = (
+  key: PropertyKey,
+  callback: (...arguments_: unknown[]) => unknown,
+): ((...arguments_: unknown[]) => unknown) => {
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "effect-event");
+  let cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (!cell) {
+    const effectEventCell: ConditionalEffectEventCell = {
+      callback,
+      event: (...arguments_) => {
+        if (getRenderFrameForScope(scope)) {
+          throw new Error(
+            "A function returned by useEffectEvent cannot be called during rendering.",
+          );
+        }
+        const currentCell = scope.cells.get(key);
+        if (currentCell?.kind !== "effect-event") return undefined;
+        return currentCell.callback(...arguments_);
+      },
+      kind: "effect-event",
+    };
+    cell = effectEventCell;
+    frame.cells.set(key, cell);
+  }
+  if (cell.kind !== "effect-event") {
+    throw new Error(`Conditional hook key ${String(key)} is not an effect event.`);
+  }
+  if (cell.callback !== callback) {
+    cell = { ...cell, callback };
+    frame.cells.set(key, cell);
+  }
+  return cell.event;
+};
+
+const readMemoCacheCell = (key: PropertyKey, size: number): unknown[] => {
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, "memo-cache");
+  let cell = frame.cells.get(key) ?? scope.cells.get(key);
+  if (!cell) {
+    cell = {
+      kind: "memo-cache",
+      value: Array.from({ length: size }, () => Symbol.for("react.memo_cache_sentinel")),
+    };
+    frame.cells.set(key, cell);
+  }
+  if (cell.kind !== "memo-cache" || !Array.isArray(cell.value)) {
+    throw new Error(`Conditional hook key ${String(key)} is not a memo cache.`);
+  }
+  return cell.value;
+};
+
+const setImperativeHandle = (
+  ref: unknown,
+  create: (...arguments_: unknown[]) => unknown,
+): (() => void) | void => {
+  const value = create();
+  if (typeof ref === "function") {
+    const cleanup = ref(value);
+    return typeof cleanup === "function" ? cleanup : () => ref(null);
+  }
+  if (typeof ref !== "object" || ref === null || !("current" in ref)) return;
+  Reflect.set(ref, "current", value);
+  return () => {
+    Reflect.set(ref, "current", null);
+  };
+};
+
+const registerEffect = (
+  key: PropertyKey,
+  kind: ConditionalEffectKind,
+  create: () => (() => void) | void,
+  dependencies?: readonly unknown[],
+  hookKind: ConditionalHookKind = kind,
+): void => {
+  ensureInstalled();
+  const { frame, scope } = getScope();
+  registerHookKind(frame, scope, key, hookKind);
+  frame.effects.set(key, {
+    create,
+    dependencies,
+    kind,
+  });
+};

--- a/examples/conditional-hooks/src/main.tsx
+++ b/examples/conditional-hooks/src/main.tsx
@@ -1,0 +1,19 @@
+import "bippy/install-hook-only";
+
+import { installConditionalHooks } from "./conditional-hooks";
+import "./styles.css";
+
+installConditionalHooks();
+
+const { createRoot } = await import("react-dom/client");
+const { StrictMode } = await import("react");
+const { default: App } = await import("./app");
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("Root element was not found.");
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/conditional-hooks/src/styles.css
+++ b/examples/conditional-hooks/src/styles.css
@@ -1,0 +1,108 @@
+:root {
+  color: #f5f2e9;
+  background: #11100e;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at top left, rgb(230 171 79 / 18%), transparent 36rem), #11100e;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+main {
+  width: min(46rem, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 12vh 0 4rem;
+}
+
+h1 {
+  max-width: 12ch;
+  margin: 0;
+  font-size: clamp(2.7rem, 8vw, 5.8rem);
+  font-weight: 600;
+  letter-spacing: -0.065em;
+  line-height: 0.94;
+}
+
+.eyebrow {
+  color: #e6ab4f;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+}
+
+.lede {
+  max-width: 38rem;
+  margin: 2rem 0;
+  color: #aaa398;
+  font-size: 1.1rem;
+  line-height: 1.65;
+}
+
+.toggle,
+.counter,
+.empty {
+  border: 1px solid #39352f;
+  border-radius: 1rem;
+  background: rgb(255 255 255 / 4%);
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.2rem;
+  cursor: pointer;
+}
+
+.toggle input {
+  width: 1.15rem;
+  height: 1.15rem;
+  accent-color: #e6ab4f;
+}
+
+.counter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  align-items: center;
+  margin-top: 1rem;
+  padding: 1.2rem;
+}
+
+.counter button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.7rem 1rem;
+  color: #211a10;
+  background: #e6ab4f;
+  cursor: pointer;
+}
+
+.counter span {
+  color: #bbb4a8;
+}
+
+.empty {
+  margin: 1rem 0 0;
+  padding: 1.2rem;
+  color: #817a70;
+}
+
+.note {
+  color: #817a70;
+  font-size: 0.9rem;
+}

--- a/examples/conditional-hooks/tsconfig.json
+++ b/examples/conditional-hooks/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "ESNext.Disposable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/conditional-hooks/vite.config.ts
+++ b/examples/conditional-hooks/vite.config.ts
@@ -1,0 +1,139 @@
+import type { PluginObj, PluginPass } from "@babel/core";
+import * as babelTypes from "@babel/types";
+import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite-plus";
+
+interface ConditionalHooksPluginState extends PluginPass {
+  didTransformComponent: boolean;
+}
+
+const isComponentName = (name: string): boolean => /^[A-Z]/.test(name);
+
+const isComponentWrapper = (expression: babelTypes.Expression): boolean => {
+  if (babelTypes.isIdentifier(expression)) {
+    return expression.name === "memo" || expression.name === "forwardRef";
+  }
+  return (
+    babelTypes.isMemberExpression(expression) &&
+    babelTypes.isIdentifier(expression.property) &&
+    (expression.property.name === "memo" || expression.property.name === "forwardRef")
+  );
+};
+
+const getComponentFunction = (
+  expression: babelTypes.Expression | null | undefined,
+): babelTypes.ArrowFunctionExpression | babelTypes.FunctionExpression | undefined => {
+  if (
+    babelTypes.isArrowFunctionExpression(expression) ||
+    babelTypes.isFunctionExpression(expression)
+  ) {
+    return expression;
+  }
+  if (
+    !babelTypes.isCallExpression(expression) ||
+    !babelTypes.isExpression(expression.callee) ||
+    !isComponentWrapper(expression.callee)
+  ) {
+    return undefined;
+  }
+  const component = expression.arguments[0];
+  return babelTypes.isExpression(component) ? getComponentFunction(component) : undefined;
+};
+
+const injectConditionalHooks = (
+  functionNode:
+    | babelTypes.ArrowFunctionExpression
+    | babelTypes.FunctionDeclaration
+    | babelTypes.FunctionExpression,
+): void => {
+  const initializeHooks = babelTypes.expressionStatement(
+    babelTypes.callExpression(babelTypes.identifier("__useConditionalHooks"), []),
+  );
+  if (babelTypes.isBlockStatement(functionNode.body)) {
+    functionNode.body.body.unshift(initializeHooks);
+    return;
+  }
+  functionNode.body = babelTypes.blockStatement([
+    initializeHooks,
+    babelTypes.returnStatement(functionNode.body),
+  ]);
+};
+
+const conditionalHooksPlugin = (): PluginObj<ConditionalHooksPluginState> => ({
+  name: "conditional-hooks",
+  pre() {
+    this.didTransformComponent = false;
+  },
+  visitor: {
+    FunctionDeclaration(path, state) {
+      const name = path.node.id?.name;
+      if (!name || !isComponentName(name)) return;
+      injectConditionalHooks(path.node);
+      state.didTransformComponent = true;
+    },
+    VariableDeclarator(path, state) {
+      if (!babelTypes.isIdentifier(path.node.id) || !isComponentName(path.node.id.name)) return;
+      const componentFunction = getComponentFunction(path.node.init);
+      if (!componentFunction) return;
+      injectConditionalHooks(componentFunction);
+      state.didTransformComponent = true;
+    },
+    ExportDefaultDeclaration(path, state) {
+      const declaration = path.node.declaration;
+      if (
+        !babelTypes.isArrowFunctionExpression(declaration) &&
+        !babelTypes.isFunctionDeclaration(declaration) &&
+        !babelTypes.isFunctionExpression(declaration)
+      ) {
+        return;
+      }
+      if (babelTypes.isFunctionDeclaration(declaration) && declaration.id) return;
+      injectConditionalHooks(declaration);
+      state.didTransformComponent = true;
+    },
+    Program: {
+      exit(path, state) {
+        if (!state.didTransformComponent) return;
+        path.node.body.unshift(
+          babelTypes.importDeclaration(
+            [
+              babelTypes.importSpecifier(
+                babelTypes.identifier("__useConditionalHooks"),
+                babelTypes.identifier("useConditionalHooks"),
+              ),
+            ],
+            babelTypes.stringLiteral("/src/conditional-hooks"),
+          ),
+        );
+      },
+    },
+  },
+});
+
+export default defineConfig({
+  plugins: [
+    react({
+      babel: {
+        plugins: [conditionalHooksPlugin],
+      },
+    }),
+  ],
+  resolve: {
+    alias: [
+      {
+        find: "bippy/install-hook-only",
+        replacement: fileURLToPath(
+          new URL("../../packages/bippy/src/install-hook-only.ts", import.meta.url),
+        ),
+      },
+      {
+        find: "bippy",
+        replacement: fileURLToPath(new URL("../../packages/bippy/src/index.ts", import.meta.url)),
+      },
+    ],
+  },
+  test: {
+    environment: "happy-dom",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,43 @@ importers:
         specifier: latest
         version: 0.2.9(@types/node@20.19.34)(@vitest/coverage-istanbul@4.1.10(vitest@4.1.10))(esbuild@0.27.4)(happy-dom@15.11.7)(jiti@2.7.0)(msw@2.12.10(@types/node@20.19.34)(typescript@5.9.3))(publint@0.3.18)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
 
+  examples/conditional-hooks:
+    dependencies:
+      bippy:
+        specifier: workspace:*
+        version: link:../../packages/bippy
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@babel/core':
+        specifier: ^7.28.0
+        version: 7.29.0
+      '@babel/types':
+        specifier: ^7.28.0
+        version: 7.29.7
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^5.0.0
+        version: 5.2.0(vite@7.3.6(@types/node@20.19.34)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      happy-dom:
+        specifier: ^15.11.7
+        version: 15.11.7
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+      vite-plus:
+        specifier: latest
+        version: 0.2.9(@types/node@20.19.34)(@vitest/coverage-istanbul@4.1.10(vitest@4.1.10))(esbuild@0.27.4)(happy-dom@15.11.7)(jiti@2.7.0)(msw@2.12.10(@types/node@20.19.34)(typescript@5.9.3))(publint@0.3.18)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+
   packages/bippy:
     dependencies:
       '@types/react-reconciler':
@@ -597,10 +634,6 @@ packages:
     resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -1014,10 +1047,6 @@ packages:
 
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -8053,7 +8082,7 @@ snapshots:
 
   '@babel/code-frame@7.27.1':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -8191,8 +8220,6 @@ snapshots:
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -8659,11 +8686,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-
   '@babel/types@7.29.7':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
@@ -8716,7 +8738,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.5
 
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
@@ -8725,7 +8747,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.4
+      semver: 7.8.5
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -8782,7 +8804,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.4
+      semver: 7.8.5
 
   '@changesets/get-release-plan@4.0.15':
     dependencies:
@@ -9101,7 +9123,7 @@ snapshots:
       resolve: 1.22.11
       resolve-from: 5.0.0
       resolve.exports: 2.0.3
-      semver: 7.7.4
+      semver: 7.8.5
       send: 0.19.2
       slugify: 1.6.6
       source-map-support: 0.5.21
@@ -9175,7 +9197,7 @@ snapshots:
       resolve: 1.22.11
       resolve-from: 5.0.0
       resolve.exports: 2.0.3
-      semver: 7.7.4
+      semver: 7.8.5
       send: 0.19.2
       slugify: 1.6.6
       source-map-support: 0.5.21
@@ -9910,7 +9932,7 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -10865,7 +10887,7 @@ snapshots:
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.7
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       ansis: 4.2.0
       babel-dead-code-elimination: 1.0.12
       diff: 8.0.3
@@ -10887,7 +10909,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.14
       '@tanstack/router-generator': 1.167.18
       '@tanstack/router-plugin': 1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(esbuild@0.27.4)(rollup@4.59.0)(vite@7.3.6(@types/node@20.19.34)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -10954,7 +10976,7 @@ snapshots:
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -13994,7 +14016,7 @@ snapshots:
   magicast@0.5.3:
     dependencies:
       '@babel/parser': 7.29.7
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -14161,12 +14183,12 @@ snapshots:
 
   metro-runtime@0.83.3:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       flow-enums-runtime: 0.0.6
 
   metro-runtime@0.83.4:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       flow-enums-runtime: 0.0.6
 
   metro-source-map@0.83.3:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 nodeLinker: hoisted
 
 packages:
+  - "examples/*"
   - "packages/*"
   - "packages/e2e/fixtures/*"


### PR DESCRIPTION
## Summary

- add a standalone `examples/conditional-hooks` workspace without changing Bippy's package API
- automatically initialize function components with a Vite transform
- virtualize the full React client hook dispatcher by Fiber and callsite
- use Bippy's exported `useFiber`, `instrument`, `onRendererInject`, `getRDTHook`, and Fiber traversal APIs
- include an interactive state/effect demo and development/production integration coverage

## Why

React's native hook list is positional, so skipping a hook changes the meaning of every later slot. This example keeps two stable bootstrap hooks at the start of transformed function components, then stores later hook state by Fiber and callsite. It demonstrates the experiment without adding experimental behavior to Bippy's package surface.

## Validation

- `pnpm --filter @bippy/example-conditional-hooks test`
- `pnpm --filter @bippy/example-conditional-hooks test:production`
- `pnpm --filter @bippy/example-conditional-hooks typecheck`
- `pnpm --filter @bippy/example-conditional-hooks build`
- `pnpm exec vp check ...`
- `git diff --check`