### PR TITLE
Add an interactive product guide for bippy

### DIFF
--- a/packages/website/app/guide/page.tsx
+++ b/packages/website/app/guide/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import { GuideEssay } from "@/components/guide/guide-essay";
+
+export const metadata: Metadata = {
+  title: "What bippy actually is",
+  description:
+    "A hands-on guide to React Fiber, the DevTools hook, render instrumentation, and bippy.",
+};
+
+const GuidePage = () => <GuideEssay />;
+
+export default GuidePage;

--- a/packages/website/app/page.tsx
+++ b/packages/website/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import NextLink from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { FiberTreeDemo } from "@/components/fiber-tree";
@@ -32,7 +33,7 @@ const Page = () => (
       <Button
         size="lg"
         nativeButton={false}
-        render={<a href="/guide">Get started</a>}
+        render={<NextLink href="/guide">Get started</NextLink>}
       />
       <Button
         variant="secondary"

--- a/packages/website/app/page.tsx
+++ b/packages/website/app/page.tsx
@@ -32,7 +32,7 @@ const Page = () => (
       <Button
         size="lg"
         nativeButton={false}
-        render={<a href="https://github.com/aidenybai/bippy#install-bippy">Get started</a>}
+        render={<a href="/guide">Get started</a>}
       />
       <Button
         variant="secondary"

--- a/packages/website/components/guide/guide-chapters.tsx
+++ b/packages/website/components/guide/guide-chapters.tsx
@@ -1,0 +1,276 @@
+import NextLink from "next/link";
+import type { ReactNode } from "react";
+
+interface GuideChapter {
+  content: ReactNode;
+  eyebrow: string;
+  title: string;
+}
+
+interface InlineCodeProps {
+  children: ReactNode;
+}
+
+interface GuideCodeProps {
+  children: string;
+  label?: string;
+}
+
+const InlineCode = ({ children }: InlineCodeProps) => (
+  <code className="rounded bg-white/7 px-1.5 py-0.5 font-mono text-[0.82em] text-[#61dafb]">
+    {children}
+  </code>
+);
+
+const GuideCode = ({ children, label }: GuideCodeProps) => (
+  <div className="my-7 overflow-hidden rounded-xl border border-white/10 bg-[#14161b]">
+    {label ? (
+      <div className="border-b border-white/8 px-4 py-2.5 font-mono text-xs text-white/35">
+        {label}
+      </div>
+    ) : null}
+    <pre className="overflow-x-auto p-4 font-mono text-xs leading-5 text-white/65">
+      <code>{children}</code>
+    </pre>
+  </div>
+);
+
+export const guideChapters: GuideChapter[] = [
+  {
+    eyebrow: "Part 1 · two trees",
+    title: "The DOM is the output. Fiber is the story.",
+    content: (
+      <>
+        <p>
+          The browser gives you a tree of elements: div, button, span. Useful, but flat. By the time
+          React hands work to the DOM, component identity is gone.
+        </p>
+        <p>
+          React keeps a second tree in memory. A Fiber can tell you the component type, its props
+          and state, who owns it, the host element it produced, and what work is pending.
+        </p>
+        <p>
+          Switch the lab between DOM and Fiber. Same interface. One is a soup of tags; the other
+          still knows <InlineCode>Avatar</InlineCode> and <InlineCode>FollowButton</InlineCode>.
+        </p>
+      </>
+    ),
+  },
+  {
+    eyebrow: "Part 2 · the handshake",
+    title: "React already phones home.",
+    content: (
+      <>
+        <p>
+          React renderers announce themselves through{" "}
+          <InlineCode>__REACT_DEVTOOLS_GLOBAL_HOOK__</InlineCode>. React DevTools installs that
+          hook, then React calls <InlineCode>inject()</InlineCode> and reports every committed root.
+        </p>
+        <p>
+          bippy pretends to be DevTools. It installs a compatible hook, keeps the original
+          callbacks working, and listens to the same commit stream.
+        </p>
+        <p>
+          Timing is the whole trick: the hook must exist before the renderer loads. In Next 15.3+,
+          use <InlineCode>instrumentation-client.ts</InlineCode>. In Vite, make bippy the first
+          import in the entry file.
+        </p>
+        <GuideCode label="instrumentation-client.ts">{`import "bippy";`}</GuideCode>
+      </>
+    ),
+  },
+  {
+    eyebrow: "Part 3 · one subscription",
+    title: "instrument() is the front door.",
+    content: (
+      <>
+        <p>
+          Register the lifecycle events you care about. bippy patches each hook event once, then
+          fans it out to every subscriber, so tools compose instead of wrapping each other forever.
+        </p>
+        <p>
+          <InlineCode>onActive</InlineCode> tells you a renderer arrived.{" "}
+          <InlineCode>onCommitFiberRoot</InlineCode> gives you the committed tree. The return value
+          removes exactly your handlers.
+        </p>
+        <GuideCode label="observe-commits.ts">{`const unsubscribe = instrument({
+  name: "my-render-tool",
+  onActive: () => setReady(true),
+  onCommitFiberRoot: (_, root) => inspect(root),
+});
+
+unsubscribe();`}</GuideCode>
+      </>
+    ),
+  },
+  {
+    eyebrow: "Part 4 · only the work",
+    title: "A Fiber exists. That does not mean it rendered.",
+    content: (
+      <>
+        <p>
+          <InlineCode>traverseFiber()</InlineCode> is a structural search. It walks children or
+          owners until your selector returns true. Great for finding a host node. Wrong for
+          answering “what rerendered in this commit?”
+        </p>
+        <p>
+          <InlineCode>traverseRenderedFibers()</InlineCode> compares the current and previous trees
+          for the same root. Its callback receives only work from that commit, tagged{" "}
+          <InlineCode>mount</InlineCode>, <InlineCode>update</InlineCode>, or{" "}
+          <InlineCode>unmount</InlineCode>.
+        </p>
+        <p>Keep passing the same root. That identity is how bippy remembers the previous tree.</p>
+      </>
+    ),
+  },
+  {
+    eyebrow: "Part 5 · the payoff",
+    title: "Build a tiny react-scan.",
+    content: (
+      <>
+        <p>
+          Now the pieces cash out. Subscribe to commits. Visit the Fibers that updated. Walk down
+          to each component&apos;s nearest host Fiber. Outline its DOM node.
+        </p>
+        <p>
+          Click either card in the lab. That cyan box is the entire idea behind a render
+          visualizer—minus the production polish.
+        </p>
+        <GuideCode label="mini-scan.ts">{`import {
+  instrument,
+  isCompositeFiber,
+  isHostFiber,
+  traverseFiber,
+  traverseRenderedFibers,
+} from "bippy";
+
+instrument({
+  onCommitFiberRoot: (_, root) => {
+    traverseRenderedFibers(root, (fiber, phase) => {
+      if (phase !== "update" || !isCompositeFiber(fiber)) return;
+
+      const host = traverseFiber(fiber, (candidate) =>
+        isHostFiber(candidate),
+      );
+
+      if (host?.stateNode instanceof HTMLElement) {
+        host.stateNode.style.outline = "2px solid #61dafb";
+      }
+    });
+  },
+});`}</GuideCode>
+      </>
+    ),
+  },
+  {
+    eyebrow: "Part 6 · reverse lookup",
+    title: "Go from a DOM node back into React.",
+    content: (
+      <>
+        <p>
+          <InlineCode>getFiber(element)</InlineCode> crosses from the rendered host instance into
+          React&apos;s tree. That is the move behind the picker on the bippy homepage.
+        </p>
+        <p>
+          From there, <InlineCode>getLatestFiber()</InlineCode> follows a retained Fiber to its
+          current version. <InlineCode>isHostFiber()</InlineCode> and{" "}
+          <InlineCode>isCompositeFiber()</InlineCode> tell host output from user components.{" "}
+          <InlineCode>getDisplayName()</InlineCode> turns the type into a human label.
+        </p>
+        <p>
+          Inside your own component, <InlineCode>useFiber()</InlineCode> skips the DOM lookup and
+          returns the calling component&apos;s Fiber. On the server it returns undefined: there is
+          no client Fiber there to inspect.
+        </p>
+      </>
+    ),
+  },
+  {
+    eyebrow: "Part 7 · what this unlocks",
+    title: "The inspector is a demo. The library is the engine.",
+    content: (
+      <>
+        <p>
+          react-scan uses this territory to show expensive renders. This site&apos;s picker starts
+          from a DOM element and finds the component that owns it. Source tooling can reconstruct
+          owner stacks and connect components back to files.
+        </p>
+        <p>
+          You can build performance overlays, visual editors, test recorders, accessibility
+          auditors, component explorers, or the debugging tool React never shipped.
+        </p>
+        <p>
+          The shared move is always the same: take React&apos;s private graph and turn it into a
+          small, useful signal.
+        </p>
+      </>
+    ),
+  },
+  {
+    eyebrow: "Part 8 · read before shipping",
+    title: "This is an escape hatch, not a contract.",
+    content: (
+      <>
+        <p>
+          Production dead-code elimination changes React&apos;s shape. A hook loaded after React
+          misses the renderer handshake. Real DevTools or refresh runtimes may already own the
+          hook. React Server Components do not create client Fibers on the server.
+        </p>
+        <p>
+          And the big one: React internals change. Work tags move. fields change meaning. Renderers
+          disagree. bippy absorbs a lot of that drift, but it cannot make private APIs public.
+        </p>
+        <p className="border-l border-orange-300/30 pl-4 text-orange-100/50">
+          Pin versions, test production builds, fail soft, and never make app correctness depend on
+          an inspection tool.
+        </p>
+      </>
+    ),
+  },
+  {
+    eyebrow: "Recap · five moves",
+    title: "You do not need all of Fiber. You need the right doorway.",
+    content: (
+      <>
+        <ol className="space-y-3 pl-0">
+          {[
+            "Load bippy before React so the DevTools hook is ready.",
+            "Use instrument() to subscribe without fighting other tools.",
+            "Use traverseRenderedFibers() for mount, update, and unmount work.",
+            "Use getFiber() and traverseFiber() to cross between DOM and React.",
+            "Treat every result as private internals that can change.",
+          ].map((recapItem, recapIndex) => (
+            <li key={recapItem} className="flex gap-3">
+              <span className="font-mono text-xs text-[#61dafb]">0{recapIndex + 1}</span>
+              <span>{recapItem}</span>
+            </li>
+          ))}
+        </ol>
+        <p>
+          That is bippy: a library for listening to React&apos;s private renderer protocol, walking
+          Fiber, and building tools on top.
+        </p>
+        <div className="flex flex-wrap gap-x-5 gap-y-2 pt-3 text-sm">
+          <a
+            className="text-[#61dafb] underline decoration-[#61dafb]/25 underline-offset-4 transition hover:text-white"
+            href="https://github.com/aidenybai/bippy#api-reference"
+          >
+            API reference ↗
+          </a>
+          <NextLink
+            className="text-[#61dafb] underline decoration-[#61dafb]/25 underline-offset-4 transition hover:text-white"
+            href="/llms.txt"
+          >
+            llms.txt ↗
+          </NextLink>
+          <a
+            className="text-[#61dafb] underline decoration-[#61dafb]/25 underline-offset-4 transition hover:text-white"
+            href="https://npmjs.com/package/bippy"
+          >
+            npm ↗
+          </a>
+        </div>
+      </>
+    ),
+  },
+];

--- a/packages/website/components/guide/guide-chapters.tsx
+++ b/packages/website/components/guide/guide-chapters.tsx
@@ -1,6 +1,8 @@
 import NextLink from "next/link";
 import type { ReactNode } from "react";
 
+import { Link } from "@/components/ui/link";
+
 interface GuideChapter {
   content: ReactNode;
   eyebrow: string;
@@ -17,19 +19,19 @@ interface GuideCodeProps {
 }
 
 const InlineCode = ({ children }: InlineCodeProps) => (
-  <code className="rounded bg-white/7 px-1.5 py-0.5 font-mono text-[0.82em] text-[#61dafb]">
+  <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
     {children}
   </code>
 );
 
 const GuideCode = ({ children, label }: GuideCodeProps) => (
-  <div className="my-7 overflow-hidden rounded-xl border border-white/10 bg-[#14161b]">
+  <div className="my-6 overflow-hidden rounded-lg border border-border bg-card">
     {label ? (
-      <div className="border-b border-white/8 px-4 py-2.5 font-mono text-xs text-white/35">
+      <div className="border-b border-border px-3 py-2 font-mono text-xs text-muted-foreground">
         {label}
       </div>
     ) : null}
-    <pre className="overflow-x-auto p-4 font-mono text-xs leading-5 text-white/65">
+    <pre className="overflow-x-auto bg-muted/30 p-3 font-mono text-xs leading-5 text-muted-foreground">
       <code>{children}</code>
     </pre>
   </div>
@@ -37,64 +39,57 @@ const GuideCode = ({ children, label }: GuideCodeProps) => (
 
 export const guideChapters: GuideChapter[] = [
   {
-    eyebrow: "Part 1 · two trees",
-    title: "The DOM is the output. Fiber is the story.",
+    eyebrow: "Part 1",
+    title: "React keeps two trees.",
     content: (
       <>
         <p>
-          The browser gives you a tree of elements: div, button, span. Useful, but flat. By the time
-          React hands work to the DOM, component identity is gone.
+          The DOM is the host output: elements, attributes, and text. It does not know that a button
+          came from <InlineCode>FollowButton</InlineCode>.
         </p>
         <p>
-          React keeps a second tree in memory. A Fiber can tell you the component type, its props
-          and state, who owns it, the host element it produced, and what work is pending.
+          Fiber keeps that missing structure. Each node can point to a component, its props and
+          state, its owner, and the host element it produced.
         </p>
         <p>
-          Switch the lab between DOM and Fiber. Same interface. One is a soup of tags; the other
-          still knows <InlineCode>Avatar</InlineCode> and <InlineCode>FollowButton</InlineCode>.
+          Toggle the example. The DOM has tags. Fiber still has component identity and render data.
         </p>
       </>
     ),
   },
   {
-    eyebrow: "Part 2 · the handshake",
-    title: "React already phones home.",
+    eyebrow: "Part 2",
+    title: "bippy pretends to be React DevTools.",
     content: (
       <>
         <p>
-          React renderers announce themselves through{" "}
-          <InlineCode>__REACT_DEVTOOLS_GLOBAL_HOOK__</InlineCode>. React DevTools installs that
-          hook, then React calls <InlineCode>inject()</InlineCode> and reports every committed root.
+          React renderers report to <InlineCode>__REACT_DEVTOOLS_GLOBAL_HOOK__</InlineCode>. They
+          call <InlineCode>inject()</InlineCode> once, then send committed roots to that hook.
         </p>
+        <p>bippy installs a compatible hook and listens to the same events.</p>
         <p>
-          bippy pretends to be DevTools. It installs a compatible hook, keeps the original callbacks
-          working, and listens to the same commit stream.
-        </p>
-        <p>
-          Timing is the whole trick: the hook must exist before the renderer loads. In Next 15.3+,
-          use <InlineCode>instrumentation-client.ts</InlineCode>. In Vite, make bippy the first
-          import in the entry file.
+          It has to load first. In Next 15.3+, use{" "}
+          <InlineCode>instrumentation-client.ts</InlineCode>. In Vite, import bippy before React.
         </p>
         <GuideCode label="instrumentation-client.ts">{`import "bippy";`}</GuideCode>
       </>
     ),
   },
   {
-    eyebrow: "Part 3 · one subscription",
-    title: "instrument() is the front door.",
+    eyebrow: "Part 3",
+    title: "Subscribe with instrument().",
     content: (
       <>
         <p>
-          Register the lifecycle events you care about. bippy patches each hook event once, then
-          fans it out to every subscriber, so tools compose instead of wrapping each other forever.
+          <InlineCode>instrument()</InlineCode> registers renderer lifecycle handlers. Calls
+          compose, so several tools can listen without replacing each other.
         </p>
         <p>
-          <InlineCode>onActive</InlineCode> tells you a renderer arrived.{" "}
-          <InlineCode>onCommitFiberRoot</InlineCode> gives you the committed tree. The return value
-          removes exactly your handlers.
+          <InlineCode>onActive</InlineCode> runs when a renderer connects.{" "}
+          <InlineCode>onCommitFiberRoot</InlineCode> receives each committed root. The returned
+          function removes that subscription.
         </p>
         <GuideCode label="observe-commits.ts">{`const unsubscribe = instrument({
-  name: "my-render-tool",
   onActive: () => setReady(true),
   onCommitFiberRoot: (_, root) => inspect(root),
 });
@@ -104,38 +99,32 @@ unsubscribe();`}</GuideCode>
     ),
   },
   {
-    eyebrow: "Part 4 · only the work",
-    title: "A Fiber exists. That does not mean it rendered.",
+    eyebrow: "Part 4",
+    title: "A Fiber can exist without rendering.",
     content: (
       <>
         <p>
-          <InlineCode>traverseFiber()</InlineCode> is a structural search. It walks children or
-          owners until your selector returns true. Great for finding a host node. Wrong for
-          answering “what rerendered in this commit?”
+          <InlineCode>traverseFiber()</InlineCode> searches the tree. Use it to find children,
+          siblings, or owners.
         </p>
         <p>
-          <InlineCode>traverseRenderedFibers()</InlineCode> compares the current and previous trees
-          for the same root. Its callback receives only work from that commit, tagged{" "}
-          <InlineCode>mount</InlineCode>, <InlineCode>update</InlineCode>, or{" "}
-          <InlineCode>unmount</InlineCode>.
+          <InlineCode>traverseRenderedFibers()</InlineCode> answers a different question: what
+          mounted, updated, or unmounted in this commit?
         </p>
-        <p>Keep passing the same root. That identity is how bippy remembers the previous tree.</p>
+        <p>Pass the same root each time so bippy can compare the current and previous trees.</p>
       </>
     ),
   },
   {
-    eyebrow: "Part 5 · the payoff",
-    title: "Build a tiny react-scan.",
+    eyebrow: "Part 5",
+    title: "A small render scanner.",
     content: (
       <>
         <p>
-          Now the pieces cash out. Subscribe to commits. Visit the Fibers that updated. Walk down to
-          each component&apos;s nearest host Fiber. Outline its DOM node.
+          Listen for a commit, visit the Fibers that updated, find each component&apos;s nearest
+          host Fiber, then mark its DOM node.
         </p>
-        <p>
-          Click either card in the lab. That cyan box is the entire idea behind a render
-          visualizer—minus the production polish.
-        </p>
+        <p>The example on the right is the basic loop behind a render visualizer.</p>
         <GuideCode label="mini-scan.ts">{`import {
   instrument,
   isCompositeFiber,
@@ -154,7 +143,7 @@ instrument({
       );
 
       if (host?.stateNode instanceof HTMLElement) {
-        host.stateNode.style.outline = "2px solid #61dafb";
+        host.stateNode.style.outline = "2px solid currentColor";
       }
     });
   },
@@ -163,112 +152,85 @@ instrument({
     ),
   },
   {
-    eyebrow: "Part 6 · reverse lookup",
-    title: "Go from a DOM node back into React.",
+    eyebrow: "Part 6",
+    title: "Go from the DOM back into React.",
     content: (
       <>
         <p>
-          <InlineCode>getFiber(element)</InlineCode> crosses from the rendered host instance into
-          React&apos;s tree. That is the move behind the picker on the bippy homepage.
+          <InlineCode>getFiber(element)</InlineCode> returns the Fiber for a host instance. The
+          picker on the homepage starts there.
         </p>
         <p>
-          From there, <InlineCode>getLatestFiber()</InlineCode> follows a retained Fiber to its
-          current version. <InlineCode>isHostFiber()</InlineCode> and{" "}
-          <InlineCode>isCompositeFiber()</InlineCode> tell host output from user components.{" "}
-          <InlineCode>getDisplayName()</InlineCode> turns the type into a human label.
+          <InlineCode>getLatestFiber()</InlineCode> follows a retained Fiber to its current version.{" "}
+          <InlineCode>isHostFiber()</InlineCode> and <InlineCode>isCompositeFiber()</InlineCode>{" "}
+          identify the node kind. <InlineCode>getDisplayName()</InlineCode> gives it a useful name.
         </p>
         <p>
-          Inside your own component, <InlineCode>useFiber()</InlineCode> skips the DOM lookup and
-          returns the calling component&apos;s Fiber. On the server it returns undefined: there is
-          no client Fiber there to inspect.
+          Inside a component, <InlineCode>useFiber()</InlineCode> returns that component&apos;s
+          Fiber. It returns undefined during server rendering.
         </p>
       </>
     ),
   },
   {
-    eyebrow: "Part 7 · what this unlocks",
-    title: "The inspector is a demo. The library is the engine.",
+    eyebrow: "Part 7",
+    title: "The inspector is only one use.",
     content: (
       <>
         <p>
-          react-scan uses this territory to show expensive renders. This site&apos;s picker starts
-          from a DOM element and finds the component that owns it. Source tooling can reconstruct
-          owner stacks and connect components back to files.
+          react-scan uses renderer data to find expensive renders. This site uses it to inspect a
+          selected element. Source tooling can rebuild owner stacks and connect components to files.
         </p>
         <p>
-          You can build performance overlays, visual editors, test recorders, accessibility
-          auditors, component explorers, or the debugging tool React never shipped.
-        </p>
-        <p>
-          The shared move is always the same: take React&apos;s private graph and turn it into a
-          small, useful signal.
+          The same primitives work for visual editors, test recorders, accessibility tools, and
+          component explorers.
         </p>
       </>
     ),
   },
   {
-    eyebrow: "Part 8 · read before shipping",
-    title: "This is an escape hatch, not a contract.",
+    eyebrow: "Part 8",
+    title: "These are private internals.",
     content: (
       <>
         <p>
-          Production dead-code elimination changes React&apos;s shape. A hook loaded after React
-          misses the renderer handshake. Real DevTools or refresh runtimes may already own the hook.
-          React Server Components do not create client Fibers on the server.
+          A late hook can miss the renderer. Production builds can change what is available. React
+          DevTools and refresh runtimes may already own the hook. Server Components have no client
+          Fiber on the server.
         </p>
+        <p>React internals also change between releases. bippy cannot turn them into a contract.</p>
         <p>
-          And the big one: React internals change. Work tags move. fields change meaning. Renderers
-          disagree. bippy absorbs a lot of that drift, but it cannot make private APIs public.
-        </p>
-        <p className="border-l border-orange-300/30 pl-4 text-orange-100/50">
-          Pin versions, test production builds, fail soft, and never make app correctness depend on
-          an inspection tool.
+          Pin versions, test production builds, fail safely, and do not make app correctness depend
+          on inspection.
         </p>
       </>
     ),
   },
   {
-    eyebrow: "Recap · five moves",
-    title: "You do not need all of Fiber. You need the right doorway.",
+    eyebrow: "Recap",
+    title: "The useful parts.",
     content: (
       <>
-        <ol className="space-y-3 pl-0">
-          {[
-            "Load bippy before React so the DevTools hook is ready.",
-            "Use instrument() to subscribe without fighting other tools.",
-            "Use traverseRenderedFibers() for mount, update, and unmount work.",
-            "Use getFiber() and traverseFiber() to cross between DOM and React.",
-            "Treat every result as private internals that can change.",
-          ].map((recapItem, recapIndex) => (
-            <li key={recapItem} className="flex gap-3">
-              <span className="font-mono text-xs text-[#61dafb]">0{recapIndex + 1}</span>
-              <span>{recapItem}</span>
-            </li>
-          ))}
-        </ol>
+        <ul className="list-disc space-y-2 pl-5">
+          <li>Load bippy before React.</li>
+          <li>Use instrument() for renderer events.</li>
+          <li>Use traverseRenderedFibers() for commit work.</li>
+          <li>Use getFiber() to cross from a host node into React.</li>
+          <li>Use traverseFiber() to search the tree.</li>
+        </ul>
         <p>
-          That is bippy: a library for listening to React&apos;s private renderer protocol, walking
-          Fiber, and building tools on top.
+          bippy is a small library for reading React&apos;s renderer protocol and Fiber tree. The
+          README has the full API.
         </p>
-        <div className="flex flex-wrap gap-x-5 gap-y-2 pt-3 text-sm">
-          <a
-            className="text-[#61dafb] underline decoration-[#61dafb]/25 underline-offset-4 transition hover:text-white"
-            href="https://github.com/aidenybai/bippy#api-reference"
-          >
-            API reference ↗
-          </a>
+        <div className="flex flex-wrap gap-x-4 gap-y-2 pt-2">
+          <Link href="https://github.com/aidenybai/bippy#api-reference">API reference</Link>
           <NextLink
-            className="text-[#61dafb] underline decoration-[#61dafb]/25 underline-offset-4 transition hover:text-white"
+            className="rounded-sm text-muted-foreground underline decoration-border underline-offset-4 transition-colors hover:text-foreground"
             href="/llms.txt"
           >
-            llms.txt ↗
+            llms.txt
           </NextLink>
-          <a
-            className="text-[#61dafb] underline decoration-[#61dafb]/25 underline-offset-4 transition hover:text-white"
-            href="https://npmjs.com/package/bippy"
-          >
-            npm ↗
-          </a>
+          <Link href="https://npmjs.com/package/bippy">npm</Link>
         </div>
       </>
     ),

--- a/packages/website/components/guide/guide-chapters.tsx
+++ b/packages/website/components/guide/guide-chapters.tsx
@@ -67,8 +67,8 @@ export const guideChapters: GuideChapter[] = [
           hook, then React calls <InlineCode>inject()</InlineCode> and reports every committed root.
         </p>
         <p>
-          bippy pretends to be DevTools. It installs a compatible hook, keeps the original
-          callbacks working, and listens to the same commit stream.
+          bippy pretends to be DevTools. It installs a compatible hook, keeps the original callbacks
+          working, and listens to the same commit stream.
         </p>
         <p>
           Timing is the whole trick: the hook must exist before the renderer loads. In Next 15.3+,
@@ -129,8 +129,8 @@ unsubscribe();`}</GuideCode>
     content: (
       <>
         <p>
-          Now the pieces cash out. Subscribe to commits. Visit the Fibers that updated. Walk down
-          to each component&apos;s nearest host Fiber. Outline its DOM node.
+          Now the pieces cash out. Subscribe to commits. Visit the Fibers that updated. Walk down to
+          each component&apos;s nearest host Fiber. Outline its DOM node.
         </p>
         <p>
           Click either card in the lab. That cyan box is the entire idea behind a render
@@ -213,8 +213,8 @@ instrument({
       <>
         <p>
           Production dead-code elimination changes React&apos;s shape. A hook loaded after React
-          misses the renderer handshake. Real DevTools or refresh runtimes may already own the
-          hook. React Server Components do not create client Fibers on the server.
+          misses the renderer handshake. Real DevTools or refresh runtimes may already own the hook.
+          React Server Components do not create client Fibers on the server.
         </p>
         <p>
           And the big one: React internals change. Work tags move. fields change meaning. Renderers

--- a/packages/website/components/guide/guide-essay.tsx
+++ b/packages/website/components/guide/guide-essay.tsx
@@ -29,7 +29,7 @@ const GuideSection = ({
   <section
     ref={sectionReference}
     className={cn(
-      "flex min-h-[72dvh] scroll-mt-12 flex-col justify-center py-16 transition-opacity duration-300 lg:min-h-[78dvh]",
+      "flex min-h-[64dvh] scroll-mt-12 flex-col justify-center py-16 transition-opacity duration-300",
       isActive ? "lg:opacity-100" : "lg:opacity-60",
     )}
     data-guide-section={sectionIndex}
@@ -40,7 +40,7 @@ const GuideSection = ({
       {children}
     </div>
     <div className="mt-8 lg:hidden">
-      <GuideShowcase activeSectionIndex={sectionIndex} compact />
+      <GuideShowcase activeSectionIndex={sectionIndex} />
     </div>
   </section>
 );
@@ -117,7 +117,7 @@ export const GuideEssay = () => {
           <section
             ref={getSectionReference(0)}
             className={cn(
-              "flex min-h-[68dvh] flex-col justify-center py-16 transition-opacity duration-300",
+              "flex min-h-[58dvh] flex-col justify-center py-16 transition-opacity duration-300",
               activeSectionIndex === 0 ? "lg:opacity-100" : "lg:opacity-60",
             )}
             data-guide-section="0"
@@ -142,7 +142,7 @@ export const GuideEssay = () => {
               The examples are scroll-synced on desktop and inline here.
             </p>
             <div className="mt-8 lg:hidden">
-              <GuideShowcase activeSectionIndex={0} compact />
+              <GuideShowcase activeSectionIndex={0} />
             </div>
           </section>
 

--- a/packages/website/components/guide/guide-essay.tsx
+++ b/packages/website/components/guide/guide-essay.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import Image from "next/image";
+import NextLink from "next/link";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 
+import { guideChapters } from "@/components/guide/guide-chapters";
 import { GuideShowcase } from "@/components/guide/guide-showcases";
 import { cn } from "@/lib/utils";
 
@@ -15,34 +17,6 @@ interface GuideSectionProps {
   title: string;
 }
 
-interface InlineCodeProps {
-  children: ReactNode;
-}
-
-interface GuideCodeProps {
-  children: string;
-  label?: string;
-}
-
-const InlineCode = ({ children }: InlineCodeProps) => (
-  <code className="rounded bg-white/7 px-1.5 py-0.5 font-mono text-[0.82em] text-[#61dafb]">
-    {children}
-  </code>
-);
-
-const GuideCode = ({ children, label }: GuideCodeProps) => (
-  <div className="my-7 overflow-hidden rounded-xl border border-white/10 bg-[#14161b]">
-    {label && (
-      <div className="border-b border-white/8 px-4 py-2.5 font-mono text-[10px] text-white/35">
-        {label}
-      </div>
-    )}
-    <pre className="overflow-x-auto p-4 font-mono text-[11px] leading-5 text-white/65">
-      <code>{children}</code>
-    </pre>
-  </div>
-);
-
 const GuideSection = ({
   children,
   eyebrow,
@@ -54,18 +28,18 @@ const GuideSection = ({
   <section
     ref={sectionReference}
     className={cn(
-      "flex min-h-[82vh] scroll-mt-12 flex-col justify-center py-20 transition-opacity duration-500 lg:min-h-[96vh] lg:py-28",
-      isActive ? "lg:opacity-100" : "lg:opacity-32",
+      "flex min-h-[82dvh] scroll-mt-12 flex-col justify-center py-20 transition-opacity duration-500 lg:min-h-[96dvh] lg:py-28",
+      isActive ? "lg:opacity-100" : "lg:opacity-[0.32]",
     )}
     data-guide-section={sectionIndex}
   >
-    <p className="mb-4 font-mono text-[10px] font-medium tracking-[0.2em] text-[#61dafb] uppercase">
+    <p className="mb-4 font-mono text-xs font-medium tracking-[0.12em] text-[#61dafb]">
       {eyebrow}
     </p>
     <h2 className="max-w-xl text-2xl font-medium tracking-[-0.025em] text-white sm:text-3xl">
       {title}
     </h2>
-    <div className="mt-6 max-w-xl space-y-5 text-[15px] leading-7 text-white/56">{children}</div>
+    <div className="mt-6 max-w-xl space-y-5 text-base leading-7 text-white/56">{children}</div>
     <div className="mt-10 lg:hidden">
       <GuideShowcase activeSectionIndex={sectionIndex} compact />
     </div>
@@ -127,12 +101,12 @@ export const GuideEssay = () => {
       <div className="mx-auto grid w-full max-w-[1536px] lg:grid-cols-[minmax(0,0.9fr)_minmax(34rem,1.1fr)]">
         <article className="px-6 sm:px-10 lg:px-14 xl:px-20">
           <header className="flex h-20 items-center justify-between">
-            <a className="flex items-center gap-2.5" href="/">
+            <NextLink className="flex items-center gap-2.5" href="/">
               <Image src="/icon.png" alt="" width={24} height={24} priority />
               <span className="text-sm font-medium tracking-tight text-white">bippy</span>
-            </a>
+            </NextLink>
             <a
-              className="font-mono text-[10px] tracking-[0.14em] text-white/35 uppercase transition hover:text-[#61dafb]"
+              className="font-mono text-xs tracking-[0.08em] text-white/35 transition hover:text-[#61dafb]"
               href="https://github.com/aidenybai/bippy"
             >
               GitHub ↗
@@ -142,12 +116,12 @@ export const GuideEssay = () => {
           <section
             ref={getSectionReference(0)}
             className={cn(
-              "flex min-h-[calc(100vh-5rem)] flex-col justify-center py-16 transition-opacity duration-500 lg:min-h-[calc(100vh-5rem)] lg:py-24",
-              activeSectionIndex === 0 ? "lg:opacity-100" : "lg:opacity-32",
+              "flex min-h-[calc(100dvh-5rem)] flex-col justify-center py-16 transition-opacity duration-500 lg:py-24",
+              activeSectionIndex === 0 ? "lg:opacity-100" : "lg:opacity-[0.32]",
             )}
             data-guide-section="0"
           >
-            <p className="mb-5 font-mono text-[10px] font-medium tracking-[0.2em] text-[#61dafb] uppercase">
+            <p className="mb-5 font-mono text-xs font-medium tracking-[0.12em] text-[#61dafb]">
               a field guide to React&apos;s other tree
             </p>
             <h1 className="max-w-2xl font-serif text-5xl leading-[0.98] font-normal tracking-[-0.045em] text-white sm:text-6xl xl:text-7xl">
@@ -155,7 +129,7 @@ export const GuideEssay = () => {
               <br />
               actually is.
             </h1>
-            <div className="mt-8 max-w-xl space-y-5 text-[15px] leading-7 text-white/58">
+            <div className="mt-8 max-w-xl space-y-5 text-base leading-7 text-white/58">
               <p>
                 Give me one render and I&apos;ll show you the component that made it, what it
                 received, and where React put it.
@@ -177,265 +151,28 @@ export const GuideEssay = () => {
             </div>
           </section>
 
-          <GuideSection
-            eyebrow="Part 1 · two trees"
-            isActive={activeSectionIndex === 1}
-            sectionIndex={1}
-            sectionReference={getSectionReference(1)}
-            title="The DOM is the output. Fiber is the story."
-          >
-            <p>
-              The browser gives you a tree of elements: div, button, span. Useful, but flat. By the
-              time React hands work to the DOM, component identity is gone.
-            </p>
-            <p>
-              React keeps a second tree in memory. A Fiber can tell you the component type, its
-              props and state, who owns it, the host element it produced, and what work is pending.
-            </p>
-            <p>
-              Switch the lab between DOM and Fiber. Same interface. One is a soup of tags; the
-              other still knows <InlineCode>Avatar</InlineCode> and{" "}
-              <InlineCode>FollowButton</InlineCode>.
-            </p>
-          </GuideSection>
+          {guideChapters.map((guideChapter, chapterIndex) => {
+            const sectionIndex = chapterIndex + 1;
 
-          <GuideSection
-            eyebrow="Part 2 · the handshake"
-            isActive={activeSectionIndex === 2}
-            sectionIndex={2}
-            sectionReference={getSectionReference(2)}
-            title="React already phones home."
-          >
-            <p>
-              React renderers announce themselves through{" "}
-              <InlineCode>__REACT_DEVTOOLS_GLOBAL_HOOK__</InlineCode>. React DevTools installs that
-              hook, then React calls <InlineCode>inject()</InlineCode> and reports every committed
-              root.
-            </p>
-            <p>
-              bippy pretends to be DevTools. It installs a compatible hook, keeps the original
-              callbacks working, and listens to the same commit stream.
-            </p>
-            <p>
-              Timing is the whole trick: the hook must exist before the renderer loads. In Next
-              15.3+, use <InlineCode>instrumentation-client.ts</InlineCode>. In Vite, make bippy the
-              first import in the entry file.
-            </p>
-            <GuideCode label="instrumentation-client.ts">{`import "bippy";`}</GuideCode>
-          </GuideSection>
-
-          <GuideSection
-            eyebrow="Part 3 · one subscription"
-            isActive={activeSectionIndex === 3}
-            sectionIndex={3}
-            sectionReference={getSectionReference(3)}
-            title="instrument() is the front door."
-          >
-            <p>
-              Register the lifecycle events you care about. bippy patches each hook event once,
-              then fans it out to every subscriber, so tools compose instead of wrapping each
-              other forever.
-            </p>
-            <p>
-              <InlineCode>onActive</InlineCode> tells you a renderer arrived.{" "}
-              <InlineCode>onCommitFiberRoot</InlineCode> gives you the committed tree. The return
-              value removes exactly your handlers.
-            </p>
-            <GuideCode label="observe-commits.ts">{`const unsubscribe = instrument({
-  name: "my-render-tool",
-  onActive: () => setReady(true),
-  onCommitFiberRoot: (_, root) => inspect(root),
-});
-
-unsubscribe();`}</GuideCode>
-          </GuideSection>
-
-          <GuideSection
-            eyebrow="Part 4 · only the work"
-            isActive={activeSectionIndex === 4}
-            sectionIndex={4}
-            sectionReference={getSectionReference(4)}
-            title="A Fiber exists. That does not mean it rendered."
-          >
-            <p>
-              <InlineCode>traverseFiber()</InlineCode> is a structural search. It walks children or
-              owners until your selector returns true. Great for finding a host node. Wrong for
-              answering “what rerendered in this commit?”
-            </p>
-            <p>
-              <InlineCode>traverseRenderedFibers()</InlineCode> compares the current and previous
-              trees for the same root. Its callback receives only work from that commit, tagged{" "}
-              <InlineCode>mount</InlineCode>, <InlineCode>update</InlineCode>, or{" "}
-              <InlineCode>unmount</InlineCode>.
-            </p>
-            <p>
-              Keep passing the same root. That identity is how bippy remembers the previous tree.
-            </p>
-          </GuideSection>
-
-          <GuideSection
-            eyebrow="Part 5 · the payoff"
-            isActive={activeSectionIndex === 5}
-            sectionIndex={5}
-            sectionReference={getSectionReference(5)}
-            title="Build a tiny react-scan."
-          >
-            <p>
-              Now the pieces cash out. Subscribe to commits. Visit the Fibers that updated. Walk
-              down to each component&apos;s nearest host Fiber. Outline its DOM node.
-            </p>
-            <p>
-              Click either card in the lab. That cyan box is the entire idea behind a render
-              visualizer—minus the production polish.
-            </p>
-            <GuideCode label="mini-scan.ts">{`import {
-  instrument,
-  isCompositeFiber,
-  isHostFiber,
-  traverseFiber,
-  traverseRenderedFibers,
-} from "bippy";
-
-instrument({
-  onCommitFiberRoot: (_, root) => {
-    traverseRenderedFibers(root, (fiber, phase) => {
-      if (phase !== "update" || !isCompositeFiber(fiber)) return;
-
-      const host = traverseFiber(fiber, (candidate) =>
-        isHostFiber(candidate),
-      );
-
-      if (host?.stateNode instanceof HTMLElement) {
-        host.stateNode.style.outline = "2px solid #61dafb";
-      }
-    });
-  },
-});`}</GuideCode>
-          </GuideSection>
-
-          <GuideSection
-            eyebrow="Part 6 · reverse lookup"
-            isActive={activeSectionIndex === 6}
-            sectionIndex={6}
-            sectionReference={getSectionReference(6)}
-            title="Go from a DOM node back into React."
-          >
-            <p>
-              <InlineCode>getFiber(element)</InlineCode> crosses from the rendered host instance
-              into React&apos;s tree. That is the move behind the picker on the bippy homepage.
-            </p>
-            <p>
-              From there, <InlineCode>getLatestFiber()</InlineCode> follows a retained Fiber to its
-              current version. <InlineCode>isHostFiber()</InlineCode> and{" "}
-              <InlineCode>isCompositeFiber()</InlineCode> tell host output from user components.{" "}
-              <InlineCode>getDisplayName()</InlineCode> turns the type into a human label.
-            </p>
-            <p>
-              Inside your own component, <InlineCode>useFiber()</InlineCode> skips the DOM lookup
-              and returns the calling component&apos;s Fiber. On the server it returns undefined:
-              there is no client Fiber there to inspect.
-            </p>
-          </GuideSection>
-
-          <GuideSection
-            eyebrow="Part 7 · what this unlocks"
-            isActive={activeSectionIndex === 7}
-            sectionIndex={7}
-            sectionReference={getSectionReference(7)}
-            title="The inspector is a demo. The library is the engine."
-          >
-            <p>
-              react-scan uses this territory to show expensive renders. This site&apos;s picker
-              starts from a DOM element and finds the component that owns it. Source tooling can
-              reconstruct owner stacks and connect components back to files.
-            </p>
-            <p>
-              You can build performance overlays, visual editors, test recorders, accessibility
-              auditors, component explorers, or the debugging tool React never shipped.
-            </p>
-            <p>
-              The shared move is always the same: take React&apos;s private graph and turn it into a
-              small, useful signal.
-            </p>
-          </GuideSection>
-
-          <GuideSection
-            eyebrow="Part 8 · read before shipping"
-            isActive={activeSectionIndex === 8}
-            sectionIndex={8}
-            sectionReference={getSectionReference(8)}
-            title="This is an escape hatch, not a contract."
-          >
-            <p>
-              Production dead-code elimination changes React&apos;s shape. A hook loaded after
-              React misses the renderer handshake. Real DevTools or refresh runtimes may already
-              own the hook. React Server Components do not create client Fibers on the server.
-            </p>
-            <p>
-              And the big one: React internals change. Work tags move. fields change meaning.
-              Renderers disagree. bippy absorbs a lot of that drift, but it cannot make private
-              APIs public.
-            </p>
-            <p className="border-l border-orange-300/30 pl-4 text-orange-100/50">
-              Pin versions, test production builds, fail soft, and never make app correctness
-              depend on an inspection tool.
-            </p>
-          </GuideSection>
-
-          <GuideSection
-            eyebrow="Recap · five moves"
-            isActive={activeSectionIndex === 9}
-            sectionIndex={9}
-            sectionReference={getSectionReference(9)}
-            title="You do not need all of Fiber. You need the right doorway."
-          >
-            <ol className="space-y-3 pl-0">
-              {[
-                "Load bippy before React so the DevTools hook is ready.",
-                "Use instrument() to subscribe without fighting other tools.",
-                "Use traverseRenderedFibers() for mount, update, and unmount work.",
-                "Use getFiber() and traverseFiber() to cross between DOM and React.",
-                "Treat every result as private internals that can change.",
-              ].map((recapItem, recapIndex) => (
-                <li key={recapItem} className="flex gap-3">
-                  <span className="font-mono text-[10px] text-[#61dafb]">
-                    0{recapIndex + 1}
-                  </span>
-                  <span>{recapItem}</span>
-                </li>
-              ))}
-            </ol>
-            <p>
-              That is bippy: a library for listening to React&apos;s private renderer protocol,
-              walking Fiber, and building tools on top.
-            </p>
-            <div className="flex flex-wrap gap-x-5 gap-y-2 pt-3 text-sm">
-              <a
-                className="text-[#61dafb] underline decoration-[#61dafb]/25 underline-offset-4 transition hover:text-white"
-                href="https://github.com/aidenybai/bippy#api-reference"
+            return (
+              <GuideSection
+                key={guideChapter.eyebrow}
+                eyebrow={guideChapter.eyebrow}
+                isActive={activeSectionIndex === sectionIndex}
+                sectionIndex={sectionIndex}
+                sectionReference={getSectionReference(sectionIndex)}
+                title={guideChapter.title}
               >
-                API reference ↗
-              </a>
-              <a
-                className="text-[#61dafb] underline decoration-[#61dafb]/25 underline-offset-4 transition hover:text-white"
-                href="/llms.txt"
-              >
-                llms.txt ↗
-              </a>
-              <a
-                className="text-[#61dafb] underline decoration-[#61dafb]/25 underline-offset-4 transition hover:text-white"
-                href="https://npmjs.com/package/bippy"
-              >
-                npm ↗
-              </a>
-            </div>
-          </GuideSection>
+                {guideChapter.content}
+              </GuideSection>
+            );
+          })}
 
-          <footer className="flex items-center justify-between border-t border-white/8 py-8 text-[11px] text-white/25">
+          <footer className="flex items-center justify-between border-t border-white/8 py-8 text-xs text-white/25">
             <span>bippy · React internals without the ceremony</span>
-            <a className="transition hover:text-white" href="/">
+            <NextLink className="transition hover:text-white" href="/">
               back to the inspector
-            </a>
+            </NextLink>
           </footer>
         </article>
 

--- a/packages/website/components/guide/guide-essay.tsx
+++ b/packages/website/components/guide/guide-essay.tsx
@@ -33,9 +33,7 @@ const GuideSection = ({
     )}
     data-guide-section={sectionIndex}
   >
-    <p className="mb-4 font-mono text-xs font-medium tracking-[0.12em] text-[#61dafb]">
-      {eyebrow}
-    </p>
+    <p className="mb-4 font-mono text-xs font-medium tracking-[0.12em] text-[#61dafb]">{eyebrow}</p>
     <h2 className="max-w-xl text-2xl font-medium tracking-[-0.025em] text-white sm:text-3xl">
       {title}
     </h2>

--- a/packages/website/components/guide/guide-essay.tsx
+++ b/packages/website/components/guide/guide-essay.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 
 import { guideChapters } from "@/components/guide/guide-chapters";
 import { GuideShowcase } from "@/components/guide/guide-showcases";
+import { Link } from "@/components/ui/link";
 import { cn } from "@/lib/utils";
 
 interface GuideSectionProps {
@@ -28,17 +29,17 @@ const GuideSection = ({
   <section
     ref={sectionReference}
     className={cn(
-      "flex min-h-[82dvh] scroll-mt-12 flex-col justify-center py-20 transition-opacity duration-500 lg:min-h-[96dvh] lg:py-28",
-      isActive ? "lg:opacity-100" : "lg:opacity-[0.32]",
+      "flex min-h-[72dvh] scroll-mt-12 flex-col justify-center py-16 transition-opacity duration-300 lg:min-h-[78dvh]",
+      isActive ? "lg:opacity-100" : "lg:opacity-60",
     )}
     data-guide-section={sectionIndex}
   >
-    <p className="mb-4 font-mono text-xs font-medium tracking-[0.12em] text-[#61dafb]">{eyebrow}</p>
-    <h2 className="max-w-xl text-2xl font-medium tracking-[-0.025em] text-white sm:text-3xl">
-      {title}
-    </h2>
-    <div className="mt-6 max-w-xl space-y-5 text-base leading-7 text-white/56">{children}</div>
-    <div className="mt-10 lg:hidden">
+    <p className="mb-3 text-xs font-medium text-muted-foreground">{eyebrow}</p>
+    <h2 className="max-w-lg text-2xl font-medium text-foreground">{title}</h2>
+    <div className="mt-4 max-w-lg space-y-4 text-sm leading-relaxed text-muted-foreground">
+      {children}
+    </div>
+    <div className="mt-8 lg:hidden">
       <GuideShowcase activeSectionIndex={sectionIndex} compact />
     </div>
   </section>
@@ -95,56 +96,52 @@ export const GuideEssay = () => {
     };
 
   return (
-    <main className="min-h-screen bg-[#0b0c0f] text-foreground selection:bg-[#61dafb]/25">
-      <div className="mx-auto grid w-full max-w-[1536px] lg:grid-cols-[minmax(0,0.9fr)_minmax(34rem,1.1fr)]">
-        <article className="px-6 sm:px-10 lg:px-14 xl:px-20">
-          <header className="flex h-20 items-center justify-between">
-            <NextLink className="flex items-center gap-2.5" href="/">
-              <Image src="/icon.png" alt="" width={24} height={24} priority />
-              <span className="text-sm font-medium tracking-tight text-white">bippy</span>
+    <main className="min-h-screen bg-background text-foreground selection:bg-muted">
+      <div className="mx-auto grid w-full max-w-7xl lg:grid-cols-[minmax(0,1fr)_minmax(32rem,1fr)]">
+        <article className="px-6 pb-12 sm:px-10 lg:px-12">
+          <header className="flex items-center justify-between pt-16 pb-8">
+            <NextLink className="flex items-center gap-2" href="/">
+              <Image
+                className="size-8 object-contain"
+                src="/icon.png"
+                alt=""
+                width={32}
+                height={32}
+                priority
+              />
+              <span className="text-xl font-medium tracking-tight">bippy</span>
             </NextLink>
-            <a
-              className="font-mono text-xs tracking-[0.08em] text-white/35 transition hover:text-[#61dafb]"
-              href="https://github.com/aidenybai/bippy"
-            >
-              GitHub ↗
-            </a>
+            <Link href="https://github.com/aidenybai/bippy">GitHub</Link>
           </header>
 
           <section
             ref={getSectionReference(0)}
             className={cn(
-              "flex min-h-[calc(100dvh-5rem)] flex-col justify-center py-16 transition-opacity duration-500 lg:py-24",
-              activeSectionIndex === 0 ? "lg:opacity-100" : "lg:opacity-[0.32]",
+              "flex min-h-[68dvh] flex-col justify-center py-16 transition-opacity duration-300",
+              activeSectionIndex === 0 ? "lg:opacity-100" : "lg:opacity-60",
             )}
             data-guide-section="0"
           >
-            <p className="mb-5 font-mono text-xs font-medium tracking-[0.12em] text-[#61dafb]">
-              a field guide to React&apos;s other tree
-            </p>
-            <h1 className="max-w-2xl font-serif text-5xl leading-[0.98] font-normal tracking-[-0.045em] text-white sm:text-6xl xl:text-7xl">
-              What bippy
-              <br />
-              actually is.
+            <h1 className="max-w-lg text-3xl font-medium text-foreground">
+              bippy is the library under the inspector.
             </h1>
-            <div className="mt-8 max-w-xl space-y-5 text-base leading-7 text-white/58">
+            <div className="mt-4 max-w-lg space-y-4 text-sm leading-relaxed text-muted-foreground">
               <p>
-                Give me one render and I&apos;ll show you the component that made it, what it
-                received, and where React put it.
+                The widget on the homepage is a demo built with bippy. It calls{" "}
+                <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
+                  getFiber()
+                </code>{" "}
+                on its own UI.
               </p>
               <p>
-                Click the counter. The card on this page is only React UI. The render signal behind
-                it is what bippy is built to catch.
-              </p>
-              <p className="border-l border-[#61dafb]/35 pl-4 text-white/38">
-                bippy is not a browser extension or a DevTools panel. It is a tiny library you load
-                into your app before React.
+                bippy is not an extension or a DevTools panel. It is a library you import before
+                React to inspect Fiber, observe renders, and access the renderer.
               </p>
             </div>
-            <p className="mt-10 text-xs text-white/25 lg:hidden">
-              This guide has a scroll-synced lab on desktop. You still get every experiment here.
+            <p className="mt-6 text-xs text-muted-foreground lg:hidden">
+              The examples are scroll-synced on desktop and inline here.
             </p>
-            <div className="mt-10 lg:hidden">
+            <div className="mt-8 lg:hidden">
               <GuideShowcase activeSectionIndex={0} compact />
             </div>
           </section>
@@ -166,9 +163,9 @@ export const GuideEssay = () => {
             );
           })}
 
-          <footer className="flex items-center justify-between border-t border-white/8 py-8 text-xs text-white/25">
-            <span>bippy · React internals without the ceremony</span>
-            <NextLink className="transition hover:text-white" href="/">
+          <footer className="flex items-center justify-between border-t border-border py-8 text-xs text-muted-foreground">
+            <span>bippy hacks into React internals.</span>
+            <NextLink className="transition-colors hover:text-foreground" href="/">
               back to the inspector
             </NextLink>
           </footer>

--- a/packages/website/components/guide/guide-essay.tsx
+++ b/packages/website/components/guide/guide-essay.tsx
@@ -1,0 +1,450 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+import { GuideShowcase } from "@/components/guide/guide-showcases";
+import { cn } from "@/lib/utils";
+
+interface GuideSectionProps {
+  children: ReactNode;
+  eyebrow: string;
+  isActive: boolean;
+  sectionIndex: number;
+  sectionReference: (element: HTMLElement | null) => void;
+  title: string;
+}
+
+interface InlineCodeProps {
+  children: ReactNode;
+}
+
+interface GuideCodeProps {
+  children: string;
+  label?: string;
+}
+
+const InlineCode = ({ children }: InlineCodeProps) => (
+  <code className="rounded bg-white/7 px-1.5 py-0.5 font-mono text-[0.82em] text-[#61dafb]">
+    {children}
+  </code>
+);
+
+const GuideCode = ({ children, label }: GuideCodeProps) => (
+  <div className="my-7 overflow-hidden rounded-xl border border-white/10 bg-[#14161b]">
+    {label && (
+      <div className="border-b border-white/8 px-4 py-2.5 font-mono text-[10px] text-white/35">
+        {label}
+      </div>
+    )}
+    <pre className="overflow-x-auto p-4 font-mono text-[11px] leading-5 text-white/65">
+      <code>{children}</code>
+    </pre>
+  </div>
+);
+
+const GuideSection = ({
+  children,
+  eyebrow,
+  isActive,
+  sectionIndex,
+  sectionReference,
+  title,
+}: GuideSectionProps) => (
+  <section
+    ref={sectionReference}
+    className={cn(
+      "flex min-h-[82vh] scroll-mt-12 flex-col justify-center py-20 transition-opacity duration-500 lg:min-h-[96vh] lg:py-28",
+      isActive ? "lg:opacity-100" : "lg:opacity-32",
+    )}
+    data-guide-section={sectionIndex}
+  >
+    <p className="mb-4 font-mono text-[10px] font-medium tracking-[0.2em] text-[#61dafb] uppercase">
+      {eyebrow}
+    </p>
+    <h2 className="max-w-xl text-2xl font-medium tracking-[-0.025em] text-white sm:text-3xl">
+      {title}
+    </h2>
+    <div className="mt-6 max-w-xl space-y-5 text-[15px] leading-7 text-white/56">{children}</div>
+    <div className="mt-10 lg:hidden">
+      <GuideShowcase activeSectionIndex={sectionIndex} compact />
+    </div>
+  </section>
+);
+
+export const GuideEssay = () => {
+  const [activeSectionIndex, setActiveSectionIndex] = useState(0);
+  const sectionElements = useRef<Array<HTMLElement | null>>([]);
+
+  useEffect(() => {
+    let animationFrame = 0;
+
+    const updateActiveSection = (): void => {
+      animationFrame = 0;
+      const viewportCenter = window.innerHeight / 2;
+      let closestSectionIndex = 0;
+      let closestDistance = Number.POSITIVE_INFINITY;
+
+      sectionElements.current.forEach((sectionElement, sectionIndex) => {
+        if (!sectionElement) return;
+        const sectionBounds = sectionElement.getBoundingClientRect();
+        const sectionCenter = sectionBounds.top + sectionBounds.height / 2;
+        const distanceFromCenter = Math.abs(sectionCenter - viewportCenter);
+
+        if (distanceFromCenter < closestDistance) {
+          closestDistance = distanceFromCenter;
+          closestSectionIndex = sectionIndex;
+        }
+      });
+
+      setActiveSectionIndex(closestSectionIndex);
+    };
+
+    const requestActiveSectionUpdate = (): void => {
+      if (animationFrame) return;
+      animationFrame = window.requestAnimationFrame(updateActiveSection);
+    };
+
+    updateActiveSection();
+    window.addEventListener("scroll", requestActiveSectionUpdate, { passive: true });
+    window.addEventListener("resize", requestActiveSectionUpdate);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      window.removeEventListener("scroll", requestActiveSectionUpdate);
+      window.removeEventListener("resize", requestActiveSectionUpdate);
+    };
+  }, []);
+
+  const getSectionReference =
+    (sectionIndex: number) =>
+    (sectionElement: HTMLElement | null): void => {
+      sectionElements.current[sectionIndex] = sectionElement;
+    };
+
+  return (
+    <main className="min-h-screen bg-[#0b0c0f] text-foreground selection:bg-[#61dafb]/25">
+      <div className="mx-auto grid w-full max-w-[1536px] lg:grid-cols-[minmax(0,0.9fr)_minmax(34rem,1.1fr)]">
+        <article className="px-6 sm:px-10 lg:px-14 xl:px-20">
+          <header className="flex h-20 items-center justify-between">
+            <a className="flex items-center gap-2.5" href="/">
+              <Image src="/icon.png" alt="" width={24} height={24} priority />
+              <span className="text-sm font-medium tracking-tight text-white">bippy</span>
+            </a>
+            <a
+              className="font-mono text-[10px] tracking-[0.14em] text-white/35 uppercase transition hover:text-[#61dafb]"
+              href="https://github.com/aidenybai/bippy"
+            >
+              GitHub ↗
+            </a>
+          </header>
+
+          <section
+            ref={getSectionReference(0)}
+            className={cn(
+              "flex min-h-[calc(100vh-5rem)] flex-col justify-center py-16 transition-opacity duration-500 lg:min-h-[calc(100vh-5rem)] lg:py-24",
+              activeSectionIndex === 0 ? "lg:opacity-100" : "lg:opacity-32",
+            )}
+            data-guide-section="0"
+          >
+            <p className="mb-5 font-mono text-[10px] font-medium tracking-[0.2em] text-[#61dafb] uppercase">
+              a field guide to React&apos;s other tree
+            </p>
+            <h1 className="max-w-2xl font-serif text-5xl leading-[0.98] font-normal tracking-[-0.045em] text-white sm:text-6xl xl:text-7xl">
+              What bippy
+              <br />
+              actually is.
+            </h1>
+            <div className="mt-8 max-w-xl space-y-5 text-[15px] leading-7 text-white/58">
+              <p>
+                Give me one render and I&apos;ll show you the component that made it, what it
+                received, and where React put it.
+              </p>
+              <p>
+                Click the counter. The card on this page is only React UI. The render signal behind
+                it is what bippy is built to catch.
+              </p>
+              <p className="border-l border-[#61dafb]/35 pl-4 text-white/38">
+                bippy is not a browser extension or a DevTools panel. It is a tiny library you load
+                into your app before React.
+              </p>
+            </div>
+            <p className="mt-10 text-xs text-white/25 lg:hidden">
+              This guide has a scroll-synced lab on desktop. You still get every experiment here.
+            </p>
+            <div className="mt-10 lg:hidden">
+              <GuideShowcase activeSectionIndex={0} compact />
+            </div>
+          </section>
+
+          <GuideSection
+            eyebrow="Part 1 · two trees"
+            isActive={activeSectionIndex === 1}
+            sectionIndex={1}
+            sectionReference={getSectionReference(1)}
+            title="The DOM is the output. Fiber is the story."
+          >
+            <p>
+              The browser gives you a tree of elements: div, button, span. Useful, but flat. By the
+              time React hands work to the DOM, component identity is gone.
+            </p>
+            <p>
+              React keeps a second tree in memory. A Fiber can tell you the component type, its
+              props and state, who owns it, the host element it produced, and what work is pending.
+            </p>
+            <p>
+              Switch the lab between DOM and Fiber. Same interface. One is a soup of tags; the
+              other still knows <InlineCode>Avatar</InlineCode> and{" "}
+              <InlineCode>FollowButton</InlineCode>.
+            </p>
+          </GuideSection>
+
+          <GuideSection
+            eyebrow="Part 2 · the handshake"
+            isActive={activeSectionIndex === 2}
+            sectionIndex={2}
+            sectionReference={getSectionReference(2)}
+            title="React already phones home."
+          >
+            <p>
+              React renderers announce themselves through{" "}
+              <InlineCode>__REACT_DEVTOOLS_GLOBAL_HOOK__</InlineCode>. React DevTools installs that
+              hook, then React calls <InlineCode>inject()</InlineCode> and reports every committed
+              root.
+            </p>
+            <p>
+              bippy pretends to be DevTools. It installs a compatible hook, keeps the original
+              callbacks working, and listens to the same commit stream.
+            </p>
+            <p>
+              Timing is the whole trick: the hook must exist before the renderer loads. In Next
+              15.3+, use <InlineCode>instrumentation-client.ts</InlineCode>. In Vite, make bippy the
+              first import in the entry file.
+            </p>
+            <GuideCode label="instrumentation-client.ts">{`import "bippy";`}</GuideCode>
+          </GuideSection>
+
+          <GuideSection
+            eyebrow="Part 3 · one subscription"
+            isActive={activeSectionIndex === 3}
+            sectionIndex={3}
+            sectionReference={getSectionReference(3)}
+            title="instrument() is the front door."
+          >
+            <p>
+              Register the lifecycle events you care about. bippy patches each hook event once,
+              then fans it out to every subscriber, so tools compose instead of wrapping each
+              other forever.
+            </p>
+            <p>
+              <InlineCode>onActive</InlineCode> tells you a renderer arrived.{" "}
+              <InlineCode>onCommitFiberRoot</InlineCode> gives you the committed tree. The return
+              value removes exactly your handlers.
+            </p>
+            <GuideCode label="observe-commits.ts">{`const unsubscribe = instrument({
+  name: "my-render-tool",
+  onActive: () => setReady(true),
+  onCommitFiberRoot: (_, root) => inspect(root),
+});
+
+unsubscribe();`}</GuideCode>
+          </GuideSection>
+
+          <GuideSection
+            eyebrow="Part 4 · only the work"
+            isActive={activeSectionIndex === 4}
+            sectionIndex={4}
+            sectionReference={getSectionReference(4)}
+            title="A Fiber exists. That does not mean it rendered."
+          >
+            <p>
+              <InlineCode>traverseFiber()</InlineCode> is a structural search. It walks children or
+              owners until your selector returns true. Great for finding a host node. Wrong for
+              answering “what rerendered in this commit?”
+            </p>
+            <p>
+              <InlineCode>traverseRenderedFibers()</InlineCode> compares the current and previous
+              trees for the same root. Its callback receives only work from that commit, tagged{" "}
+              <InlineCode>mount</InlineCode>, <InlineCode>update</InlineCode>, or{" "}
+              <InlineCode>unmount</InlineCode>.
+            </p>
+            <p>
+              Keep passing the same root. That identity is how bippy remembers the previous tree.
+            </p>
+          </GuideSection>
+
+          <GuideSection
+            eyebrow="Part 5 · the payoff"
+            isActive={activeSectionIndex === 5}
+            sectionIndex={5}
+            sectionReference={getSectionReference(5)}
+            title="Build a tiny react-scan."
+          >
+            <p>
+              Now the pieces cash out. Subscribe to commits. Visit the Fibers that updated. Walk
+              down to each component&apos;s nearest host Fiber. Outline its DOM node.
+            </p>
+            <p>
+              Click either card in the lab. That cyan box is the entire idea behind a render
+              visualizer—minus the production polish.
+            </p>
+            <GuideCode label="mini-scan.ts">{`import {
+  instrument,
+  isCompositeFiber,
+  isHostFiber,
+  traverseFiber,
+  traverseRenderedFibers,
+} from "bippy";
+
+instrument({
+  onCommitFiberRoot: (_, root) => {
+    traverseRenderedFibers(root, (fiber, phase) => {
+      if (phase !== "update" || !isCompositeFiber(fiber)) return;
+
+      const host = traverseFiber(fiber, (candidate) =>
+        isHostFiber(candidate),
+      );
+
+      if (host?.stateNode instanceof HTMLElement) {
+        host.stateNode.style.outline = "2px solid #61dafb";
+      }
+    });
+  },
+});`}</GuideCode>
+          </GuideSection>
+
+          <GuideSection
+            eyebrow="Part 6 · reverse lookup"
+            isActive={activeSectionIndex === 6}
+            sectionIndex={6}
+            sectionReference={getSectionReference(6)}
+            title="Go from a DOM node back into React."
+          >
+            <p>
+              <InlineCode>getFiber(element)</InlineCode> crosses from the rendered host instance
+              into React&apos;s tree. That is the move behind the picker on the bippy homepage.
+            </p>
+            <p>
+              From there, <InlineCode>getLatestFiber()</InlineCode> follows a retained Fiber to its
+              current version. <InlineCode>isHostFiber()</InlineCode> and{" "}
+              <InlineCode>isCompositeFiber()</InlineCode> tell host output from user components.{" "}
+              <InlineCode>getDisplayName()</InlineCode> turns the type into a human label.
+            </p>
+            <p>
+              Inside your own component, <InlineCode>useFiber()</InlineCode> skips the DOM lookup
+              and returns the calling component&apos;s Fiber. On the server it returns undefined:
+              there is no client Fiber there to inspect.
+            </p>
+          </GuideSection>
+
+          <GuideSection
+            eyebrow="Part 7 · what this unlocks"
+            isActive={activeSectionIndex === 7}
+            sectionIndex={7}
+            sectionReference={getSectionReference(7)}
+            title="The inspector is a demo. The library is the engine."
+          >
+            <p>
+              react-scan uses this territory to show expensive renders. This site&apos;s picker
+              starts from a DOM element and finds the component that owns it. Source tooling can
+              reconstruct owner stacks and connect components back to files.
+            </p>
+            <p>
+              You can build performance overlays, visual editors, test recorders, accessibility
+              auditors, component explorers, or the debugging tool React never shipped.
+            </p>
+            <p>
+              The shared move is always the same: take React&apos;s private graph and turn it into a
+              small, useful signal.
+            </p>
+          </GuideSection>
+
+          <GuideSection
+            eyebrow="Part 8 · read before shipping"
+            isActive={activeSectionIndex === 8}
+            sectionIndex={8}
+            sectionReference={getSectionReference(8)}
+            title="This is an escape hatch, not a contract."
+          >
+            <p>
+              Production dead-code elimination changes React&apos;s shape. A hook loaded after
+              React misses the renderer handshake. Real DevTools or refresh runtimes may already
+              own the hook. React Server Components do not create client Fibers on the server.
+            </p>
+            <p>
+              And the big one: React internals change. Work tags move. fields change meaning.
+              Renderers disagree. bippy absorbs a lot of that drift, but it cannot make private
+              APIs public.
+            </p>
+            <p className="border-l border-orange-300/30 pl-4 text-orange-100/50">
+              Pin versions, test production builds, fail soft, and never make app correctness
+              depend on an inspection tool.
+            </p>
+          </GuideSection>
+
+          <GuideSection
+            eyebrow="Recap · five moves"
+            isActive={activeSectionIndex === 9}
+            sectionIndex={9}
+            sectionReference={getSectionReference(9)}
+            title="You do not need all of Fiber. You need the right doorway."
+          >
+            <ol className="space-y-3 pl-0">
+              {[
+                "Load bippy before React so the DevTools hook is ready.",
+                "Use instrument() to subscribe without fighting other tools.",
+                "Use traverseRenderedFibers() for mount, update, and unmount work.",
+                "Use getFiber() and traverseFiber() to cross between DOM and React.",
+                "Treat every result as private internals that can change.",
+              ].map((recapItem, recapIndex) => (
+                <li key={recapItem} className="flex gap-3">
+                  <span className="font-mono text-[10px] text-[#61dafb]">
+                    0{recapIndex + 1}
+                  </span>
+                  <span>{recapItem}</span>
+                </li>
+              ))}
+            </ol>
+            <p>
+              That is bippy: a library for listening to React&apos;s private renderer protocol,
+              walking Fiber, and building tools on top.
+            </p>
+            <div className="flex flex-wrap gap-x-5 gap-y-2 pt-3 text-sm">
+              <a
+                className="text-[#61dafb] underline decoration-[#61dafb]/25 underline-offset-4 transition hover:text-white"
+                href="https://github.com/aidenybai/bippy#api-reference"
+              >
+                API reference ↗
+              </a>
+              <a
+                className="text-[#61dafb] underline decoration-[#61dafb]/25 underline-offset-4 transition hover:text-white"
+                href="/llms.txt"
+              >
+                llms.txt ↗
+              </a>
+              <a
+                className="text-[#61dafb] underline decoration-[#61dafb]/25 underline-offset-4 transition hover:text-white"
+                href="https://npmjs.com/package/bippy"
+              >
+                npm ↗
+              </a>
+            </div>
+          </GuideSection>
+
+          <footer className="flex items-center justify-between border-t border-white/8 py-8 text-[11px] text-white/25">
+            <span>bippy · React internals without the ceremony</span>
+            <a className="transition hover:text-white" href="/">
+              back to the inspector
+            </a>
+          </footer>
+        </article>
+
+        <aside className="relative hidden lg:block">
+          <div className="sticky top-0 flex h-dvh items-center p-6 xl:p-8">
+            <GuideShowcase activeSectionIndex={activeSectionIndex} />
+          </div>
+        </aside>
+      </div>
+    </main>
+  );
+};

--- a/packages/website/components/guide/guide-showcases.tsx
+++ b/packages/website/components/guide/guide-showcases.tsx
@@ -8,12 +8,10 @@ import { cn } from "@/lib/utils";
 
 interface GuideShowcaseProps {
   activeSectionIndex: number;
-  compact?: boolean;
 }
 
 interface ShowcaseFrameProps {
   children: ReactNode;
-  compact: boolean;
 }
 
 interface ShowcaseHeaderProps {
@@ -66,13 +64,8 @@ const TreeRow = ({ children, depth = 0 }: TreeRowProps) => (
   </div>
 );
 
-const ShowcaseFrame = ({ children, compact }: ShowcaseFrameProps) => (
-  <figure
-    className={cn(
-      "flex w-full min-w-0 flex-col overflow-hidden rounded-lg border border-border bg-card p-4 text-card-foreground",
-      compact ? "min-h-[420px]" : "h-[min(620px,calc(100dvh-3rem))]",
-    )}
-  >
+const ShowcaseFrame = ({ children }: ShowcaseFrameProps) => (
+  <figure className="flex min-h-[420px] w-full min-w-0 flex-col overflow-hidden rounded-lg border border-border bg-card p-4 text-card-foreground">
     {children}
   </figure>
 );
@@ -444,11 +437,11 @@ const showcaseComponents = [
   RecapShowcase,
 ];
 
-export const GuideShowcase = ({ activeSectionIndex, compact = false }: GuideShowcaseProps) => {
+export const GuideShowcase = ({ activeSectionIndex }: GuideShowcaseProps) => {
   const ActiveShowcase = showcaseComponents[activeSectionIndex] ?? IntroShowcase;
 
   return (
-    <ShowcaseFrame key={activeSectionIndex} compact={compact}>
+    <ShowcaseFrame key={activeSectionIndex}>
       <ActiveShowcase />
     </ShowcaseFrame>
   );

--- a/packages/website/components/guide/guide-showcases.tsx
+++ b/packages/website/components/guide/guide-showcases.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 
+import { FiberTreeDemo } from "@/components/fiber-tree";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface GuideShowcaseProps {
@@ -10,21 +12,23 @@ interface GuideShowcaseProps {
 }
 
 interface ShowcaseFrameProps {
-  children: React.ReactNode;
+  children: ReactNode;
   compact: boolean;
-  sectionIndex: number;
 }
 
-interface CodeWindowProps {
-  children: React.ReactNode;
+interface ShowcaseHeaderProps {
+  children: ReactNode;
+  description?: string;
+}
+
+interface CodeBlockProps {
+  children: ReactNode;
   filename: string;
 }
 
-interface TreeLineProps {
-  children: React.ReactNode;
+interface TreeRowProps {
+  children: ReactNode;
   depth?: number;
-  isActive?: boolean;
-  tone?: "accent" | "muted" | "plain";
 }
 
 interface PhaseRowProps {
@@ -32,172 +36,97 @@ interface PhaseRowProps {
   phase: "mount" | "unmount" | "update";
 }
 
-const accentText = "text-[#61dafb]";
-const accentBackground = "bg-[#61dafb]";
-
-const TreeLine = ({ children, depth = 0, isActive = false, tone = "plain" }: TreeLineProps) => (
-  <div
-    className={cn(
-      "flex h-7 items-center rounded-sm px-2 font-mono text-xs",
-      isActive && "bg-[#61dafb]/12",
-      tone === "accent" && accentText,
-      tone === "muted" && "text-white/38",
-      tone === "plain" && "text-white/75",
-    )}
-    style={{ paddingLeft: `${depth * 14 + 8}px` }}
-  >
-    <span className="mr-1.5 text-white/25">›</span>
-    {children}
+const ShowcaseHeader = ({ children, description }: ShowcaseHeaderProps) => (
+  <div>
+    <h3 className="text-sm font-medium text-foreground">{children}</h3>
+    {description ? (
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{description}</p>
+    ) : null}
   </div>
 );
 
-const CodeWindow = ({ children, filename }: CodeWindowProps) => (
-  <div className="overflow-hidden rounded-xl border border-white/10 bg-black/35">
-    <div className="flex h-9 items-center justify-between border-b border-white/8 px-3 font-mono text-[10px] text-white/40">
-      <span>{filename}</span>
-      <span className={accentText}>● live</span>
+const CodeBlock = ({ children, filename }: CodeBlockProps) => (
+  <div className="overflow-hidden rounded-lg border border-border bg-background">
+    <div className="border-b border-border px-3 py-2 font-mono text-xs text-muted-foreground">
+      {filename}
     </div>
-    <pre className="overflow-x-auto p-4 font-mono text-[11px] leading-5 text-white/66">
+    <pre className="overflow-x-auto p-3 font-mono text-xs leading-5 text-muted-foreground">
       <code>{children}</code>
     </pre>
   </div>
 );
 
-const ShowcaseFrame = ({ children, compact, sectionIndex }: ShowcaseFrameProps) => (
+const TreeRow = ({ children, depth = 0 }: TreeRowProps) => (
   <div
-    className={cn(
-      "relative flex min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#14161b] shadow-2xl shadow-black/35",
-      compact ? "h-[430px]" : "h-[min(760px,calc(100dvh-3rem))]",
-    )}
+    className="flex h-7 items-center rounded-sm font-mono text-xs text-muted-foreground"
+    style={{ paddingLeft: `${depth * 14 + 8}px` }}
   >
-    <div className="flex h-11 shrink-0 items-center justify-between border-b border-white/8 px-4">
-      <div className="flex gap-1.5">
-        <span className="size-2 rounded-full bg-white/15" />
-        <span className="size-2 rounded-full bg-white/15" />
-        <span className={cn("size-2 rounded-full", accentBackground)} />
-      </div>
-      <span className="font-mono text-[10px] tracking-[0.18em] text-white/35">
-        {String(sectionIndex + 1).padStart(2, "0")} / 10
-      </span>
-    </div>
-    <div className="min-h-0 flex-1 p-4 sm:p-6">{children}</div>
+    <span className="mr-1.5 text-border">›</span>
+    {children}
   </div>
 );
 
-const IntroShowcase = () => {
-  const [renderCount, setRenderCount] = useState(1);
+const ShowcaseFrame = ({ children, compact }: ShowcaseFrameProps) => (
+  <figure
+    className={cn(
+      "flex w-full min-w-0 flex-col overflow-hidden rounded-lg border border-border bg-card p-4 text-card-foreground",
+      compact ? "min-h-[420px]" : "h-[min(620px,calc(100dvh-3rem))]",
+    )}
+  >
+    {children}
+  </figure>
+);
 
-  return (
-    <div className="flex h-full flex-col justify-between gap-6">
-      <div>
-        <p className="mb-2 font-mono text-[10px] tracking-[0.2em] text-white/35 uppercase">
-          a live render
-        </p>
-        <h3 className="text-xl font-medium tracking-tight text-white">Counter</h3>
-      </div>
-      <button
-        className="group relative mx-auto flex aspect-square w-48 flex-col items-center justify-center rounded-full border border-[#61dafb]/35 bg-[#61dafb]/6 transition hover:bg-[#61dafb]/10 active:scale-[0.98]"
-        onClick={() => setRenderCount((currentRenderCount) => currentRenderCount + 1)}
-        type="button"
-      >
-        <span className="font-mono text-[10px] tracking-[0.2em] text-[#61dafb]/70 uppercase">
-          click to render
-        </span>
-        <span className="mt-2 text-6xl font-light tabular-nums text-white">{renderCount - 1}</span>
-        <span className="absolute inset-3 rounded-full border border-[#61dafb]/10 transition group-hover:inset-2" />
-      </button>
-      <div className="rounded-xl border border-white/8 bg-black/25 p-3 font-mono text-[11px]">
-        <div className="flex justify-between text-white/38">
-          <span>component</span>
-          <span className={accentText}>Counter</span>
-        </div>
-        <div className="mt-2 flex justify-between text-white/38">
-          <span>renders observed</span>
-          <span className="text-white/80">{renderCount}</span>
-        </div>
-      </div>
+const IntroShowcase = () => (
+  <div className="flex h-full min-h-0 flex-col gap-4">
+    <ShowcaseHeader description="The homepage inspector is built with bippy. It calls getFiber() on its own UI.">
+      inspect this page
+    </ShowcaseHeader>
+    <div className="min-h-0 flex-1">
+      <FiberTreeDemo />
     </div>
-  );
-};
+  </div>
+);
 
 const TwoTreesShowcase = () => {
   const [isFiberVisible, setIsFiberVisible] = useState(true);
 
   return (
-    <div className="flex h-full flex-col gap-4">
-      <div className="grid grid-cols-2 rounded-lg bg-black/25 p-1 text-xs">
-        <button
-          className={cn(
-            "rounded-md px-3 py-2 transition",
-            !isFiberVisible ? "bg-white/10 text-white" : "text-white/38",
-          )}
-          onClick={() => setIsFiberVisible(false)}
-          type="button"
-        >
-          DOM
-        </button>
-        <button
-          className={cn(
-            "rounded-md px-3 py-2 transition",
-            isFiberVisible ? "bg-[#61dafb]/12 text-[#61dafb]" : "text-white/38",
-          )}
-          onClick={() => setIsFiberVisible(true)}
-          type="button"
-        >
-          Fiber
-        </button>
+    <div className="flex h-full min-h-0 flex-col gap-4">
+      <div className="flex items-start justify-between gap-4">
+        <ShowcaseHeader description="Same UI, different tree.">DOM and Fiber</ShowcaseHeader>
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant={isFiberVisible ? "outline" : "secondary"}
+            onClick={() => setIsFiberVisible(false)}
+          >
+            DOM
+          </Button>
+          <Button
+            size="sm"
+            variant={isFiberVisible ? "secondary" : "outline"}
+            onClick={() => setIsFiberVisible(true)}
+          >
+            Fiber
+          </Button>
+        </div>
       </div>
-      <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-white/8 bg-black/20 p-3">
+      <div className="min-h-0 flex-1">
         {isFiberVisible ? (
-          <div>
-            <TreeLine tone="muted">HostRoot</TreeLine>
-            <TreeLine depth={1} tone="accent">
-              App
-            </TreeLine>
-            <TreeLine depth={2} tone="accent">
-              ProfileCard
-            </TreeLine>
-            <TreeLine depth={3}>article</TreeLine>
-            <TreeLine depth={4} tone="accent" isActive>
-              Avatar
-            </TreeLine>
-            <TreeLine depth={5}>img</TreeLine>
-            <TreeLine depth={4} tone="accent">
-              FollowButton
-            </TreeLine>
-            <TreeLine depth={5}>button</TreeLine>
-            <div className="mt-4 border-t border-white/8 pt-4 font-mono text-[11px] leading-6 text-white/45">
-              <p>
-                <span className="text-white/25">props </span>
-                {'{ size: 40, status: "online" }'}
-              </p>
-              <p>
-                <span className="text-white/25">state </span>
-                {"{ isFollowing: false }"}
-              </p>
-              <p>
-                <span className="text-white/25">owner </span>
-                <span className={accentText}>ProfileCard</span>
-              </p>
-            </div>
-          </div>
+          <FiberTreeDemo />
         ) : (
-          <div>
-            <TreeLine tone="muted">html</TreeLine>
-            <TreeLine depth={1} tone="muted">
-              body
-            </TreeLine>
-            <TreeLine depth={2}>main</TreeLine>
-            <TreeLine depth={3}>article.card</TreeLine>
-            <TreeLine depth={4}>div.flex</TreeLine>
-            <TreeLine depth={5} isActive>
-              img.rounded-full
-            </TreeLine>
-            <TreeLine depth={4}>button.bg-cyan</TreeLine>
-            <div className="mt-5 rounded-lg border border-dashed border-white/10 p-4 text-center text-xs leading-5 text-white/35">
-              The DOM knows boxes and attributes.
-              <br />
-              It forgot who made them.
+          <div className="h-80 overflow-hidden rounded-lg border border-border bg-background p-3">
+            <TreeRow>html</TreeRow>
+            <TreeRow depth={1}>body</TreeRow>
+            <TreeRow depth={2}>main</TreeRow>
+            <TreeRow depth={3}>article</TreeRow>
+            <TreeRow depth={4}>div</TreeRow>
+            <TreeRow depth={5}>img</TreeRow>
+            <TreeRow depth={4}>button</TreeRow>
+            <div className="mt-4 border-t border-border p-3 text-xs leading-relaxed text-muted-foreground">
+              The DOM has elements and attributes. Component names, owners, props, and hooks are in
+              Fiber.
             </div>
           </div>
         )}
@@ -207,30 +136,30 @@ const TwoTreesShowcase = () => {
 };
 
 const HookShowcase = () => (
-  <div className="flex h-full flex-col justify-center">
-    <div className="relative space-y-7">
+  <div className="flex h-full flex-col gap-4">
+    <ShowcaseHeader description="bippy installs the same global hook used by React DevTools.">
+      renderer handshake
+    </ShowcaseHeader>
+    <div className="flex flex-1 flex-col justify-center">
       {[
-        ["01", 'import "bippy"', "install the hook"],
-        ["02", "renderer.inject()", "React phones home"],
-        ["03", "onCommitFiberRoot", "every committed tree"],
-      ].map(([step, label, detail], stepIndex) => (
-        <div key={step} className="relative flex items-center gap-4">
-          {stepIndex < 2 && (
-            <div className="absolute top-12 left-[19px] h-7 w-px bg-gradient-to-b from-[#61dafb]/60 to-[#61dafb]/10" />
-          )}
-          <div className="flex size-10 shrink-0 items-center justify-center rounded-full border border-[#61dafb]/25 bg-[#61dafb]/8 font-mono text-[10px] text-[#61dafb]">
-            {step}
+        ['import "bippy"', "install the hook"],
+        ["renderer.inject()", "React registers the renderer"],
+        ["onCommitFiberRoot", "React reports each commit"],
+      ].map(([label, description], rowIndex) => (
+        <div key={label}>
+          <div className="rounded-lg border border-border bg-background p-3">
+            <p className="font-mono text-xs text-foreground">{label}</p>
+            <p className="mt-1 text-xs text-muted-foreground">{description}</p>
           </div>
-          <div className="min-w-0 flex-1 rounded-xl border border-white/8 bg-black/20 px-4 py-3">
-            <p className="truncate font-mono text-xs text-white/80">{label}</p>
-            <p className="mt-1 text-xs text-white/35">{detail}</p>
-          </div>
+          {rowIndex < 2 ? (
+            <div className="flex h-6 items-center pl-4 text-sm text-muted-foreground">↓</div>
+          ) : null}
         </div>
       ))}
     </div>
-    <div className="mt-9 rounded-xl border border-[#61dafb]/15 bg-[#61dafb]/5 p-4 text-sm leading-6 text-white/58">
-      bippy takes the same handshake React DevTools uses. It just arrives first.
-    </div>
+    <p className="rounded-lg bg-muted p-3 text-xs leading-relaxed text-muted-foreground">
+      Import order matters. The hook has to exist before the renderer loads.
+    </p>
   </div>
 );
 
@@ -239,62 +168,40 @@ const InstrumentShowcase = () => {
 
   return (
     <div className="flex h-full flex-col gap-4">
-      <CodeWindow filename="instrument.ts">
-        <span className={accentText}>{"const unsubscribe"}</span>
-        {" = instrument({\n"}
-        {"  onActive() {\n"}
-        {"    ready()\n"}
-        {"  },\n"}
-        {"  onCommitFiberRoot(_, root) {\n"}
+      <ShowcaseHeader description="Multiple calls compose. The returned function removes one subscription.">
+        instrument()
+      </ShowcaseHeader>
+      <CodeBlock filename="instrument.ts">
+        {"const unsubscribe = instrument({\n"}
+        {"  onActive: () => setReady(true),\n"}
+        {"  onCommitFiberRoot: (_, root) => {\n"}
         {"    inspect(root)\n"}
         {"  },\n"}
         {"})"}
-      </CodeWindow>
-      <div className="flex items-center justify-between rounded-xl border border-white/8 bg-black/20 p-4">
+      </CodeBlock>
+      <div className="mt-auto flex items-center justify-between rounded-lg border border-border p-3">
         <div>
-          <p className="text-sm text-white/75">commit listener</p>
-          <p className="mt-1 font-mono text-[10px] text-white/30">
+          <p className="text-sm text-foreground">commit listener</p>
+          <p className="text-xs text-muted-foreground">
             {isSubscribed ? "receiving roots" : "unsubscribed"}
           </p>
         </div>
-        <button
-          className={cn(
-            "rounded-full border px-3 py-1.5 font-mono text-[10px] transition",
-            isSubscribed
-              ? "border-[#61dafb]/30 bg-[#61dafb]/10 text-[#61dafb]"
-              : "border-white/10 text-white/35",
-          )}
+        <Button
+          size="sm"
+          variant={isSubscribed ? "secondary" : "outline"}
           onClick={() => setIsSubscribed((currentValue) => !currentValue)}
-          type="button"
         >
-          {isSubscribed ? "active" : "resume"}
-        </button>
-      </div>
-      <div className="mt-auto grid grid-cols-2 gap-3 text-center">
-        <div className="rounded-lg border border-white/8 p-3">
-          <p className="text-lg text-white">1</p>
-          <p className="mt-1 text-[10px] text-white/35">patched hook</p>
-        </div>
-        <div className="rounded-lg border border-white/8 p-3">
-          <p className="text-lg text-white">∞</p>
-          <p className="mt-1 text-[10px] text-white/35">subscriptions</p>
-        </div>
+          {isSubscribed ? "unsubscribe" : "subscribe"}
+        </Button>
       </div>
     </div>
   );
 };
 
 const PhaseRow = ({ name, phase }: PhaseRowProps) => (
-  <div className="flex items-center justify-between rounded-lg border border-white/8 bg-black/18 px-3 py-2.5">
-    <span className="font-mono text-xs text-white/65">{name}</span>
-    <span
-      className={cn(
-        "rounded-full px-2 py-0.5 font-mono text-[9px]",
-        phase === "mount" && "bg-emerald-400/10 text-emerald-300",
-        phase === "update" && "bg-[#61dafb]/10 text-[#61dafb]",
-        phase === "unmount" && "bg-orange-400/10 text-orange-300",
-      )}
-    >
+  <div className="flex items-center justify-between border-b border-border px-3 py-2.5 last:border-b-0">
+    <span className="font-mono text-xs text-foreground">{name}</span>
+    <span className="rounded bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground">
       {phase}
     </span>
   </div>
@@ -305,37 +212,29 @@ const RenderedFibersShowcase = () => {
   const isInitialCommit = commitNumber === 1;
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="mb-5 flex items-end justify-between">
-        <div>
-          <p className="font-mono text-[10px] tracking-[0.18em] text-white/30 uppercase">commit</p>
-          <p className="mt-1 text-3xl font-light text-white">#{commitNumber}</p>
-        </div>
-        <button
-          className="rounded-full bg-white px-4 py-2 text-xs font-medium text-black transition hover:bg-[#61dafb]"
+    <div className="flex h-full flex-col gap-4">
+      <div className="flex items-start justify-between gap-4">
+        <ShowcaseHeader description="Only Fibers that rendered in this commit are visited.">
+          rendered Fibers
+        </ShowcaseHeader>
+        <Button
+          size="sm"
+          variant="secondary"
           onClick={() => setCommitNumber((currentCommitNumber) => currentCommitNumber + 1)}
-          type="button"
         >
-          update count
-        </button>
+          update
+        </Button>
       </div>
-      <div className="space-y-2">
+      <div className="overflow-hidden rounded-lg border border-border bg-background">
         <PhaseRow name="Counter" phase={isInitialCommit ? "mount" : "update"} />
         <PhaseRow name="button" phase={isInitialCommit ? "mount" : "update"} />
-        {isInitialCommit && <PhaseRow name="StaticFooter" phase="mount" />}
+        {isInitialCommit ? <PhaseRow name="StaticFooter" phase="mount" /> : null}
       </div>
-      <div className="mt-5 rounded-xl border border-white/8 bg-black/20 p-4 font-mono text-[10px] leading-5 text-white/38">
-        <p className="text-white/65">traverseRenderedFibers(root)</p>
-        <p className="mt-2">
-          visited <span className={accentText}>{isInitialCommit ? 3 : 2}</span> fibers
-        </p>
-        <p>
-          skipped <span className="text-white/65">{isInitialCommit ? 0 : 1}</span> unchanged branch
-        </p>
+      <div className="rounded-lg bg-muted p-3 font-mono text-xs leading-5 text-muted-foreground">
+        <p>commit: {commitNumber}</p>
+        <p>visited: {isInitialCommit ? 3 : 2}</p>
+        <p>unchanged branches skipped: {isInitialCommit ? 0 : 1}</p>
       </div>
-      <p className="mt-auto text-xs leading-5 text-white/30">
-        A full walk sees everything. A rendered walk sees what changed now.
-      </p>
     </div>
   );
 };
@@ -356,62 +255,46 @@ const MiniScanShowcase = () => {
   };
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="mb-4 flex items-center justify-between">
-        <p className="font-mono text-[10px] tracking-[0.18em] text-white/30 uppercase">
-          mini react-scan
-        </p>
-        <span className="flex items-center gap-1.5 text-[10px] text-white/35">
-          <span className="size-1.5 animate-pulse rounded-full bg-[#61dafb]" />
-          watching
-        </span>
-      </div>
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
-        <button
+    <div className="flex h-full flex-col gap-4">
+      <ShowcaseHeader description="Click a component. The selected host node is the latest update.">
+        mini react-scan
+      </ShowcaseHeader>
+      <div className="grid grid-cols-2 gap-3">
+        <Button
           className={cn(
-            "relative rounded-xl border bg-black/20 p-5 text-left transition",
-            highlightedCard === "first"
-              ? "border-[#61dafb] shadow-[0_0_0_3px_rgba(97,218,251,0.1)]"
-              : "border-white/8",
+            "h-auto items-start justify-start rounded-lg p-4 text-left",
+            highlightedCard === "first" && "ring-2 ring-ring",
           )}
+          variant="outline"
           onClick={updateFirstCard}
-          type="button"
         >
-          <span className="text-xs text-white/35">Inbox</span>
-          <span className="mt-5 block text-4xl font-light text-white">{firstCount}</span>
-          {highlightedCard === "first" && (
-            <span className="absolute -top-2 left-3 rounded bg-[#61dafb] px-1.5 py-0.5 font-mono text-[8px] text-black">
-              Counter · update
-            </span>
-          )}
-        </button>
-        <button
+          <span>
+            <span className="block text-xs text-muted-foreground">Inbox</span>
+            <span className="mt-3 block text-2xl font-medium text-foreground">{firstCount}</span>
+          </span>
+        </Button>
+        <Button
           className={cn(
-            "relative rounded-xl border bg-black/20 p-5 text-left transition",
-            highlightedCard === "second"
-              ? "border-[#61dafb] shadow-[0_0_0_3px_rgba(97,218,251,0.1)]"
-              : "border-white/8",
+            "h-auto items-start justify-start rounded-lg p-4 text-left",
+            highlightedCard === "second" && "ring-2 ring-ring",
           )}
+          variant="outline"
           onClick={updateSecondCard}
-          type="button"
         >
-          <span className="text-xs text-white/35">Drafts</span>
-          <span className="mt-5 block text-4xl font-light text-white">{secondCount}</span>
-          {highlightedCard === "second" && (
-            <span className="absolute -top-2 left-3 rounded bg-[#61dafb] px-1.5 py-0.5 font-mono text-[8px] text-black">
-              Counter · update
-            </span>
-          )}
-        </button>
+          <span>
+            <span className="block text-xs text-muted-foreground">Drafts</span>
+            <span className="mt-3 block text-2xl font-medium text-foreground">{secondCount}</span>
+          </span>
+        </Button>
       </div>
-      <CodeWindow filename="scan.ts">
+      <CodeBlock filename="scan.ts">
         {"traverseRenderedFibers(root, (fiber, phase) => {\n"}
         {'  if (phase !== "update") return\n'}
         {"  const host = traverseFiber(fiber,\n"}
         {"    (candidate) => isHostFiber(candidate))\n"}
         {"  outline(host?.stateNode)\n"}
         {"})"}
-      </CodeWindow>
+      </CodeBlock>
     </div>
   );
 };
@@ -421,176 +304,130 @@ const ReverseLookupShowcase = () => {
 
   return (
     <div className="flex h-full flex-col gap-4">
-      <div className="rounded-xl border border-white/8 bg-black/20 p-4">
-        <div className="flex items-center gap-3">
-          <button
-            aria-label="Inspect avatar"
-            className={cn(
-              "size-11 rounded-full border bg-gradient-to-br from-[#61dafb]/35 to-violet-400/20 transition",
-              selectedElement === "avatar"
-                ? "border-[#61dafb] ring-3 ring-[#61dafb]/10"
-                : "border-white/10",
-            )}
-            onClick={() => setSelectedElement("avatar")}
-            type="button"
-          />
-          <div className="min-w-0 flex-1">
-            <button
-              className={cn(
-                "rounded border px-1 text-left text-sm text-white transition",
-                selectedElement === "name" ? "border-[#61dafb]" : "border-transparent",
-              )}
-              onClick={() => setSelectedElement("name")}
-              type="button"
-            >
-              Aiden
-            </button>
-            <p className="mt-1 text-xs text-white/35">@aidenybai</p>
-          </div>
-          <button
-            className={cn(
-              "rounded-full border px-3 py-1.5 text-xs transition",
-              selectedElement === "button"
-                ? "border-[#61dafb] bg-[#61dafb]/10 text-[#61dafb]"
-                : "border-white/10 text-white/65",
-            )}
-            onClick={() => setSelectedElement("button")}
-            type="button"
-          >
-            Follow
-          </button>
-        </div>
+      <ShowcaseHeader description="Pick a DOM node, then walk its owner chain.">
+        DOM to Fiber
+      </ShowcaseHeader>
+      <div className="flex items-center gap-3 rounded-lg border border-border bg-background p-3">
+        <Button
+          aria-label="Inspect avatar"
+          className="size-10 rounded-full"
+          size="icon"
+          variant={selectedElement === "avatar" ? "secondary" : "outline"}
+          onClick={() => setSelectedElement("avatar")}
+        >
+          AB
+        </Button>
+        <Button
+          className="min-w-0 flex-1 justify-start"
+          size="sm"
+          variant={selectedElement === "name" ? "secondary" : "ghost"}
+          onClick={() => setSelectedElement("name")}
+        >
+          Aiden
+        </Button>
+        <Button
+          size="sm"
+          variant={selectedElement === "button" ? "secondary" : "outline"}
+          onClick={() => setSelectedElement("button")}
+        >
+          Follow
+        </Button>
       </div>
-      <div className="flex items-center justify-center gap-2 py-1 font-mono text-[10px] text-white/28">
-        <span>DOM node</span>
-        <span className={accentText}>→</span>
-        <span>getFiber</span>
-        <span className={accentText}>→</span>
-        <span>owner</span>
-      </div>
-      <div className="min-h-0 flex-1 rounded-xl border border-white/8 bg-black/20 p-3">
-        <TreeLine tone="plain">
-          {selectedElement === "button" ? "button" : selectedElement === "avatar" ? "img" : "span"}
-        </TreeLine>
-        <TreeLine depth={1} tone="accent" isActive>
+      <div className="rounded-lg border border-border bg-background p-3">
+        <TreeRow>
+          {selectedElement === "button" ? "button" : selectedElement === "avatar" ? "div" : "span"}
+        </TreeRow>
+        <TreeRow depth={1}>
           {selectedElement === "button"
             ? "FollowButton"
             : selectedElement === "avatar"
               ? "Avatar"
               : "ProfileName"}
-        </TreeLine>
-        <TreeLine depth={2} tone="accent">
-          ProfileCard
-        </TreeLine>
-        <TreeLine depth={3} tone="accent">
-          PeoplePage
-        </TreeLine>
-        <div className="mt-4 border-t border-white/8 px-2 pt-4 font-mono text-[10px] leading-6 text-white/35">
-          <p>
-            latest <span className="text-white/65">getLatestFiber(fiber)</span>
-          </p>
-          <p>
-            kind <span className="text-white/65">isCompositeFiber → true</span>
-          </p>
-        </div>
+        </TreeRow>
+        <TreeRow depth={2}>ProfileCard</TreeRow>
+        <TreeRow depth={3}>PeoplePage</TreeRow>
+      </div>
+      <div className="rounded-lg bg-muted p-3 font-mono text-xs leading-5 text-muted-foreground">
+        <p>getLatestFiber(fiber)</p>
+        <p>isCompositeFiber(fiber) → true</p>
       </div>
     </div>
   );
 };
 
 const BuiltWithShowcase = () => (
-  <div className="grid h-full auto-rows-fr grid-cols-2 gap-3">
-    {[
-      ["react-scan", "render heat"],
-      ["bippy.dev", "fiber picker"],
-      ["owner stacks", "who rendered this"],
-      ["source maps", "where it lives"],
-    ].map(([title, detail], itemIndex) => (
-      <div
-        key={title}
-        className={cn(
-          "flex flex-col justify-between rounded-xl border p-4",
-          itemIndex === 0 ? "border-[#61dafb]/30 bg-[#61dafb]/7" : "border-white/8 bg-black/20",
-        )}
-      >
-        <span className="font-mono text-[9px] text-white/25">0{itemIndex + 1}</span>
-        <div>
-          <p className={cn("text-sm font-medium", itemIndex === 0 ? accentText : "text-white/75")}>
-            {title}
-          </p>
-          <p className="mt-1 text-xs text-white/30">{detail}</p>
+  <div className="flex h-full flex-col gap-4">
+    <ShowcaseHeader description="Different tools, same access to React's renderer.">
+      built with bippy
+    </ShowcaseHeader>
+    <div className="overflow-hidden rounded-lg border border-border bg-background">
+      {[
+        ["react-scan", "find expensive renders"],
+        ["bippy.dev", "inspect the current page"],
+        ["owner stacks", "find who rendered a component"],
+        ["source tools", "connect components to files"],
+      ].map(([title, description]) => (
+        <div
+          key={title}
+          className="flex items-center justify-between gap-4 border-b border-border px-3 py-3 last:border-b-0"
+        >
+          <span className="text-sm font-medium text-foreground">{title}</span>
+          <span className="text-right text-xs text-muted-foreground">{description}</span>
         </div>
-      </div>
-    ))}
+      ))}
+    </div>
   </div>
 );
 
 const FailureShowcase = () => (
-  <div className="flex h-full flex-col">
-    <div className="mb-5 flex items-center gap-3">
-      <div className="flex size-9 items-center justify-center rounded-full border border-orange-300/20 bg-orange-300/8 text-orange-200">
-        !
-      </div>
-      <div>
-        <p className="text-sm text-white/75">sharp tools, sharp edges</p>
-        <p className="text-xs text-white/30">know when the hook goes quiet</p>
-      </div>
-    </div>
-    <div className="space-y-2">
+  <div className="flex h-full flex-col gap-4">
+    <ShowcaseHeader description="Private internals have failure modes.">
+      check these first
+    </ShowcaseHeader>
+    <div className="overflow-hidden rounded-lg border border-border bg-background">
       {[
-        ["load order", "hook installed after React"],
-        ["production", "internals changed or stripped"],
+        ["load order", "the hook loaded after React"],
+        ["production", "the build changed React internals"],
         ["DevTools", "another hook owns the handshake"],
         ["server", "RSC has no client Fiber"],
-      ].map(([title, detail]) => (
+      ].map(([title, description]) => (
         <div
           key={title}
-          className="flex items-center justify-between gap-4 rounded-lg border border-white/8 bg-black/20 px-3 py-3"
+          className="border-b border-border px-3 py-3 last:border-b-0 sm:flex sm:items-center sm:justify-between sm:gap-4"
         >
-          <span className="font-mono text-[10px] text-orange-200/70">{title}</span>
-          <span className="text-right text-[11px] text-white/32">{detail}</span>
+          <span className="font-mono text-xs text-foreground">{title}</span>
+          <span className="mt-1 block text-xs text-muted-foreground sm:mt-0">{description}</span>
         </div>
       ))}
     </div>
-    <div className="mt-auto rounded-xl border border-orange-300/15 bg-orange-300/5 p-4 text-xs leading-5 text-orange-100/55">
-      React internals are not a contract. Pin, test, fail soft, and expect repairs.
-    </div>
+    <p className="mt-auto rounded-lg bg-muted p-3 text-xs leading-relaxed text-muted-foreground">
+      Pin React and bippy, test production builds, and fail without breaking the app.
+    </p>
   </div>
 );
 
 const RecapShowcase = () => (
-  <div className="flex h-full flex-col justify-between gap-6">
-    <div>
-      <p className="font-mono text-[10px] tracking-[0.18em] text-[#61dafb] uppercase">you got it</p>
-      <h3 className="mt-3 max-w-sm text-3xl font-light tracking-tight text-white">
-        React renders.
-        <br />
-        bippy listens.
-      </h3>
-    </div>
-    <div className="space-y-3">
+  <div className="flex h-full flex-col gap-4">
+    <ShowcaseHeader description="The small API map.">bippy in five lines</ShowcaseHeader>
+    <div className="space-y-2 text-sm text-muted-foreground">
       {[
-        "install before React",
-        "subscribe to commits",
-        "visit only rendered Fibers",
-        "walk between DOM and components",
-        "build the impossible tool",
-      ].map((item) => (
-        <div key={item} className="flex items-center gap-3 text-sm text-white/58">
-          <span className="flex size-5 items-center justify-center rounded-full bg-[#61dafb]/10 font-mono text-[10px] text-[#61dafb]">
-            ✓
-          </span>
-          {item}
+        ["import", "install the hook before React"],
+        ["instrument", "subscribe to renderer events"],
+        ["traverseRenderedFibers", "visit commit work"],
+        ["getFiber", "go from host node to React"],
+        ["traverseFiber", "walk the tree"],
+      ].map(([method, description]) => (
+        <div key={method} className="rounded-lg border border-border bg-background p-3">
+          <code className="font-mono text-xs text-foreground">{method}</code>
+          <p className="mt-1 text-xs">{description}</p>
         </div>
       ))}
     </div>
-    <a
-      className="flex items-center justify-between rounded-xl border border-[#61dafb]/25 bg-[#61dafb]/8 p-4 text-sm text-[#61dafb] transition hover:bg-[#61dafb]/12"
-      href="https://github.com/aidenybai/bippy#api-reference"
-    >
-      open the API reference
-      <span aria-hidden="true">↗</span>
-    </a>
+    <Button
+      className="mt-auto"
+      nativeButton={false}
+      render={<a href="https://github.com/aidenybai/bippy#api-reference">API reference</a>}
+    />
   </div>
 );
 
@@ -611,7 +448,7 @@ export const GuideShowcase = ({ activeSectionIndex, compact = false }: GuideShow
   const ActiveShowcase = showcaseComponents[activeSectionIndex] ?? IntroShowcase;
 
   return (
-    <ShowcaseFrame key={activeSectionIndex} compact={compact} sectionIndex={activeSectionIndex}>
+    <ShowcaseFrame key={activeSectionIndex} compact={compact}>
       <ActiveShowcase />
     </ShowcaseFrame>
   );

--- a/packages/website/components/guide/guide-showcases.tsx
+++ b/packages/website/components/guide/guide-showcases.tsx
@@ -1,0 +1,629 @@
+"use client";
+
+import { useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface GuideShowcaseProps {
+  activeSectionIndex: number;
+  compact?: boolean;
+}
+
+interface ShowcaseFrameProps {
+  children: React.ReactNode;
+  compact: boolean;
+  sectionIndex: number;
+}
+
+interface CodeWindowProps {
+  children: React.ReactNode;
+  filename: string;
+}
+
+interface TreeLineProps {
+  children: React.ReactNode;
+  depth?: number;
+  isActive?: boolean;
+  tone?: "accent" | "muted" | "plain";
+}
+
+interface PhaseRowProps {
+  name: string;
+  phase: "mount" | "unmount" | "update";
+}
+
+const accentText = "text-[#61dafb]";
+const accentBackground = "bg-[#61dafb]";
+
+const TreeLine = ({ children, depth = 0, isActive = false, tone = "plain" }: TreeLineProps) => (
+  <div
+    className={cn(
+      "flex h-7 items-center rounded-sm px-2 font-mono text-xs",
+      isActive && "bg-[#61dafb]/12",
+      tone === "accent" && accentText,
+      tone === "muted" && "text-white/38",
+      tone === "plain" && "text-white/75",
+    )}
+    style={{ paddingLeft: `${depth * 14 + 8}px` }}
+  >
+    <span className="mr-1.5 text-white/25">›</span>
+    {children}
+  </div>
+);
+
+const CodeWindow = ({ children, filename }: CodeWindowProps) => (
+  <div className="overflow-hidden rounded-xl border border-white/10 bg-black/35">
+    <div className="flex h-9 items-center justify-between border-b border-white/8 px-3 font-mono text-[10px] text-white/40">
+      <span>{filename}</span>
+      <span className={accentText}>● live</span>
+    </div>
+    <pre className="overflow-x-auto p-4 font-mono text-[11px] leading-5 text-white/66">
+      <code>{children}</code>
+    </pre>
+  </div>
+);
+
+const ShowcaseFrame = ({ children, compact, sectionIndex }: ShowcaseFrameProps) => (
+  <div
+    className={cn(
+      "relative flex min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#14161b] shadow-2xl shadow-black/35",
+      compact ? "h-[430px]" : "h-[min(760px,calc(100dvh-3rem))]",
+    )}
+  >
+    <div className="flex h-11 shrink-0 items-center justify-between border-b border-white/8 px-4">
+      <div className="flex gap-1.5">
+        <span className="size-2 rounded-full bg-white/15" />
+        <span className="size-2 rounded-full bg-white/15" />
+        <span className={cn("size-2 rounded-full", accentBackground)} />
+      </div>
+      <span className="font-mono text-[10px] tracking-[0.18em] text-white/35">
+        {String(sectionIndex + 1).padStart(2, "0")} / 10
+      </span>
+    </div>
+    <div className="min-h-0 flex-1 p-4 sm:p-6">{children}</div>
+  </div>
+);
+
+const IntroShowcase = () => {
+  const [renderCount, setRenderCount] = useState(1);
+
+  return (
+    <div className="flex h-full flex-col justify-between gap-6">
+      <div>
+        <p className="mb-2 font-mono text-[10px] tracking-[0.2em] text-white/35 uppercase">
+          a live render
+        </p>
+        <h3 className="text-xl font-medium tracking-tight text-white">Counter</h3>
+      </div>
+      <button
+        className="group relative mx-auto flex aspect-square w-48 flex-col items-center justify-center rounded-full border border-[#61dafb]/35 bg-[#61dafb]/6 transition hover:bg-[#61dafb]/10 active:scale-[0.98]"
+        onClick={() => setRenderCount((currentRenderCount) => currentRenderCount + 1)}
+        type="button"
+      >
+        <span className="font-mono text-[10px] tracking-[0.2em] text-[#61dafb]/70 uppercase">
+          click to render
+        </span>
+        <span className="mt-2 text-6xl font-light tabular-nums text-white">{renderCount - 1}</span>
+        <span className="absolute inset-3 rounded-full border border-[#61dafb]/10 transition group-hover:inset-2" />
+      </button>
+      <div className="rounded-xl border border-white/8 bg-black/25 p-3 font-mono text-[11px]">
+        <div className="flex justify-between text-white/38">
+          <span>component</span>
+          <span className={accentText}>Counter</span>
+        </div>
+        <div className="mt-2 flex justify-between text-white/38">
+          <span>renders observed</span>
+          <span className="text-white/80">{renderCount}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const TwoTreesShowcase = () => {
+  const [isFiberVisible, setIsFiberVisible] = useState(true);
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div className="grid grid-cols-2 rounded-lg bg-black/25 p-1 text-xs">
+        <button
+          className={cn(
+            "rounded-md px-3 py-2 transition",
+            !isFiberVisible ? "bg-white/10 text-white" : "text-white/38",
+          )}
+          onClick={() => setIsFiberVisible(false)}
+          type="button"
+        >
+          DOM
+        </button>
+        <button
+          className={cn(
+            "rounded-md px-3 py-2 transition",
+            isFiberVisible ? "bg-[#61dafb]/12 text-[#61dafb]" : "text-white/38",
+          )}
+          onClick={() => setIsFiberVisible(true)}
+          type="button"
+        >
+          Fiber
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-white/8 bg-black/20 p-3">
+        {isFiberVisible ? (
+          <div>
+            <TreeLine tone="muted">HostRoot</TreeLine>
+            <TreeLine depth={1} tone="accent">
+              App
+            </TreeLine>
+            <TreeLine depth={2} tone="accent">
+              ProfileCard
+            </TreeLine>
+            <TreeLine depth={3}>article</TreeLine>
+            <TreeLine depth={4} tone="accent" isActive>
+              Avatar
+            </TreeLine>
+            <TreeLine depth={5}>img</TreeLine>
+            <TreeLine depth={4} tone="accent">
+              FollowButton
+            </TreeLine>
+            <TreeLine depth={5}>button</TreeLine>
+            <div className="mt-4 border-t border-white/8 pt-4 font-mono text-[11px] leading-6 text-white/45">
+              <p>
+                <span className="text-white/25">props </span>
+                {"{ size: 40, status: \"online\" }"}
+              </p>
+              <p>
+                <span className="text-white/25">state </span>
+                {"{ isFollowing: false }"}
+              </p>
+              <p>
+                <span className="text-white/25">owner </span>
+                <span className={accentText}>ProfileCard</span>
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <TreeLine tone="muted">html</TreeLine>
+            <TreeLine depth={1} tone="muted">
+              body
+            </TreeLine>
+            <TreeLine depth={2}>main</TreeLine>
+            <TreeLine depth={3}>article.card</TreeLine>
+            <TreeLine depth={4}>div.flex</TreeLine>
+            <TreeLine depth={5} isActive>
+              img.rounded-full
+            </TreeLine>
+            <TreeLine depth={4}>button.bg-cyan</TreeLine>
+            <div className="mt-5 rounded-lg border border-dashed border-white/10 p-4 text-center text-xs leading-5 text-white/35">
+              The DOM knows boxes and attributes.
+              <br />
+              It forgot who made them.
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const HookShowcase = () => (
+  <div className="flex h-full flex-col justify-center">
+    <div className="relative space-y-7">
+      {[
+        ["01", "import \"bippy\"", "install the hook"],
+        ["02", "renderer.inject()", "React phones home"],
+        ["03", "onCommitFiberRoot", "every committed tree"],
+      ].map(([step, label, detail], stepIndex) => (
+        <div key={step} className="relative flex items-center gap-4">
+          {stepIndex < 2 && (
+            <div className="absolute top-12 left-[19px] h-7 w-px bg-gradient-to-b from-[#61dafb]/60 to-[#61dafb]/10" />
+          )}
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-full border border-[#61dafb]/25 bg-[#61dafb]/8 font-mono text-[10px] text-[#61dafb]">
+            {step}
+          </div>
+          <div className="min-w-0 flex-1 rounded-xl border border-white/8 bg-black/20 px-4 py-3">
+            <p className="truncate font-mono text-xs text-white/80">{label}</p>
+            <p className="mt-1 text-xs text-white/35">{detail}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+    <div className="mt-9 rounded-xl border border-[#61dafb]/15 bg-[#61dafb]/5 p-4 text-sm leading-6 text-white/58">
+      bippy takes the same handshake React DevTools uses. It just arrives first.
+    </div>
+  </div>
+);
+
+const InstrumentShowcase = () => {
+  const [isSubscribed, setIsSubscribed] = useState(true);
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <CodeWindow filename="instrument.ts">
+        <span className={accentText}>{"const unsubscribe"}</span>
+        {" = instrument({\n"}
+        {"  onActive() {\n"}
+        {"    ready()\n"}
+        {"  },\n"}
+        {"  onCommitFiberRoot(_, root) {\n"}
+        {"    inspect(root)\n"}
+        {"  },\n"}
+        {"})"}
+      </CodeWindow>
+      <div className="flex items-center justify-between rounded-xl border border-white/8 bg-black/20 p-4">
+        <div>
+          <p className="text-sm text-white/75">commit listener</p>
+          <p className="mt-1 font-mono text-[10px] text-white/30">
+            {isSubscribed ? "receiving roots" : "unsubscribed"}
+          </p>
+        </div>
+        <button
+          className={cn(
+            "rounded-full border px-3 py-1.5 font-mono text-[10px] transition",
+            isSubscribed
+              ? "border-[#61dafb]/30 bg-[#61dafb]/10 text-[#61dafb]"
+              : "border-white/10 text-white/35",
+          )}
+          onClick={() => setIsSubscribed((currentValue) => !currentValue)}
+          type="button"
+        >
+          {isSubscribed ? "active" : "resume"}
+        </button>
+      </div>
+      <div className="mt-auto grid grid-cols-2 gap-3 text-center">
+        <div className="rounded-lg border border-white/8 p-3">
+          <p className="text-lg text-white">1</p>
+          <p className="mt-1 text-[10px] text-white/35">patched hook</p>
+        </div>
+        <div className="rounded-lg border border-white/8 p-3">
+          <p className="text-lg text-white">∞</p>
+          <p className="mt-1 text-[10px] text-white/35">subscriptions</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const PhaseRow = ({ name, phase }: PhaseRowProps) => (
+  <div className="flex items-center justify-between rounded-lg border border-white/8 bg-black/18 px-3 py-2.5">
+    <span className="font-mono text-xs text-white/65">{name}</span>
+    <span
+      className={cn(
+        "rounded-full px-2 py-0.5 font-mono text-[9px]",
+        phase === "mount" && "bg-emerald-400/10 text-emerald-300",
+        phase === "update" && "bg-[#61dafb]/10 text-[#61dafb]",
+        phase === "unmount" && "bg-orange-400/10 text-orange-300",
+      )}
+    >
+      {phase}
+    </span>
+  </div>
+);
+
+const RenderedFibersShowcase = () => {
+  const [commitNumber, setCommitNumber] = useState(1);
+  const isInitialCommit = commitNumber === 1;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="mb-5 flex items-end justify-between">
+        <div>
+          <p className="font-mono text-[10px] tracking-[0.18em] text-white/30 uppercase">commit</p>
+          <p className="mt-1 text-3xl font-light text-white">#{commitNumber}</p>
+        </div>
+        <button
+          className="rounded-full bg-white px-4 py-2 text-xs font-medium text-black transition hover:bg-[#61dafb]"
+          onClick={() => setCommitNumber((currentCommitNumber) => currentCommitNumber + 1)}
+          type="button"
+        >
+          update count
+        </button>
+      </div>
+      <div className="space-y-2">
+        <PhaseRow name="Counter" phase={isInitialCommit ? "mount" : "update"} />
+        <PhaseRow name="button" phase={isInitialCommit ? "mount" : "update"} />
+        {isInitialCommit && <PhaseRow name="StaticFooter" phase="mount" />}
+      </div>
+      <div className="mt-5 rounded-xl border border-white/8 bg-black/20 p-4 font-mono text-[10px] leading-5 text-white/38">
+        <p className="text-white/65">traverseRenderedFibers(root)</p>
+        <p className="mt-2">
+          visited <span className={accentText}>{isInitialCommit ? 3 : 2}</span> fibers
+        </p>
+        <p>
+          skipped <span className="text-white/65">{isInitialCommit ? 0 : 1}</span> unchanged branch
+        </p>
+      </div>
+      <p className="mt-auto text-xs leading-5 text-white/30">
+        A full walk sees everything. A rendered walk sees what changed now.
+      </p>
+    </div>
+  );
+};
+
+const MiniScanShowcase = () => {
+  const [firstCount, setFirstCount] = useState(0);
+  const [secondCount, setSecondCount] = useState(0);
+  const [highlightedCard, setHighlightedCard] = useState<"first" | "second">("first");
+
+  const updateFirstCard = (): void => {
+    setFirstCount((currentCount) => currentCount + 1);
+    setHighlightedCard("first");
+  };
+
+  const updateSecondCard = (): void => {
+    setSecondCount((currentCount) => currentCount + 1);
+    setHighlightedCard("second");
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="mb-4 flex items-center justify-between">
+        <p className="font-mono text-[10px] tracking-[0.18em] text-white/30 uppercase">
+          mini react-scan
+        </p>
+        <span className="flex items-center gap-1.5 text-[10px] text-white/35">
+          <span className="size-1.5 animate-pulse rounded-full bg-[#61dafb]" />
+          watching
+        </span>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+        <button
+          className={cn(
+            "relative rounded-xl border bg-black/20 p-5 text-left transition",
+            highlightedCard === "first"
+              ? "border-[#61dafb] shadow-[0_0_0_3px_rgba(97,218,251,0.1)]"
+              : "border-white/8",
+          )}
+          onClick={updateFirstCard}
+          type="button"
+        >
+          <span className="text-xs text-white/35">Inbox</span>
+          <span className="mt-5 block text-4xl font-light text-white">{firstCount}</span>
+          {highlightedCard === "first" && (
+            <span className="absolute -top-2 left-3 rounded bg-[#61dafb] px-1.5 py-0.5 font-mono text-[8px] text-black">
+              Counter · update
+            </span>
+          )}
+        </button>
+        <button
+          className={cn(
+            "relative rounded-xl border bg-black/20 p-5 text-left transition",
+            highlightedCard === "second"
+              ? "border-[#61dafb] shadow-[0_0_0_3px_rgba(97,218,251,0.1)]"
+              : "border-white/8",
+          )}
+          onClick={updateSecondCard}
+          type="button"
+        >
+          <span className="text-xs text-white/35">Drafts</span>
+          <span className="mt-5 block text-4xl font-light text-white">{secondCount}</span>
+          {highlightedCard === "second" && (
+            <span className="absolute -top-2 left-3 rounded bg-[#61dafb] px-1.5 py-0.5 font-mono text-[8px] text-black">
+              Counter · update
+            </span>
+          )}
+        </button>
+      </div>
+      <CodeWindow filename="scan.ts">
+        {"traverseRenderedFibers(root, (fiber, phase) => {\n"}
+        {"  if (phase !== \"update\") return\n"}
+        {"  const host = traverseFiber(fiber,\n"}
+        {"    (candidate) => isHostFiber(candidate))\n"}
+        {"  outline(host?.stateNode)\n"}
+        {"})"}
+      </CodeWindow>
+    </div>
+  );
+};
+
+const ReverseLookupShowcase = () => {
+  const [selectedElement, setSelectedElement] = useState("button");
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div className="rounded-xl border border-white/8 bg-black/20 p-4">
+        <div className="flex items-center gap-3">
+          <button
+            aria-label="Inspect avatar"
+            className={cn(
+              "size-11 rounded-full border bg-gradient-to-br from-[#61dafb]/35 to-violet-400/20 transition",
+              selectedElement === "avatar" ? "border-[#61dafb] ring-3 ring-[#61dafb]/10" : "border-white/10",
+            )}
+            onClick={() => setSelectedElement("avatar")}
+            type="button"
+          />
+          <div className="min-w-0 flex-1">
+            <button
+              className={cn(
+                "rounded border px-1 text-left text-sm text-white transition",
+                selectedElement === "name" ? "border-[#61dafb]" : "border-transparent",
+              )}
+              onClick={() => setSelectedElement("name")}
+              type="button"
+            >
+              Aiden
+            </button>
+            <p className="mt-1 text-xs text-white/35">@aidenybai</p>
+          </div>
+          <button
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-xs transition",
+              selectedElement === "button"
+                ? "border-[#61dafb] bg-[#61dafb]/10 text-[#61dafb]"
+                : "border-white/10 text-white/65",
+            )}
+            onClick={() => setSelectedElement("button")}
+            type="button"
+          >
+            Follow
+          </button>
+        </div>
+      </div>
+      <div className="flex items-center justify-center gap-2 py-1 font-mono text-[10px] text-white/28">
+        <span>DOM node</span>
+        <span className={accentText}>→</span>
+        <span>getFiber</span>
+        <span className={accentText}>→</span>
+        <span>owner</span>
+      </div>
+      <div className="min-h-0 flex-1 rounded-xl border border-white/8 bg-black/20 p-3">
+        <TreeLine tone="plain">
+          {selectedElement === "button"
+            ? "button"
+            : selectedElement === "avatar"
+              ? "img"
+              : "span"}
+        </TreeLine>
+        <TreeLine depth={1} tone="accent" isActive>
+          {selectedElement === "button"
+            ? "FollowButton"
+            : selectedElement === "avatar"
+              ? "Avatar"
+              : "ProfileName"}
+        </TreeLine>
+        <TreeLine depth={2} tone="accent">
+          ProfileCard
+        </TreeLine>
+        <TreeLine depth={3} tone="accent">
+          PeoplePage
+        </TreeLine>
+        <div className="mt-4 border-t border-white/8 px-2 pt-4 font-mono text-[10px] leading-6 text-white/35">
+          <p>
+            latest <span className="text-white/65">getLatestFiber(fiber)</span>
+          </p>
+          <p>
+            kind <span className="text-white/65">isCompositeFiber → true</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const BuiltWithShowcase = () => (
+  <div className="grid h-full auto-rows-fr grid-cols-2 gap-3">
+    {[
+      ["react-scan", "render heat"],
+      ["bippy.dev", "fiber picker"],
+      ["owner stacks", "who rendered this"],
+      ["source maps", "where it lives"],
+    ].map(([title, detail], itemIndex) => (
+      <div
+        key={title}
+        className={cn(
+          "flex flex-col justify-between rounded-xl border p-4",
+          itemIndex === 0
+            ? "border-[#61dafb]/30 bg-[#61dafb]/7"
+            : "border-white/8 bg-black/20",
+        )}
+      >
+        <span className="font-mono text-[9px] text-white/25">0{itemIndex + 1}</span>
+        <div>
+          <p className={cn("text-sm font-medium", itemIndex === 0 ? accentText : "text-white/75")}>
+            {title}
+          </p>
+          <p className="mt-1 text-xs text-white/30">{detail}</p>
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+const FailureShowcase = () => (
+  <div className="flex h-full flex-col">
+    <div className="mb-5 flex items-center gap-3">
+      <div className="flex size-9 items-center justify-center rounded-full border border-orange-300/20 bg-orange-300/8 text-orange-200">
+        !
+      </div>
+      <div>
+        <p className="text-sm text-white/75">sharp tools, sharp edges</p>
+        <p className="text-xs text-white/30">know when the hook goes quiet</p>
+      </div>
+    </div>
+    <div className="space-y-2">
+      {[
+        ["load order", "hook installed after React"],
+        ["production", "internals changed or stripped"],
+        ["DevTools", "another hook owns the handshake"],
+        ["server", "RSC has no client Fiber"],
+      ].map(([title, detail]) => (
+        <div
+          key={title}
+          className="flex items-center justify-between gap-4 rounded-lg border border-white/8 bg-black/20 px-3 py-3"
+        >
+          <span className="font-mono text-[10px] text-orange-200/70">{title}</span>
+          <span className="text-right text-[11px] text-white/32">{detail}</span>
+        </div>
+      ))}
+    </div>
+    <div className="mt-auto rounded-xl border border-orange-300/15 bg-orange-300/5 p-4 text-xs leading-5 text-orange-100/55">
+      React internals are not a contract. Pin, test, fail soft, and expect repairs.
+    </div>
+  </div>
+);
+
+const RecapShowcase = () => (
+  <div className="flex h-full flex-col justify-between gap-6">
+    <div>
+      <p className="font-mono text-[10px] tracking-[0.18em] text-[#61dafb] uppercase">you got it</p>
+      <h3 className="mt-3 max-w-sm text-3xl font-light tracking-tight text-white">
+        React renders.
+        <br />
+        bippy listens.
+      </h3>
+    </div>
+    <div className="space-y-3">
+      {[
+        "install before React",
+        "subscribe to commits",
+        "visit only rendered Fibers",
+        "walk between DOM and components",
+        "build the impossible tool",
+      ].map((item) => (
+        <div key={item} className="flex items-center gap-3 text-sm text-white/58">
+          <span className="flex size-5 items-center justify-center rounded-full bg-[#61dafb]/10 font-mono text-[10px] text-[#61dafb]">
+            ✓
+          </span>
+          {item}
+        </div>
+      ))}
+    </div>
+    <a
+      className="flex items-center justify-between rounded-xl border border-[#61dafb]/25 bg-[#61dafb]/8 p-4 text-sm text-[#61dafb] transition hover:bg-[#61dafb]/12"
+      href="https://github.com/aidenybai/bippy#api-reference"
+    >
+      open the API reference
+      <span aria-hidden="true">↗</span>
+    </a>
+  </div>
+);
+
+const showcaseComponents = [
+  IntroShowcase,
+  TwoTreesShowcase,
+  HookShowcase,
+  InstrumentShowcase,
+  RenderedFibersShowcase,
+  MiniScanShowcase,
+  ReverseLookupShowcase,
+  BuiltWithShowcase,
+  FailureShowcase,
+  RecapShowcase,
+];
+
+export const GuideShowcase = ({
+  activeSectionIndex,
+  compact = false,
+}: GuideShowcaseProps) => {
+  const ActiveShowcase = showcaseComponents[activeSectionIndex] ?? IntroShowcase;
+
+  return (
+    <ShowcaseFrame
+      key={activeSectionIndex}
+      compact={compact}
+      sectionIndex={activeSectionIndex}
+    >
+      <ActiveShowcase />
+    </ShowcaseFrame>
+  );
+};

--- a/packages/website/components/guide/guide-showcases.tsx
+++ b/packages/website/components/guide/guide-showcases.tsx
@@ -169,7 +169,7 @@ const TwoTreesShowcase = () => {
             <div className="mt-4 border-t border-white/8 pt-4 font-mono text-[11px] leading-6 text-white/45">
               <p>
                 <span className="text-white/25">props </span>
-                {"{ size: 40, status: \"online\" }"}
+                {'{ size: 40, status: "online" }'}
               </p>
               <p>
                 <span className="text-white/25">state </span>
@@ -210,7 +210,7 @@ const HookShowcase = () => (
   <div className="flex h-full flex-col justify-center">
     <div className="relative space-y-7">
       {[
-        ["01", "import \"bippy\"", "install the hook"],
+        ["01", 'import "bippy"', "install the hook"],
         ["02", "renderer.inject()", "React phones home"],
         ["03", "onCommitFiberRoot", "every committed tree"],
       ].map(([step, label, detail], stepIndex) => (
@@ -406,7 +406,7 @@ const MiniScanShowcase = () => {
       </div>
       <CodeWindow filename="scan.ts">
         {"traverseRenderedFibers(root, (fiber, phase) => {\n"}
-        {"  if (phase !== \"update\") return\n"}
+        {'  if (phase !== "update") return\n'}
         {"  const host = traverseFiber(fiber,\n"}
         {"    (candidate) => isHostFiber(candidate))\n"}
         {"  outline(host?.stateNode)\n"}
@@ -427,7 +427,9 @@ const ReverseLookupShowcase = () => {
             aria-label="Inspect avatar"
             className={cn(
               "size-11 rounded-full border bg-gradient-to-br from-[#61dafb]/35 to-violet-400/20 transition",
-              selectedElement === "avatar" ? "border-[#61dafb] ring-3 ring-[#61dafb]/10" : "border-white/10",
+              selectedElement === "avatar"
+                ? "border-[#61dafb] ring-3 ring-[#61dafb]/10"
+                : "border-white/10",
             )}
             onClick={() => setSelectedElement("avatar")}
             type="button"
@@ -468,11 +470,7 @@ const ReverseLookupShowcase = () => {
       </div>
       <div className="min-h-0 flex-1 rounded-xl border border-white/8 bg-black/20 p-3">
         <TreeLine tone="plain">
-          {selectedElement === "button"
-            ? "button"
-            : selectedElement === "avatar"
-              ? "img"
-              : "span"}
+          {selectedElement === "button" ? "button" : selectedElement === "avatar" ? "img" : "span"}
         </TreeLine>
         <TreeLine depth={1} tone="accent" isActive>
           {selectedElement === "button"
@@ -512,9 +510,7 @@ const BuiltWithShowcase = () => (
         key={title}
         className={cn(
           "flex flex-col justify-between rounded-xl border p-4",
-          itemIndex === 0
-            ? "border-[#61dafb]/30 bg-[#61dafb]/7"
-            : "border-white/8 bg-black/20",
+          itemIndex === 0 ? "border-[#61dafb]/30 bg-[#61dafb]/7" : "border-white/8 bg-black/20",
         )}
       >
         <span className="font-mono text-[9px] text-white/25">0{itemIndex + 1}</span>
@@ -611,18 +607,11 @@ const showcaseComponents = [
   RecapShowcase,
 ];
 
-export const GuideShowcase = ({
-  activeSectionIndex,
-  compact = false,
-}: GuideShowcaseProps) => {
+export const GuideShowcase = ({ activeSectionIndex, compact = false }: GuideShowcaseProps) => {
   const ActiveShowcase = showcaseComponents[activeSectionIndex] ?? IntroShowcase;
 
   return (
-    <ShowcaseFrame
-      key={activeSectionIndex}
-      compact={compact}
-      sectionIndex={activeSectionIndex}
-    >
+    <ShowcaseFrame key={activeSectionIndex} compact={compact} sectionIndex={activeSectionIndex}>
       <ActiveShowcase />
     </ShowcaseFrame>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new `/guide` explainer with ten scroll-synced chapters
- use the existing bippy website tokens, Geist typography, UI components, compact density, and homepage voice
- reuse the real `FiberTreeDemo` for live Fiber examples instead of illustrated DevTools chrome
- cover hook timing, `instrument()`, rendered Fiber traversal, a mini render scanner, DOM lookup, use cases, and failure modes
- point the homepage “Get started” CTA to the guide

## Screenshot
[Restyled bippy guide with compact article and live Fiber inspector](https://cursor.com/agents/bc-3536315c-857b-4fe0-ae4a-bd99f2d7a4ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fguide-restyled-compact-desktop.webp)

## Verification
- `pnpm run check`
- `pnpm exec tsc --noEmit` in `packages/website`
- `pnpm run build` in `packages/website`
- React Doctor changed-files scan: 100/100
- manually verified homepage navigation, desktop scroll sync, real Fiber inspector, DOM/Fiber toggle, subscription and render controls, mini-scan interactions, mobile stacking, and no horizontal overflow
- no browser runtime errors

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3536315c-857b-4fe0-ae4a-bd99f2d7a4ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3536315c-857b-4fe0-ae4a-bd99f2d7a4ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

