### PR TITLE
test: harden useFiber production coverage

### DIFF
--- a/packages/bippy/tests/production-renderers-process.test.ts
+++ b/packages/bippy/tests/production-renderers-process.test.ts
@@ -11,7 +11,7 @@ interface ProductionRendererFixture {
 const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const bippyEntryUrl = pathToFileURL(resolve(packageDirectory, "src/index.ts")).href;
 
-const wait = (duration: number): string =>
+const delay = (duration: number): string =>
   `await new Promise((resolvePromise) => setTimeout(resolvePromise, ${duration}));`;
 
 const productionRendererFixtures: ProductionRendererFixture[] = [
@@ -21,13 +21,13 @@ const productionRendererFixtures: ProductionRendererFixture[] = [
       const renderer = await import("react-nil");
       createHostElement = (revision) => React.createElement("nil-view", { revision });
       renderer.render(React.createElement(Probe, { revision: 1 }));
-      ${wait(20)}
+      await waitForRevision(1);
       const mountedFiber = verifyMountedFiber();
       renderer.render(React.createElement(Probe, { revision: 2 }));
-      ${wait(20)}
+      await waitForRevision(2);
       verifyUpdatedFiber(mountedFiber);
       renderer.render(null);
-      ${wait(20)}
+      ${delay(20)}
     `,
   },
   {
@@ -37,10 +37,10 @@ const productionRendererFixtures: ProductionRendererFixture[] = [
       const { render } = await import("ink-testing-library");
       createHostElement = (revision) => React.createElement(Text, null, String(revision));
       const instance = render(React.createElement(Probe, { revision: 1 }));
-      ${wait(30)}
+      await waitForRevision(1);
       const mountedFiber = verifyMountedFiber();
       instance.rerender(React.createElement(Probe, { revision: 2 }));
-      ${wait(30)}
+      await waitForRevision(2);
       verifyUpdatedFiber(mountedFiber);
       instance.unmount();
       instance.cleanup();
@@ -108,10 +108,10 @@ const productionRendererFixtures: ProductionRendererFixture[] = [
       createHostElement = (revision) =>
         React.createElement("bippy-production-test", { id: String(revision) });
       root.render(React.createElement(Probe, { revision: 1 }));
-      ${wait(30)}
+      await waitForRevision(1);
       const mountedFiber = verifyMountedFiber();
       root.render(React.createElement(Probe, { revision: 2 }));
-      ${wait(30)}
+      await waitForRevision(2);
       verifyUpdatedFiber(mountedFiber);
       root.unmount();
       engine.detach();
@@ -136,10 +136,10 @@ const productionRendererFixtures: ProductionRendererFixture[] = [
       createHostElement = (revision) =>
         React.createElement("pixiContainer", { label: String(revision) });
       await root.render(React.createElement(Probe, { revision: 1 }), {});
-      ${wait(20)}
+      await waitForRevision(1);
       const mountedFiber = verifyMountedFiber();
       await root.render(React.createElement(Probe, { revision: 2 }), {});
-      ${wait(20)}
+      await waitForRevision(2);
       verifyUpdatedFiber(mountedFiber);
       await root.render(null, {});
     `,
@@ -276,15 +276,15 @@ const productionRendererFixtures: ProductionRendererFixture[] = [
       createHostElement = (revision) =>
         React.createElement("group", { name: String(revision) });
       root.render(React.createElement(Probe, { revision: 1 }));
-      ${wait(30)}
       reactThreeFiber.reconciler.flushSyncWork();
+      await waitForRevision(1);
       const mountedFiber = verifyMountedFiber();
       root.render(React.createElement(Probe, { revision: 2 }));
-      ${wait(30)}
       reactThreeFiber.reconciler.flushSyncWork();
+      await waitForRevision(2);
       verifyUpdatedFiber(mountedFiber);
       root.unmount();
-      ${wait(10)}
+      ${delay(10)}
     `,
   },
 ];
@@ -302,6 +302,15 @@ const createProductionScript = (rendererScript: string): string => `
   let expectedStateInitializerCalls = 1;
   let stateInitializerCalls = 0;
   let wasBindRestoredDuringRender = true;
+  const waitForRevision = async (expectedRevision) => {
+    const deadline = Date.now() + 2_000;
+    while (observedFiber?.memoizedProps?.revision !== expectedRevision) {
+      if (Date.now() >= deadline) {
+        throw new Error(\`renderer did not render revision \${expectedRevision}\`);
+      }
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 1));
+    }
+  };
   const Probe = ({ revision }) => {
     observedFiber = Bippy.useFiber();
     wasBindRestoredDuringRender &&= Function.prototype.bind === originalBind;

--- a/packages/bippy/tests/use-fiber-version-matrix.test.ts
+++ b/packages/bippy/tests/use-fiber-version-matrix.test.ts
@@ -132,6 +132,14 @@ const runRuntime = (
     const originalBind = Function.prototype.bind;
     const mountedRoots = [];
 
+    const waitFor = async (condition, message) => {
+      const deadline = Date.now() + 2_000;
+      while (!condition()) {
+        if (Date.now() >= deadline) throw new Error(message);
+        await new Promise((resolvePromise) => setTimeout(resolvePromise, 1));
+      }
+    };
+
     const flush = (callback) => {
       if (typeof ReactDOM.flushSync === "function") {
         ReactDOM.flushSync(callback);
@@ -170,27 +178,49 @@ const runRuntime = (
     };
 
     let observedFiber;
+    let observedSecondFiber;
+    let stateInitializerCalls = 0;
     let updateState;
+    let wasBindRestoredDuringRender = true;
     const Probe = ({ revision }) => {
+      const [, setState] = React.useState(() => {
+        stateInitializerCalls += 1;
+        return 0;
+      });
       observedFiber = Bippy.useFiber();
-      const [, setState] = React.useState(0);
+      wasBindRestoredDuringRender &&= Function.prototype.bind === originalBind;
+      observedSecondFiber = Bippy.useFiber();
+      wasBindRestoredDuringRender &&= Function.prototype.bind === originalBind;
       updateState = setState;
       return React.createElement("div", null, revision);
     };
     const probeRoot = mount(React.createElement(Probe, { revision: 1 }));
     const mountedFiber = observedFiber;
     assertFiber(mountedFiber, Probe);
-    probeRoot.render(React.createElement(Probe, { revision: 2 }));
-    const propsUpdatedFiber = observedFiber;
-    assertFiber(propsUpdatedFiber, Probe);
-    assert.notEqual(propsUpdatedFiber, mountedFiber);
-    assert.equal(propsUpdatedFiber.alternate, mountedFiber);
-    assert.equal(propsUpdatedFiber.memoizedProps.revision, 2);
-    assert.equal(Bippy.getLatestFiber(mountedFiber), propsUpdatedFiber);
+    assert.equal(observedSecondFiber, mountedFiber);
+
+    let previousFiber = mountedFiber;
+    for (let revision = 2; revision <= 12; revision += 1) {
+      probeRoot.render(React.createElement(Probe, { revision }));
+      const propsUpdatedFiber = observedFiber;
+      assertFiber(propsUpdatedFiber, Probe);
+      assert.equal(observedSecondFiber, propsUpdatedFiber);
+      assert.notEqual(propsUpdatedFiber, previousFiber);
+      assert.equal(propsUpdatedFiber.alternate, previousFiber);
+      assert.equal(propsUpdatedFiber.memoizedProps.revision, revision);
+      assert.equal(Bippy.getLatestFiber(previousFiber), propsUpdatedFiber);
+      previousFiber = propsUpdatedFiber;
+    }
+
     flush(() => updateState(1));
     const stateUpdatedFiber = observedFiber;
     assertFiber(stateUpdatedFiber, Probe);
-    assert.notEqual(stateUpdatedFiber, propsUpdatedFiber);
+    assert.equal(observedSecondFiber, stateUpdatedFiber);
+    assert.notEqual(stateUpdatedFiber, previousFiber);
+    assert.equal(stateUpdatedFiber.alternate, previousFiber);
+    assert.equal(stateUpdatedFiber.memoizedProps.revision, 12);
+    assert.equal(stateInitializerCalls, 1);
+    assert.equal(wasBindRestoredDuringRender, true);
 
     const renderPhaseFibers = [];
     const RenderPhaseProbe = () => {
@@ -247,16 +277,22 @@ const runRuntime = (
       if (shouldSuspend) throw suspensePromise;
       return React.createElement("div", null, "ready");
     };
-    const suspenseElement = React.createElement(
-      React.Suspense,
-      { fallback: React.createElement("div", null, "loading") },
-      React.createElement(SuspenseProbe),
-    );
-    const suspenseRoot = mount(suspenseElement);
+    const createSuspenseElement = () =>
+      React.createElement(
+        React.Suspense,
+        { fallback: React.createElement("div", null, "loading") },
+        React.createElement(SuspenseProbe),
+      );
+    const suspenseRoot = mount(createSuspenseElement());
     assertFiber(suspendedFiber, SuspenseProbe);
+    assert.equal(suspenseRoot.container.textContent, "loading");
     shouldSuspend = false;
     resolveSuspense();
-    suspenseRoot.render(suspenseElement);
+    suspenseRoot.render(createSuspenseElement());
+    await waitFor(
+      () => suspenseRoot.container.textContent === "ready",
+      "suspended component did not resolve",
+    );
     assertFiber(suspendedFiber, SuspenseProbe);
 
     let thrownFiber;
@@ -285,9 +321,10 @@ const runRuntime = (
     }
     assertFiber(thrownFiber, ThrowingProbe);
 
+    let firstComponentFiber;
     let remountedFiber;
     const FirstComponent = () => {
-      Bippy.useFiber();
+      firstComponentFiber = Bippy.useFiber();
       return null;
     };
     const ReplacementComponent = () => {
@@ -295,8 +332,19 @@ const runRuntime = (
       return null;
     };
     const replacementRoot = mount(React.createElement(FirstComponent));
+    assertFiber(firstComponentFiber, FirstComponent);
     replacementRoot.render(React.createElement(ReplacementComponent));
     assertFiber(remountedFiber, ReplacementComponent);
+    assert.notEqual(remountedFiber, firstComponentFiber);
+
+    const strictModeFibers = [];
+    const StrictModeProbe = () => {
+      strictModeFibers.push(Bippy.useFiber());
+      return null;
+    };
+    mount(React.createElement(React.StrictMode, null, React.createElement(StrictModeProbe)));
+    assert.ok(strictModeFibers.length >= 1);
+    strictModeFibers.forEach((fiber) => assertFiber(fiber, StrictModeProbe));
 
     if (typeof React.startTransition === "function") {
       let transitionFiber;
@@ -310,9 +358,11 @@ const runRuntime = (
       mount(React.createElement(TransitionProbe));
       const fiberBeforeTransition = transitionFiber;
       React.startTransition(() => setTransitionState(1));
-      await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+      await waitFor(
+        () => transitionFiber !== fiberBeforeTransition,
+        "transition did not render a new fiber",
+      );
       assertFiber(transitionFiber, TransitionProbe);
-      assert.notEqual(transitionFiber, fiberBeforeTransition);
     }
 
     let serverFiber = "not-rendered";
@@ -341,7 +391,7 @@ const runRuntime = (
         hydrationContainer,
         React.createElement(HydrationProbe),
       );
-      await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+      await waitFor(() => Bippy.isFiber(observedFiber), "hydration did not capture a fiber");
       mountedRoots.push({
         container: hydrationContainer,
         render: () => {},

--- a/packages/e2e/fixtures/astro-app/src/components/test-app.tsx
+++ b/packages/e2e/fixtures/astro-app/src/components/test-app.tsx
@@ -1,8 +1,11 @@
 import * as bippy from "bippy";
 import * as bippySource from "bippy/source";
 import type { Fiber } from "bippy";
+import { createFiberReference } from "../../../fiber-reference";
+import { createUseFiberScenarios } from "../../../use-fiber-scenarios";
 
-import React, {
+import * as React from "react";
+import {
   Component,
   Fragment,
   Suspense,
@@ -13,20 +16,34 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 
 declare global {
   interface Window {
     __BIPPY__: typeof bippy & typeof bippySource;
     __USE_FIBER__: Fiber | undefined;
+    __USE_FIBER_MATCH__: boolean;
   }
 }
 
+const { FiberProvider, useFiber: useReferenceFiber } = createFiberReference(React);
+const UseFiberScenarios = createUseFiberScenarios({
+  createPortal,
+  react: React,
+  useFiber: bippy.useFiber,
+  useReferenceFiber,
+});
 const TestContext = createContext("default-context");
 
 export const UseFiberProbe = () => {
+  const referenceFiber = useReferenceFiber();
   const fiber = bippy.useFiber();
   const [revision, setRevision] = useState(0);
-  if (typeof window !== "undefined") window.__USE_FIBER__ = fiber;
+  if (typeof window !== "undefined") {
+    window.__USE_FIBER__ = fiber;
+    window.__USE_FIBER_MATCH__ =
+      fiber !== undefined && (fiber === referenceFiber || fiber === referenceFiber?.alternate);
+  }
 
   return (
     <button data-testid="use-fiber-update" onClick={() => setRevision((previous) => previous + 1)}>
@@ -110,9 +127,10 @@ export const TestHarness = () => {
   }, []);
 
   return (
-    <>
+    <FiberProvider>
       <UseFiberProbe />
+      <UseFiberScenarios />
       <TestParent />
-    </>
+    </FiberProvider>
   );
 };

--- a/packages/e2e/fixtures/fiber-reference.ts
+++ b/packages/e2e/fixtures/fiber-reference.ts
@@ -1,0 +1,67 @@
+import type { Fiber } from "bippy";
+import type * as React from "react";
+
+interface FiberReferenceProviderProps {
+  children?: React.ReactNode;
+}
+
+interface FiberReference {
+  FiberProvider: React.ComponentType<FiberReferenceProviderProps>;
+  useFiber: () => Fiber | undefined;
+}
+
+const getFiberByHookValue = (
+  fiber: Fiber | null | undefined,
+  hookValue: unknown,
+): Fiber | undefined => {
+  if (!fiber) return undefined;
+
+  let currentHook = fiber.memoizedState;
+  while (currentHook) {
+    if (currentHook.memoizedState === hookValue) return fiber;
+    currentHook = currentHook.next;
+  }
+
+  let childFiber = fiber.child;
+  while (childFiber) {
+    const matchedFiber = getFiberByHookValue(childFiber, hookValue);
+    if (matchedFiber) return matchedFiber;
+    childFiber = childFiber.sibling;
+  }
+
+  return undefined;
+};
+
+export const createFiberReference = (react: typeof React): FiberReference => {
+  const FiberContext = react.createContext<Fiber | null>(null);
+
+  class FiberProvider extends react.Component<FiberReferenceProviderProps> {
+    declare _reactInternals: Fiber;
+
+    override render() {
+      return react.createElement(
+        FiberContext.Provider,
+        { value: this._reactInternals },
+        this.props.children,
+      );
+    }
+  }
+
+  const useFiber = (): Fiber | undefined => {
+    const providerFiber = react.useContext(FiberContext);
+    if (providerFiber === null) {
+      throw new Error("useFiber must be called within FiberProvider");
+    }
+    const [hookIdentifier] = react.useState<object>(() => ({}));
+
+    return react.useMemo(() => {
+      for (const rootFiber of [providerFiber, providerFiber?.alternate]) {
+        const matchedFiber = getFiberByHookValue(rootFiber, hookIdentifier);
+        if (matchedFiber) return matchedFiber;
+      }
+      return undefined;
+    }, [hookIdentifier, providerFiber]);
+  };
+
+  return { FiberProvider, useFiber };
+};

--- a/packages/e2e/fixtures/next-app/app/test-harness.tsx
+++ b/packages/e2e/fixtures/next-app/app/test-harness.tsx
@@ -3,8 +3,11 @@
 import * as bippy from "bippy";
 import * as bippySource from "bippy/source";
 import type { Fiber } from "bippy";
+import { createFiberReference } from "../../fiber-reference";
+import { createUseFiberScenarios } from "../../use-fiber-scenarios";
 
-import React, {
+import * as React from "react";
+import {
   Component,
   Fragment,
   Suspense,
@@ -15,20 +18,34 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 
 declare global {
   interface Window {
     __BIPPY__: typeof bippy & typeof bippySource;
     __USE_FIBER__: Fiber | undefined;
+    __USE_FIBER_MATCH__: boolean;
   }
 }
 
+const { FiberProvider, useFiber: useReferenceFiber } = createFiberReference(React);
+const UseFiberScenarios = createUseFiberScenarios({
+  createPortal,
+  react: React,
+  useFiber: bippy.useFiber,
+  useReferenceFiber,
+});
 const TestContext = createContext("default-context");
 
 export const UseFiberProbe = () => {
+  const referenceFiber = useReferenceFiber();
   const fiber = bippy.useFiber();
   const [revision, setRevision] = useState(0);
-  if (typeof window !== "undefined") window.__USE_FIBER__ = fiber;
+  if (typeof window !== "undefined") {
+    window.__USE_FIBER__ = fiber;
+    window.__USE_FIBER_MATCH__ =
+      fiber !== undefined && (fiber === referenceFiber || fiber === referenceFiber?.alternate);
+  }
 
   return (
     <button data-testid="use-fiber-update" onClick={() => setRevision((previous) => previous + 1)}>
@@ -112,9 +129,10 @@ export const TestHarness = () => {
   }, []);
 
   return (
-    <>
+    <FiberProvider>
       <UseFiberProbe />
+      <UseFiberScenarios />
       <TestParent />
-    </>
+    </FiberProvider>
   );
 };

--- a/packages/e2e/fixtures/react-router-app/app/test-harness.tsx
+++ b/packages/e2e/fixtures/react-router-app/app/test-harness.tsx
@@ -1,8 +1,11 @@
 import * as bippy from "bippy";
 import * as bippySource from "bippy/source";
 import type { Fiber } from "bippy";
+import { createFiberReference } from "../../fiber-reference";
+import { createUseFiberScenarios } from "../../use-fiber-scenarios";
 
-import React, {
+import * as React from "react";
+import {
   Component,
   Fragment,
   Suspense,
@@ -13,20 +16,34 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 
 declare global {
   interface Window {
     __BIPPY__: typeof bippy & typeof bippySource;
     __USE_FIBER__: Fiber | undefined;
+    __USE_FIBER_MATCH__: boolean;
   }
 }
 
+const { FiberProvider, useFiber: useReferenceFiber } = createFiberReference(React);
+const UseFiberScenarios = createUseFiberScenarios({
+  createPortal,
+  react: React,
+  useFiber: bippy.useFiber,
+  useReferenceFiber,
+});
 const TestContext = createContext("default-context");
 
 export const UseFiberProbe = () => {
+  const referenceFiber = useReferenceFiber();
   const fiber = bippy.useFiber();
   const [revision, setRevision] = useState(0);
-  if (typeof window !== "undefined") window.__USE_FIBER__ = fiber;
+  if (typeof window !== "undefined") {
+    window.__USE_FIBER__ = fiber;
+    window.__USE_FIBER_MATCH__ =
+      fiber !== undefined && (fiber === referenceFiber || fiber === referenceFiber?.alternate);
+  }
 
   return (
     <button data-testid="use-fiber-update" onClick={() => setRevision((previous) => previous + 1)}>
@@ -110,9 +127,10 @@ export const TestHarness = () => {
   }, []);
 
   return (
-    <>
+    <FiberProvider>
       <UseFiberProbe />
+      <UseFiberScenarios />
       <TestParent />
-    </>
+    </FiberProvider>
   );
 };

--- a/packages/e2e/fixtures/remix-app/app/test-harness.tsx
+++ b/packages/e2e/fixtures/remix-app/app/test-harness.tsx
@@ -1,8 +1,11 @@
 import * as bippy from "bippy";
 import * as bippySource from "bippy/source";
 import type { Fiber } from "bippy";
+import { createFiberReference } from "../../fiber-reference";
+import { createUseFiberScenarios } from "../../use-fiber-scenarios";
 
-import React, {
+import * as React from "react";
+import {
   Component,
   Fragment,
   Suspense,
@@ -13,20 +16,34 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 
 declare global {
   interface Window {
     __BIPPY__: typeof bippy & typeof bippySource;
     __USE_FIBER__: Fiber | undefined;
+    __USE_FIBER_MATCH__: boolean;
   }
 }
 
+const { FiberProvider, useFiber: useReferenceFiber } = createFiberReference(React);
+const UseFiberScenarios = createUseFiberScenarios({
+  createPortal,
+  react: React,
+  useFiber: bippy.useFiber,
+  useReferenceFiber,
+});
 const TestContext = createContext("default-context");
 
 export const UseFiberProbe = () => {
+  const referenceFiber = useReferenceFiber();
   const fiber = bippy.useFiber();
   const [revision, setRevision] = useState(0);
-  if (typeof window !== "undefined") window.__USE_FIBER__ = fiber;
+  if (typeof window !== "undefined") {
+    window.__USE_FIBER__ = fiber;
+    window.__USE_FIBER_MATCH__ =
+      fiber !== undefined && (fiber === referenceFiber || fiber === referenceFiber?.alternate);
+  }
 
   return (
     <button data-testid="use-fiber-update" onClick={() => setRevision((previous) => previous + 1)}>
@@ -110,9 +127,10 @@ export const TestHarness = () => {
   }, []);
 
   return (
-    <>
+    <FiberProvider>
       <UseFiberProbe />
+      <UseFiberScenarios />
       <TestParent />
-    </>
+    </FiberProvider>
   );
 };

--- a/packages/e2e/fixtures/rsbuild-app/rsbuild.config.ts
+++ b/packages/e2e/fixtures/rsbuild-app/rsbuild.config.ts
@@ -5,4 +5,7 @@ import { pluginReact } from "@rsbuild/plugin-react";
 // pipeline (react-refresh-webpack-plugin lineage), distinct from Vite's.
 export default defineConfig({
   plugins: [pluginReact()],
+  resolve: {
+    dedupe: ["react", "react-dom"],
+  },
 });

--- a/packages/e2e/fixtures/rsbuild-app/src/index.tsx
+++ b/packages/e2e/fixtures/rsbuild-app/src/index.tsx
@@ -21,12 +21,12 @@ window.__BIPPY__ = { ...bippy, ...bippySource };
 const rootElement = document.getElementById("root");
 if (rootElement) {
   createRoot(rootElement).render(
-    <FiberReferenceProvider>
-      <StrictMode>
+    <StrictMode>
+      <FiberReferenceProvider>
         <UseFiberProbe />
         <UseFiberScenarios />
-        <TestParent />
-      </StrictMode>
-    </FiberReferenceProvider>,
+      </FiberReferenceProvider>
+      <TestParent />
+    </StrictMode>,
   );
 }

--- a/packages/e2e/fixtures/rsbuild-app/src/index.tsx
+++ b/packages/e2e/fixtures/rsbuild-app/src/index.tsx
@@ -6,12 +6,13 @@ import type { Fiber } from "bippy";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
-import { TestParent, UseFiberProbe } from "./test-app";
+import { FiberReferenceProvider, TestParent, UseFiberProbe, UseFiberScenarios } from "./test-app";
 
 declare global {
   interface Window {
     __BIPPY__: typeof bippy & typeof bippySource;
     __USE_FIBER__: Fiber | undefined;
+    __USE_FIBER_MATCH__: boolean;
   }
 }
 
@@ -20,9 +21,12 @@ window.__BIPPY__ = { ...bippy, ...bippySource };
 const rootElement = document.getElementById("root");
 if (rootElement) {
   createRoot(rootElement).render(
-    <StrictMode>
-      <UseFiberProbe />
-      <TestParent />
-    </StrictMode>,
+    <FiberReferenceProvider>
+      <StrictMode>
+        <UseFiberProbe />
+        <UseFiberScenarios />
+        <TestParent />
+      </StrictMode>
+    </FiberReferenceProvider>,
   );
 }

--- a/packages/e2e/fixtures/rsbuild-app/src/test-app.tsx
+++ b/packages/e2e/fixtures/rsbuild-app/src/test-app.tsx
@@ -1,5 +1,8 @@
 import { useFiber } from "bippy";
-import React, {
+import { createFiberReference } from "../../fiber-reference";
+import { createUseFiberScenarios } from "../../use-fiber-scenarios";
+import * as React from "react";
+import {
   Component,
   Fragment,
   Suspense,
@@ -10,13 +13,27 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 
+const { FiberProvider: FiberReferenceProvider, useFiber: useReferenceFiber } =
+  createFiberReference(React);
+export const UseFiberScenarios = createUseFiberScenarios({
+  createPortal,
+  react: React,
+  useFiber,
+  useReferenceFiber,
+});
 const TestContext = createContext("default-context");
 
+export { FiberReferenceProvider };
+
 export const UseFiberProbe = () => {
+  const referenceFiber = useReferenceFiber();
   const fiber = useFiber();
   const [revision, setRevision] = useState(0);
   window.__USE_FIBER__ = fiber;
+  window.__USE_FIBER_MATCH__ =
+    fiber !== undefined && (fiber === referenceFiber || fiber === referenceFiber?.alternate);
 
   return (
     <button data-testid="use-fiber-update" onClick={() => setRevision((previous) => previous + 1)}>

--- a/packages/e2e/fixtures/tanstack-app/src/test-harness.tsx
+++ b/packages/e2e/fixtures/tanstack-app/src/test-harness.tsx
@@ -3,7 +3,10 @@ import "bippy/install-hook-only";
 import * as bippy from "bippy";
 import * as bippySource from "bippy/source";
 import type { Fiber } from "bippy";
-import React, {
+import { createFiberReference } from "../../fiber-reference";
+import { createUseFiberScenarios } from "../../use-fiber-scenarios";
+import * as React from "react";
+import {
   Component,
   Fragment,
   Suspense,
@@ -14,20 +17,34 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 
 declare global {
   interface Window {
     __BIPPY__: typeof bippy & typeof bippySource;
     __USE_FIBER__: Fiber | undefined;
+    __USE_FIBER_MATCH__: boolean;
   }
 }
 
+const { FiberProvider, useFiber: useReferenceFiber } = createFiberReference(React);
+const UseFiberScenarios = createUseFiberScenarios({
+  createPortal,
+  react: React,
+  useFiber: bippy.useFiber,
+  useReferenceFiber,
+});
 const TestContext = createContext("default-context");
 
 export const UseFiberProbe = () => {
+  const referenceFiber = useReferenceFiber();
   const fiber = bippy.useFiber();
   const [revision, setRevision] = useState(0);
-  if (typeof window !== "undefined") window.__USE_FIBER__ = fiber;
+  if (typeof window !== "undefined") {
+    window.__USE_FIBER__ = fiber;
+    window.__USE_FIBER_MATCH__ =
+      fiber !== undefined && (fiber === referenceFiber || fiber === referenceFiber?.alternate);
+  }
 
   return (
     <button data-testid="use-fiber-update" onClick={() => setRevision((previous) => previous + 1)}>
@@ -111,9 +128,10 @@ export const TestHarness = () => {
   }, []);
 
   return (
-    <>
+    <FiberProvider>
       <UseFiberProbe />
+      <UseFiberScenarios />
       <TestParent />
-    </>
+    </FiberProvider>
   );
 };

--- a/packages/e2e/fixtures/use-fiber-scenarios.ts
+++ b/packages/e2e/fixtures/use-fiber-scenarios.ts
@@ -1,0 +1,371 @@
+import type { Fiber } from "bippy";
+import type * as React from "react";
+
+interface UseFiberScenariosOptions {
+  createPortal: (
+    children: React.ReactNode,
+    container: Element | DocumentFragment,
+  ) => React.ReactPortal;
+  react: typeof React;
+  useFiber: () => Fiber | undefined;
+  useReferenceFiber: () => Fiber | undefined;
+}
+
+interface RevisionProps {
+  revision: number;
+}
+
+interface RemountProbeProps {
+  generation: number;
+}
+
+interface ScenarioErrorBoundaryProps {
+  children?: React.ReactNode;
+}
+
+interface ScenarioErrorBoundaryState {
+  hasError: boolean;
+}
+
+interface LazyScenarioModule {
+  default: React.ComponentType;
+}
+
+const isMatchingReferenceFiber = (
+  fiber: Fiber | undefined,
+  referenceFiber: Fiber | undefined,
+): boolean => {
+  if (typeof window === "undefined") {
+    return fiber === undefined && referenceFiber === undefined;
+  }
+  return fiber !== undefined && (fiber === referenceFiber || fiber === referenceFiber?.alternate);
+};
+
+export const createUseFiberScenarios = ({
+  createPortal,
+  react,
+  useFiber,
+  useReferenceFiber,
+}: UseFiberScenariosOptions): React.ComponentType => {
+  const useFiberMatch = (): boolean => {
+    const referenceFiber = useReferenceFiber();
+    const firstFiber = useFiber();
+    const secondFiber = useFiber();
+    return firstFiber === secondFiber && isMatchingReferenceFiber(firstFiber, referenceFiber);
+  };
+
+  const createMatchOutput = (testId: string, isMatch: boolean, value?: React.ReactNode) =>
+    react.createElement(
+      "output",
+      { "data-fiber-match": String(isMatch), "data-testid": testId },
+      value ?? String(isMatch),
+    );
+
+  const SiblingProbe = ({ revision }: RevisionProps) => {
+    const isMatch = useFiberMatch();
+    return createMatchOutput(`use-fiber-sibling-${revision}`, isMatch);
+  };
+
+  const HookOrderProbe = () => {
+    const [revision, setRevision] = react.useState(0);
+    const isMatch = useFiberMatch();
+    react.useReducer((state: number) => state, revision);
+    return react.createElement(
+      "button",
+      {
+        "data-fiber-match": String(isMatch),
+        "data-testid": "use-fiber-hook-order",
+        onClick: () => setRevision((previousRevision) => previousRevision + 1),
+      },
+      revision,
+    );
+  };
+
+  const ForwardRefProbe = react.forwardRef<HTMLDivElement>((_properties, forwardedReference) => {
+    const isMatch = useFiberMatch();
+    return react.createElement(
+      "div",
+      {
+        "data-fiber-match": String(isMatch),
+        "data-testid": "use-fiber-forward-ref",
+        ref: forwardedReference,
+      },
+      String(isMatch),
+    );
+  });
+
+  const MemoProbe = react.memo(({ revision }: RevisionProps) => {
+    const isMatch = useFiberMatch();
+    return createMatchOutput("use-fiber-memo", isMatch, revision);
+  });
+
+  const MemoHarness = () => {
+    const [revision, setRevision] = react.useState(0);
+    return react.createElement(
+      react.Fragment,
+      null,
+      react.createElement(
+        "button",
+        {
+          "data-testid": "use-fiber-memo-update",
+          onClick: () => setRevision((previousRevision) => previousRevision + 1),
+        },
+        revision,
+      ),
+      react.createElement(MemoProbe, { revision }),
+    );
+  };
+
+  const RenderPhaseProbe = () => {
+    const didEveryRenderMatch = react.useRef(true);
+    const isMatch = useFiberMatch();
+    didEveryRenderMatch.current &&= isMatch;
+    const [revision, setRevision] = react.useState(0);
+    if (revision === 0) setRevision(1);
+    return createMatchOutput("use-fiber-render-phase", didEveryRenderMatch.current, revision);
+  };
+
+  const useCommitEffect = typeof window === "undefined" ? react.useEffect : react.useLayoutEffect;
+  const CommitPhaseUpdateProbe = () => {
+    const [revision, setRevision] = react.useState(0);
+    const didEveryRenderMatch = react.useRef(true);
+    didEveryRenderMatch.current &&= useFiberMatch();
+    useCommitEffect(() => {
+      if (revision === 0) setRevision(1);
+    }, [revision]);
+    return createMatchOutput("use-fiber-commit-phase", didEveryRenderMatch.current, revision);
+  };
+
+  const BatchedUpdateProbe = () => {
+    const [revision, setRevision] = react.useState(0);
+    const isMatch = useFiberMatch();
+    const updateRevision = () => {
+      setRevision((previousRevision) => previousRevision + 1);
+      setRevision((previousRevision) => previousRevision + 1);
+    };
+    return react.createElement(
+      "button",
+      {
+        "data-fiber-match": String(isMatch),
+        "data-testid": "use-fiber-batched-update",
+        onClick: updateRevision,
+      },
+      revision,
+    );
+  };
+
+  const RemountProbe = ({ generation }: RemountProbeProps) => {
+    const isMatch = useFiberMatch();
+    return createMatchOutput("use-fiber-remount-result", isMatch, generation);
+  };
+
+  const RemountHarness = () => {
+    const [generation, setGeneration] = react.useState(0);
+    return react.createElement(
+      react.Fragment,
+      null,
+      react.createElement(
+        "button",
+        {
+          "data-testid": "use-fiber-remount",
+          onClick: () => setGeneration((previousGeneration) => previousGeneration + 1),
+        },
+        generation,
+      ),
+      react.createElement(RemountProbe, { generation, key: generation }),
+    );
+  };
+
+  const TransitionProbe = () => {
+    const [revision, setRevision] = react.useState(0);
+    const isMatch = useFiberMatch();
+    const startTransition = Reflect.get(react, "startTransition");
+    const updateRevision = () => {
+      if (typeof startTransition === "function") {
+        startTransition(() => setRevision((previousRevision) => previousRevision + 1));
+      } else {
+        setRevision((previousRevision) => previousRevision + 1);
+      }
+    };
+    return react.createElement(
+      "button",
+      {
+        "data-fiber-match": String(isMatch),
+        "data-testid": "use-fiber-transition",
+        onClick: updateRevision,
+      },
+      revision,
+    );
+  };
+
+  let didSuspendedRenderMatch = true;
+  let isSuspenseResolved = false;
+  let resolveSuspense: (() => void) | undefined;
+  const suspensePromise = new Promise<void>((resolvePromise) => {
+    resolveSuspense = resolvePromise;
+  });
+
+  const SuspenseProbe = () => {
+    const isMatch = useFiberMatch();
+    didSuspendedRenderMatch &&= isMatch;
+    if (!isSuspenseResolved) throw suspensePromise;
+    return createMatchOutput("use-fiber-suspense-result", didSuspendedRenderMatch);
+  };
+
+  const SuspenseFallback = () =>
+    createMatchOutput("use-fiber-suspense-fallback", didSuspendedRenderMatch);
+
+  const SuspenseHarness = () => {
+    const [isVisible, setIsVisible] = react.useState(false);
+    const resolveSuspenseBoundary = () => {
+      isSuspenseResolved = true;
+      resolveSuspense?.();
+    };
+    return react.createElement(
+      react.Fragment,
+      null,
+      react.createElement(
+        "button",
+        { "data-testid": "use-fiber-suspense-show", onClick: () => setIsVisible(true) },
+        String(isVisible),
+      ),
+      react.createElement(
+        "button",
+        {
+          "data-testid": "use-fiber-suspense-resolve",
+          onClick: resolveSuspenseBoundary,
+        },
+        String(isSuspenseResolved),
+      ),
+      isVisible
+        ? react.createElement(
+            react.Suspense,
+            { fallback: react.createElement(SuspenseFallback) },
+            react.createElement(SuspenseProbe),
+          )
+        : null,
+    );
+  };
+
+  const LazyProbeInner = () => {
+    const isMatch = useFiberMatch();
+    return createMatchOutput("use-fiber-lazy-result", isMatch);
+  };
+  let resolveLazyModule: ((module: LazyScenarioModule) => void) | undefined;
+  const lazyModulePromise = new Promise<LazyScenarioModule>((resolveModule) => {
+    resolveLazyModule = resolveModule;
+  });
+  const LazyProbe = react.lazy(() => lazyModulePromise);
+
+  const LazyHarness = () => {
+    const [isVisible, setIsVisible] = react.useState(false);
+    return react.createElement(
+      react.Fragment,
+      null,
+      react.createElement(
+        "button",
+        { "data-testid": "use-fiber-lazy-show", onClick: () => setIsVisible(true) },
+        String(isVisible),
+      ),
+      react.createElement(
+        "button",
+        {
+          "data-testid": "use-fiber-lazy-resolve",
+          onClick: () => resolveLazyModule?.({ default: LazyProbeInner }),
+        },
+        "resolve",
+      ),
+      isVisible
+        ? react.createElement(
+            react.Suspense,
+            {
+              fallback: react.createElement(
+                "output",
+                { "data-testid": "use-fiber-lazy-fallback" },
+                "loading",
+              ),
+            },
+            react.createElement(LazyProbe),
+          )
+        : null,
+    );
+  };
+
+  let didThrowingRenderMatch = false;
+  const ThrowingProbe = () => {
+    didThrowingRenderMatch = useFiberMatch();
+    throw new Error("expected useFiber fixture error");
+  };
+
+  class ScenarioErrorBoundary extends react.Component<
+    ScenarioErrorBoundaryProps,
+    ScenarioErrorBoundaryState
+  > {
+    override state = { hasError: false };
+
+    static getDerivedStateFromError(): ScenarioErrorBoundaryState {
+      return { hasError: true };
+    }
+
+    override render() {
+      return this.state.hasError
+        ? createMatchOutput("use-fiber-error-result", didThrowingRenderMatch)
+        : this.props.children;
+    }
+  }
+
+  const ErrorHarness = () => {
+    const [isVisible, setIsVisible] = react.useState(false);
+    return react.createElement(
+      react.Fragment,
+      null,
+      react.createElement(
+        "button",
+        { "data-testid": "use-fiber-error-show", onClick: () => setIsVisible(true) },
+        String(isVisible),
+      ),
+      isVisible
+        ? react.createElement(ScenarioErrorBoundary, null, react.createElement(ThrowingProbe))
+        : null,
+    );
+  };
+
+  const PortalProbe = () => {
+    const isMatch = useFiberMatch();
+    return createMatchOutput("use-fiber-portal", isMatch);
+  };
+
+  const PortalHarness = () => {
+    const [portalContainer, setPortalContainer] = react.useState<HTMLElement | null>(null);
+    react.useEffect(() => {
+      const container = document.createElement("div");
+      container.dataset.testid = "use-fiber-portal-container";
+      document.body.appendChild(container);
+      setPortalContainer(container);
+      return () => container.remove();
+    }, []);
+    return portalContainer ? createPortal(react.createElement(PortalProbe), portalContainer) : null;
+  };
+
+  const UseFiberScenarios = () =>
+    react.createElement(
+      "section",
+      { "data-testid": "use-fiber-scenarios" },
+      react.createElement(SiblingProbe, { revision: 1 }),
+      react.createElement(SiblingProbe, { revision: 2 }),
+      react.createElement(HookOrderProbe),
+      react.createElement(ForwardRefProbe),
+      react.createElement(MemoHarness),
+      react.createElement(RenderPhaseProbe),
+      react.createElement(CommitPhaseUpdateProbe),
+      react.createElement(BatchedUpdateProbe),
+      react.createElement(RemountHarness),
+      react.createElement(TransitionProbe),
+      react.createElement(SuspenseHarness),
+      react.createElement(LazyHarness),
+      react.createElement(ErrorHarness),
+      react.createElement(PortalHarness),
+    );
+
+  return UseFiberScenarios;
+};

--- a/packages/e2e/fixtures/use-fiber-versions-app/index.html
+++ b/packages/e2e/fixtures/use-fiber-versions-app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>useFiber React versions</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/e2e/fixtures/use-fiber-versions-app/package.json
+++ b/packages/e2e/fixtures/use-fiber-versions-app/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bippy/e2e-use-fiber-versions",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build:17": "pnpm typecheck && REACT_VERSION=17 vite build --outDir dist/react-17",
+    "build:18": "pnpm typecheck && REACT_VERSION=18 vite build --outDir dist/react-18",
+    "preview:17": "REACT_VERSION=17 vite preview --outDir dist/react-17",
+    "preview:18": "REACT_VERSION=18 vite preview --outDir dist/react-18",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "bippy": "workspace:*",
+    "react-17": "npm:react@17.0.2",
+    "react-18": "npm:react@18.3.1",
+    "react-dom-17": "npm:react-dom@17.0.2",
+    "react-dom-18": "npm:react-dom@18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
+    "typescript": "^5",
+    "vite": "^6"
+  }
+}

--- a/packages/e2e/fixtures/use-fiber-versions-app/src/main.ts
+++ b/packages/e2e/fixtures/use-fiber-versions-app/src/main.ts
@@ -1,0 +1,78 @@
+import "bippy/install-hook-only";
+
+import * as bippy from "bippy";
+import * as bippySource from "bippy/source";
+import type { Fiber } from "bippy";
+import { createFiberReference } from "../../fiber-reference";
+import { createUseFiberScenarios } from "../../use-fiber-scenarios";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { createPortal } from "react-dom";
+
+declare global {
+  interface Window {
+    __BIPPY__: typeof bippy & typeof bippySource;
+    __REACT_VERSION__: string;
+    __USE_FIBER__: Fiber | undefined;
+    __USE_FIBER_MATCH__: boolean;
+  }
+}
+
+const { FiberProvider, useFiber: useReferenceFiber } = createFiberReference(React);
+const UseFiberScenarios = createUseFiberScenarios({
+  createPortal,
+  react: React,
+  useFiber: bippy.useFiber,
+  useReferenceFiber,
+});
+
+const useFiberMatch = (referenceFiber: Fiber | undefined): boolean => {
+  const fiber = bippy.useFiber();
+  window.__USE_FIBER__ = fiber;
+  return fiber !== undefined && (fiber === referenceFiber || fiber === referenceFiber?.alternate);
+};
+
+const UseFiberProbe = () => {
+  const referenceFiber = useReferenceFiber();
+  const [revision, setRevision] = React.useState(0);
+  const isMatch = useFiberMatch(referenceFiber);
+  window.__USE_FIBER_MATCH__ = isMatch;
+  return React.createElement(
+    "button",
+    {
+      "data-fiber-match": String(isMatch),
+      "data-testid": "use-fiber-update",
+      onClick: () => setRevision((previousRevision) => previousRevision + 1),
+    },
+    revision,
+  );
+};
+
+const UseFiberVersionsApp = () =>
+  React.createElement(
+    FiberProvider,
+    null,
+    React.createElement(UseFiberProbe),
+    React.createElement(UseFiberScenarios),
+    React.createElement("div", { "data-testid": "test-child" }, React.version),
+  );
+
+window.__BIPPY__ = { ...bippy, ...bippySource };
+window.__REACT_VERSION__ = React.version;
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("root element not found");
+const appElement = React.createElement(UseFiberVersionsApp);
+const createRoot = Reflect.get(ReactDOM, "createRoot");
+if (typeof createRoot === "function") {
+  const reactRoot: unknown = Reflect.apply(createRoot, ReactDOM, [rootElement]);
+  if (typeof reactRoot !== "object" || reactRoot === null) {
+    throw new Error("createRoot did not return a root");
+  }
+  const renderRoot = Reflect.get(reactRoot, "render");
+  if (typeof renderRoot !== "function") throw new Error("root render method not found");
+  Reflect.apply(renderRoot, reactRoot, [appElement]);
+} else {
+  const legacyRender = Reflect.get(ReactDOM, "render");
+  if (typeof legacyRender !== "function") throw new Error("ReactDOM.render not found");
+  Reflect.apply(legacyRender, ReactDOM, [appElement, rootElement]);
+}

--- a/packages/e2e/fixtures/use-fiber-versions-app/tsconfig.json
+++ b/packages/e2e/fixtures/use-fiber-versions-app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src", "vite.config.ts", "../fiber-reference.ts", "../use-fiber-scenarios.ts"]
+}

--- a/packages/e2e/fixtures/use-fiber-versions-app/vite.config.ts
+++ b/packages/e2e/fixtures/use-fiber-versions-app/vite.config.ts
@@ -1,0 +1,22 @@
+import { dirname } from "node:path";
+import { createRequire } from "node:module";
+import { defineConfig } from "vite";
+
+const packageRequire = createRequire(import.meta.url);
+const reactVersion = process.env.REACT_VERSION;
+if (reactVersion !== "17" && reactVersion !== "18") {
+  throw new Error("REACT_VERSION must be 17 or 18");
+}
+const reactPackageName = `react-${reactVersion}`;
+const reactDOMPackageName = `react-dom-${reactVersion}`;
+const reactDirectory = dirname(packageRequire.resolve(`${reactPackageName}/package.json`));
+const reactDOMDirectory = dirname(packageRequire.resolve(`${reactDOMPackageName}/package.json`));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      react: reactDirectory,
+      "react-dom": reactDOMDirectory,
+    },
+  },
+});

--- a/packages/e2e/fixtures/vite-app/src/main.tsx
+++ b/packages/e2e/fixtures/vite-app/src/main.tsx
@@ -19,11 +19,11 @@ declare global {
 window.__BIPPY__ = { ...bippy, ...bippySource };
 
 createRoot(document.getElementById("root")!).render(
-  <FiberReferenceProvider>
-    <StrictMode>
+  <StrictMode>
+    <FiberReferenceProvider>
       <UseFiberProbe />
       <UseFiberScenarios />
-      <TestParent />
-    </StrictMode>
-  </FiberReferenceProvider>,
+    </FiberReferenceProvider>
+    <TestParent />
+  </StrictMode>,
 );

--- a/packages/e2e/fixtures/vite-app/src/main.tsx
+++ b/packages/e2e/fixtures/vite-app/src/main.tsx
@@ -6,20 +6,24 @@ import type { Fiber } from "bippy";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
-import { TestParent, UseFiberProbe } from "./test-app";
+import { FiberReferenceProvider, TestParent, UseFiberProbe, UseFiberScenarios } from "./test-app";
 
 declare global {
   interface Window {
     __BIPPY__: typeof bippy & typeof bippySource;
     __USE_FIBER__: Fiber | undefined;
+    __USE_FIBER_MATCH__: boolean;
   }
 }
 
 window.__BIPPY__ = { ...bippy, ...bippySource };
 
 createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <UseFiberProbe />
-    <TestParent />
-  </StrictMode>,
+  <FiberReferenceProvider>
+    <StrictMode>
+      <UseFiberProbe />
+      <UseFiberScenarios />
+      <TestParent />
+    </StrictMode>
+  </FiberReferenceProvider>,
 );

--- a/packages/e2e/fixtures/vite-app/src/test-app.tsx
+++ b/packages/e2e/fixtures/vite-app/src/test-app.tsx
@@ -1,5 +1,8 @@
 import { useFiber } from "bippy";
-import React, {
+import { createFiberReference } from "../../fiber-reference";
+import { createUseFiberScenarios } from "../../use-fiber-scenarios";
+import * as React from "react";
+import {
   Component,
   Fragment,
   Suspense,
@@ -10,13 +13,27 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 
+const { FiberProvider: FiberReferenceProvider, useFiber: useReferenceFiber } =
+  createFiberReference(React);
+export const UseFiberScenarios = createUseFiberScenarios({
+  createPortal,
+  react: React,
+  useFiber,
+  useReferenceFiber,
+});
 const TestContext = createContext("default-context");
 
+export { FiberReferenceProvider };
+
 export const UseFiberProbe = () => {
+  const referenceFiber = useReferenceFiber();
   const fiber = useFiber();
   const [revision, setRevision] = useState(0);
   window.__USE_FIBER__ = fiber;
+  window.__USE_FIBER_MATCH__ =
+    fiber !== undefined && (fiber === referenceFiber || fiber === referenceFiber?.alternate);
 
   return (
     <button data-testid="use-fiber-update" onClick={() => setRevision((previous) => previous + 1)}>

--- a/packages/e2e/playwright.production.config.ts
+++ b/packages/e2e/playwright.production.config.ts
@@ -11,6 +11,8 @@ const profilingPort = 5_182;
 const scriptTagPort = 5_183;
 const kitchenSinkPort = 5_184;
 const stressProductionPort = 5_185;
+const react17UseFiberPort = 5_186;
+const react18UseFiberPort = 5_187;
 
 const sharedProductionTestMatch = [/use-fiber\.spec\.ts/, /production\.spec\.ts/];
 const profilingTestMatch = /profiling\.spec\.ts/;
@@ -62,6 +64,16 @@ export default defineConfig({
       name: "astro-production",
       testMatch: sharedProductionTestMatch,
       use: { ...devices["Desktop Chrome"], baseURL: `http://localhost:${astroPort}` },
+    },
+    {
+      name: "react-17-use-fiber-production",
+      testMatch: /use-fiber\.spec\.ts/,
+      use: { ...devices["Desktop Chrome"], baseURL: `http://localhost:${react17UseFiberPort}` },
+    },
+    {
+      name: "react-18-use-fiber-production",
+      testMatch: /use-fiber\.spec\.ts/,
+      use: { ...devices["Desktop Chrome"], baseURL: `http://localhost:${react18UseFiberPort}` },
     },
     {
       name: "profiling",
@@ -124,6 +136,18 @@ export default defineConfig({
     {
       command: `nr --filter @bippy/e2e-astro build && nr --filter @bippy/e2e-astro preview --port ${astroPort}`,
       port: astroPort,
+      reuseExistingServer: false,
+      timeout: 60_000,
+    },
+    {
+      command: `pnpm --filter @bippy/e2e-use-fiber-versions build:17 && pnpm --filter @bippy/e2e-use-fiber-versions preview:17 --port ${react17UseFiberPort}`,
+      port: react17UseFiberPort,
+      reuseExistingServer: false,
+      timeout: 60_000,
+    },
+    {
+      command: `pnpm --filter @bippy/e2e-use-fiber-versions build:18 && pnpm --filter @bippy/e2e-use-fiber-versions preview:18 --port ${react18UseFiberPort}`,
+      port: react18UseFiberPort,
       reuseExistingServer: false,
       timeout: 60_000,
     },

--- a/packages/e2e/tests/global.d.ts
+++ b/packages/e2e/tests/global.d.ts
@@ -38,6 +38,7 @@ declare global {
   interface Window {
     __BIPPY__: typeof Bippy & typeof BippySource;
     __USE_FIBER__: Fiber | undefined;
+    __USE_FIBER_MATCH__: boolean;
     __COMMIT_COUNT__: number;
     __HMR_EFFECT_LOG__: string[];
     __BIPPY_PROBE_READY__: boolean | undefined;

--- a/packages/e2e/tests/web/use-fiber.spec.ts
+++ b/packages/e2e/tests/web/use-fiber.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { waitForBippy, waitForTestChild } from "./helpers";
+
+const expectFiberMatch = async (page: Page, testId: string) => {
+  await expect(page.getByTestId(testId)).toHaveAttribute("data-fiber-match", "true");
+};
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/");
@@ -7,49 +12,113 @@ test.beforeEach(async ({ page }) => {
   await waitForTestChild(page);
 });
 
-test("useFiber returns the exact calling fiber", async ({ page }) => {
-  const mountedResult = await page.evaluate(() => {
-    const parentElement = document.querySelector('[data-testid="parent-host"]');
-    if (!parentElement) throw new Error("parent host element not found");
-    const observedFiber = window.__USE_FIBER__
-      ? window.__BIPPY__.getLatestFiber(window.__USE_FIBER__)
-      : null;
-    const hostFiber = window.__BIPPY__.getFiberFromHostInstance(parentElement);
-    let rootFiber = hostFiber ? window.__BIPPY__.getLatestFiber(hostFiber) : null;
-    while (rootFiber?.return) rootFiber = rootFiber.return;
-    if (rootFiber) rootFiber = window.__BIPPY__.getLatestFiber(rootFiber);
-    const matchedFiber = window.__BIPPY__.traverseFiber(
-      rootFiber,
-      (candidateFiber) => candidateFiber === observedFiber,
-    );
-    return {
-      capturedExactFiber: observedFiber === matchedFiber,
-    };
-  });
+test("runs version fixtures against the expected React production line", async ({
+  page,
+}, testInfo) => {
+  const isReact17 = testInfo.project.name.startsWith("react-17");
+  const isReact18 = testInfo.project.name.startsWith("react-18");
+  testInfo.skip(!isReact17 && !isReact18);
+  await expect(page.getByTestId("test-child")).toContainText(isReact17 ? "17." : "18.");
+});
 
-  expect(mountedResult.capturedExactFiber).toBe(true);
+test("server rendering returns undefined without breaking FiberProvider checks", async ({
+  page,
+}, testInfo) => {
+  const serverRenderedProjects = [
+    "nextjs-production",
+    "tanstack-production",
+    "react-router-production",
+    "remix-production",
+    "astro-production",
+  ];
+  testInfo.skip(!serverRenderedProjects.includes(testInfo.project.name));
+  const response = await page.request.get("/");
+  const markup = await response.text();
+  expect(markup).toContain('data-testid="use-fiber-render-phase"');
+  expect(markup).not.toContain('data-fiber-match="false"');
+});
 
-  await page.getByTestId("use-fiber-update").click();
-  await expect(page.getByTestId("use-fiber-update")).toHaveText("1");
+test("useFiber matches an independent FiberProvider across repeated updates", async ({ page }) => {
+  expect(await page.evaluate(() => window.__USE_FIBER_MATCH__)).toBe(true);
 
-  const updatedResult = await page.evaluate(() => {
-    const parentElement = document.querySelector('[data-testid="parent-host"]');
-    if (!parentElement) throw new Error("parent host element not found");
-    const observedFiber = window.__USE_FIBER__
-      ? window.__BIPPY__.getLatestFiber(window.__USE_FIBER__)
-      : null;
-    const hostFiber = window.__BIPPY__.getFiberFromHostInstance(parentElement);
-    let rootFiber = hostFiber ? window.__BIPPY__.getLatestFiber(hostFiber) : null;
-    while (rootFiber?.return) rootFiber = rootFiber.return;
-    if (rootFiber) rootFiber = window.__BIPPY__.getLatestFiber(rootFiber);
-    const matchedFiber = window.__BIPPY__.traverseFiber(
-      rootFiber,
-      (candidateFiber) => candidateFiber === observedFiber,
-    );
-    return {
-      capturedExactFiber: observedFiber === matchedFiber,
-    };
-  });
+  const updateButton = page.getByTestId("use-fiber-update");
+  for (let revision = 1; revision <= 10; revision += 1) {
+    await updateButton.click();
+    await expect(updateButton).toHaveText(String(revision));
+    expect(await page.evaluate(() => window.__USE_FIBER_MATCH__)).toBe(true);
+  }
+});
 
-  expect(updatedResult).toEqual({ capturedExactFiber: true });
+test("useFiber matches for sibling, forward ref, memo, and render-phase components", async ({
+  page,
+}) => {
+  for (const testId of [
+    "use-fiber-sibling-1",
+    "use-fiber-sibling-2",
+    "use-fiber-hook-order",
+    "use-fiber-forward-ref",
+    "use-fiber-memo",
+    "use-fiber-render-phase",
+    "use-fiber-commit-phase",
+    "use-fiber-batched-update",
+    "use-fiber-remount-result",
+    "use-fiber-transition",
+    "use-fiber-portal",
+  ]) {
+    await expectFiberMatch(page, testId);
+  }
+});
+
+test("useFiber matches after batched, memo, remount, and transition updates", async ({ page }) => {
+  const hookOrderButton = page.getByTestId("use-fiber-hook-order");
+  const batchedUpdateButton = page.getByTestId("use-fiber-batched-update");
+  const memoButton = page.getByTestId("use-fiber-memo-update");
+  const remountButton = page.getByTestId("use-fiber-remount");
+  const transitionButton = page.getByTestId("use-fiber-transition");
+
+  await expect(page.getByTestId("use-fiber-commit-phase")).toHaveText("1");
+  await expectFiberMatch(page, "use-fiber-commit-phase");
+
+  for (let revision = 1; revision <= 5; revision += 1) {
+    await hookOrderButton.click();
+    await expect(hookOrderButton).toHaveText(String(revision));
+    await expectFiberMatch(page, "use-fiber-hook-order");
+
+    await batchedUpdateButton.click();
+    await expect(batchedUpdateButton).toHaveText(String(revision * 2));
+    await expectFiberMatch(page, "use-fiber-batched-update");
+
+    await memoButton.click();
+    await expect(page.getByTestId("use-fiber-memo")).toHaveText(String(revision));
+    await expectFiberMatch(page, "use-fiber-memo");
+
+    await remountButton.click();
+    await expect(page.getByTestId("use-fiber-remount-result")).toHaveText(String(revision));
+    await expectFiberMatch(page, "use-fiber-remount-result");
+
+    await transitionButton.click();
+    await expect(transitionButton).toHaveText(String(revision));
+    await expectFiberMatch(page, "use-fiber-transition");
+  }
+});
+
+test("useFiber matches renders that suspend and retry", async ({ page }) => {
+  await page.getByTestId("use-fiber-suspense-show").click();
+  await expectFiberMatch(page, "use-fiber-suspense-fallback");
+
+  await page.getByTestId("use-fiber-suspense-resolve").click();
+  await expectFiberMatch(page, "use-fiber-suspense-result");
+});
+
+test("useFiber matches lazy components after Suspense resolution", async ({ page }) => {
+  await page.getByTestId("use-fiber-lazy-show").click();
+  await expect(page.getByTestId("use-fiber-lazy-fallback")).toBeVisible();
+
+  await page.getByTestId("use-fiber-lazy-resolve").click();
+  await expectFiberMatch(page, "use-fiber-lazy-result");
+});
+
+test("useFiber matches fibers from failed renders", async ({ page }) => {
+  await page.getByTestId("use-fiber-error-show").click();
+  await expectFiberMatch(page, "use-fiber-error-result");
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -991,6 +991,37 @@ importers:
         specifier: ^7
         version: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
 
+  packages/e2e/fixtures/use-fiber-versions-app:
+    dependencies:
+      bippy:
+        specifier: workspace:*
+        version: link:../../../bippy
+      react-17:
+        specifier: npm:react@17.0.2
+        version: react@17.0.2
+      react-18:
+        specifier: npm:react@18.3.1
+        version: react@18.3.1
+      react-dom-17:
+        specifier: npm:react-dom@17.0.2
+        version: react-dom@17.0.2(react@19.2.8)
+      react-dom-18:
+        specifier: npm:react-dom@18.3.1
+        version: react-dom@18.3.1(react@19.2.8)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19.2.4
+        version: 19.2.4(@types/react@19.2.18)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vite:
+        specifier: ^6
+        version: 6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+
   packages/e2e/fixtures/vite-app:
     dependencies:
       bippy:


### PR DESCRIPTION
## Summary

- add an independent `_reactInternals` FiberProvider reference for validating `useFiber`
- cover repeated, render-phase, commit-phase, batched, transition, remount, portal, Suspense, lazy, failed-render, SSR, and hydration paths
- add production browser fixtures for React 17 and React 18, deterministic renderer waits, and React deduplication for Rsbuild

## Test plan

- `pnpm --filter bippy test`
- `pnpm check`
- production Playwright `useFiber` suite across Vite, Next.js, TanStack Start, React Router, Remix, Rsbuild, Astro, React 17, and React 18
- repeated production runs for the React version matrix and custom renderer suite
