### PR TITLE
fix: redirect bippy.dev to the GitHub README

### DIFF
--- a/packages/website/app/[[...slug]]/page.tsx
+++ b/packages/website/app/[[...slug]]/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
-const CatchAll = () => redirect("https://aidenybai.com/bippy");
+const CatchAll = () => redirect("https://github.com/aidenybai/bippy#readme");
 
 export default CatchAll;


### PR DESCRIPTION
## Summary

Point the website catch-all redirect at `https://github.com/aidenybai/bippy#readme` instead of `https://aidenybai.com/bippy`. This covers the homepage and ordinary nested routes. The existing `llm.txt` / `llms.txt` redirect remains unchanged.

## Validation

- `pnpm --filter @bippy/website build` passed.
- Started the production server and verified `/`, `/source`, and `/api/useFiber` return HTTP 307 with the exact GitHub URL, including `#readme`, in the Location header.
- `pnpm check` passed with the two existing E2E warnings.

No README edits or unrelated kitchen-sink changes included. The production domain will pick up this redirect after merge and deployment.