### PR TITLE
parser: MUI + Emotion parity fixture (mui-theme) and generic evaluator fixes

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -27,9 +27,10 @@
   "devDependencies": {
     "@babel/runtime": "^7.29.7",
     "@emotion/react": "11.14.0",
-    "@emotion/styled": "11.14.1",
+    "@emotion/styled": "11.14.0",
     "@lingui/core": "5.6.0",
     "@lingui/react": "5.6.0",
+    "@mui/material": "5.16.14",
     "@reduxjs/toolkit": "2.12.0",
     "@tanstack/react-query": "5.101.4",
     "@types/node": "^20",

--- a/packages/parser/src/evaluate/compiler-helpers.ts
+++ b/packages/parser/src/evaluate/compiler-helpers.ts
@@ -6,7 +6,9 @@ import {
   getObjectProperty,
   getTruthiness,
   isKnownList,
+  isNullish,
   listValue,
+  mapValue,
   objectValue,
   omitObjectKeys,
   primitiveValue,
@@ -68,17 +70,21 @@ const spreadArray: HelperImplementation = ([target, source]) => {
   return unknownValue("spread of an indefinite array");
 };
 
+/** `null == source` yields `{}`; the excluded keys must be a literal list for the rest to be known. */
 const objectWithoutProperties: HelperImplementation = ([source, excluded]) => {
   if (!source || !excluded) return source ?? UNDEFINED_VALUE;
-  if (source.kind !== "object" || !isKnownList(excluded)) {
-    return unknownValue("rest of a non-object");
-  }
+  if (!isKnownList(excluded)) return unknownValue("rest with dynamic excluded keys");
   const omitted = new Set<string>();
   for (const key of excluded.items) {
     if (key.kind !== "primitive") return unknownValue("rest with dynamic excluded keys");
     omitted.add(String(key.value));
   }
-  return omitObjectKeys(source, omitted);
+  return mapValue(source, (alternative) => {
+    if (isNullish(alternative) === true) return objectValue();
+    return alternative.kind === "object"
+      ? omitObjectKeys(alternative, omitted)
+      : unknownValue("rest of a non-object");
+  });
 };
 
 const defineProperty: HelperImplementation = ([target, key, value]) => {

--- a/packages/parser/src/evaluate/interpreter.ts
+++ b/packages/parser/src/evaluate/interpreter.ts
@@ -904,12 +904,27 @@ export class Interpreter {
           type.component.properties.set(propertyName, value);
           return target;
         }
+        const displayName =
+          propertyName === "displayName" &&
+          value.kind === "primitive" &&
+          typeof value.value === "string"
+            ? value.value
+            : null;
+        if (type.kind === "stub") {
+          if (displayName !== null) type.stub.displayName = displayName;
+          return target;
+        }
         if (type.kind !== "memo" && type.kind !== "forward-ref" && type.kind !== "lazy")
           return target;
         if (propertyName === "displayName") {
-          return value.kind === "primitive" && typeof value.value === "string"
-            ? componentReference({ ...type, displayName: value.value })
-            : target;
+          if (displayName === null) return target;
+          if (type.kind === "forward-ref") {
+            nameAnonymousInner(type.render, displayName);
+            type.component.name ??= type.render.name;
+          } else if (type.kind === "memo" && type.inner.kind === "function") {
+            nameAnonymousInner(type.inner.component, displayName);
+          }
+          return componentReference({ ...type, displayName });
         }
         type.properties.set(propertyName, value);
         return target;
@@ -1800,6 +1815,8 @@ export class Interpreter {
         if (key === "displayName")
           return type.displayName === null ? UNDEFINED_VALUE : primitiveValue(type.displayName);
         if (key === "$$typeof") return { kind: "symbol", key: WRAPPER_SYMBOL_KEYS[type.kind] };
+        if (type.kind === "forward-ref" && key === "render") return type.render;
+        if (type.kind === "memo" && key === "type") return componentReference(type.inner);
         if (WRAPPER_OWN_KEYS[type.kind].has(key))
           return unknownValue(`${type.kind}.${key}`, location);
         return UNDEFINED_VALUE;
@@ -3132,16 +3149,23 @@ export class Interpreter {
         location,
       );
     };
-    if (
-      discriminant.kind === "primitive" &&
-      caseValues.every((value) => value === null || value.kind === "primitive")
-    ) {
-      let matchIndex = caseValues.findIndex(
-        (value) =>
-          value !== null &&
-          value.kind === "primitive" &&
-          Object.is(value.value, discriminant.value),
+    let matchIndex = -1;
+    let isDecided = true;
+    for (const [caseIndex, caseValue] of caseValues.entries()) {
+      if (caseValue === null) continue;
+      const verdict = getTruthiness(
+        applyBinaryOperator("===", discriminant, caseValue, context.environment),
       );
+      if (verdict === true) {
+        matchIndex = caseIndex;
+        break;
+      }
+      if (verdict === null) {
+        isDecided = false;
+        break;
+      }
+    }
+    if (isDecided) {
       if (matchIndex === -1)
         matchIndex = statement.cases.findIndex((switchCase) => switchCase.test === null);
       return matchIndex === -1 ? proceed(context) : runThenProceed(matchIndex);
@@ -3487,6 +3511,16 @@ const applyBinaryOperator = (
     default:
       return unknownPrimitiveValue("number", `${operator} on dynamic values`);
   }
+};
+
+/** React's dev `displayName` setter on `memo`/`forwardRef` also names an anonymous inner function. */
+const nameAnonymousInner = (
+  inner: { name: string | null; properties: Map<string, StaticValue> },
+  displayName: string,
+): void => {
+  if (inner.name || inner.properties.has("displayName")) return;
+  inner.name = displayName;
+  inner.properties.set("displayName", primitiveValue(displayName));
 };
 
 const EQUALITY_OPERATORS = new Set(["===", "!==", "==", "!="]);

--- a/packages/parser/src/evaluate/react-calls.ts
+++ b/packages/parser/src/evaluate/react-calls.ts
@@ -372,6 +372,7 @@ export const evaluateReactApiCall = (
       return componentReference({
         kind: "forward-ref",
         component: createFunctionComponentDefinition(first, first.name),
+        render: first,
         displayName: null,
         properties: new Map(),
       });

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -202,7 +202,11 @@ export type StaticElementType =
   | { kind: "function"; component: ComponentDefinition }
   | { kind: "class"; component: ComponentDefinition }
   | ({ kind: "memo"; inner: StaticElementType; hasCompare: boolean } & WrapperElementType)
-  | ({ kind: "forward-ref"; component: ComponentDefinition } & WrapperElementType)
+  | ({
+      kind: "forward-ref";
+      component: ComponentDefinition;
+      render: StaticFunctionValue;
+    } & WrapperElementType)
   | ({ kind: "lazy"; inner: StaticElementType | null } & WrapperElementType)
   | { kind: "fragment" }
   | { kind: "strict-mode" }

--- a/packages/parser/tests/components/compiled-classic.js
+++ b/packages/parser/tests/components/compiled-classic.js
@@ -47,6 +47,31 @@ function _objectWithoutProperties(source, excluded) {
   return target;
 }
 
+/** MUI's `Menu`: rest of an optional prop object, `{}` when it was never passed. */
+function Transitioned(props) {
+  var _props$TransitionProp = props.TransitionProps,
+    _ref = _props$TransitionProp === void 0 ? {} : _props$TransitionProp,
+    onEntering = _ref.onEntering,
+    TransitionProps = _objectWithoutPropertiesLoose(props.TransitionProps, ["onEntering"]),
+    other = _objectWithoutPropertiesLoose(props, ["TransitionProps"]);
+  var keys = Object.keys(TransitionProps);
+  return React.createElement(
+    keys.length === 0 ? "i" : "b",
+    _extends({}, other, { "data-entering": typeof onEntering }),
+    keys.length,
+  );
+}
+
+function _objectWithoutPropertiesLoose(source, excluded) {
+  if (source == null) return {};
+  var target = {};
+  for (var key in source) {
+    if (excluded.indexOf(key) >= 0) continue;
+    target[key] = source[key];
+  }
+  return target;
+}
+
 var Memoized = /*#__PURE__*/ React.memo(function Memoized(_ref) {
   var value = _ref.value;
   return React.createElement("code", null, value);
@@ -62,6 +87,10 @@ export default function CompiledClassic() {
       { title: "panel" },
       React.createElement(Memoized, { value: "memo" }),
       React.createElement(React.StrictMode, null, React.createElement("hr", null)),
+      React.createElement(Transitioned, { title: "bare" }),
+      React.createElement(Transitioned, {
+        TransitionProps: { onEntering: function () {}, timeout: 200 },
+      }),
     ),
   );
 }

--- a/packages/parser/tests/components/display-names.tsx
+++ b/packages/parser/tests/components/display-names.tsx
@@ -1,0 +1,113 @@
+import styled from "@emotion/styled";
+import { type ComponentType, forwardRef, memo, type ReactNode } from "react";
+
+// `react-is`-style reflection over wrapper objects: a `switch` on `$$typeof`
+// symbols, `forwardRef(...).render` and `memo(...).type`, with the computed
+// name written back as `displayName` on both a plain wrapper and an emotion
+// styled component (the way MUI's `createStyled` does).
+
+const FORWARD_REF = Symbol.for("react.forward_ref");
+const MEMO = Symbol.for("react.memo");
+
+interface NamedFunction {
+  displayName?: string;
+  name: string;
+}
+
+interface WrapperObject {
+  $$typeof: symbol;
+  render?: NamedFunction;
+  type?: unknown;
+}
+
+const isWrapperObject = (value: unknown): value is WrapperObject =>
+  typeof value === "object" && value !== null && "$$typeof" in value;
+
+const getFunctionName = (render: NamedFunction, fallback: string): string =>
+  render.displayName || render.name || fallback;
+
+const getDisplayName = (Component: unknown): string | undefined => {
+  if (Component === null || Component === undefined) return undefined;
+  if (typeof Component === "string") return Component;
+  if (typeof Component === "function") return getFunctionName(Component, "Component");
+  if (!isWrapperObject(Component)) return undefined;
+  switch (Component.$$typeof) {
+    case FORWARD_REF:
+      return `ForwardRef(${Component.render ? getFunctionName(Component.render, "") : ""})`;
+    case MEMO:
+      return `memo(${getDisplayName(Component.type)})`;
+    default:
+      return undefined;
+  }
+};
+
+const withLabel = <P extends object>(Inner: ComponentType<P>): ComponentType<P> => {
+  const Labeled = (props: P) => <Inner {...props} />;
+  Labeled.displayName = `Labeled(${getDisplayName(Inner)})`;
+  return Labeled;
+};
+
+const Plain = ({ children }: { children?: ReactNode }) => <span>{children}</span>;
+
+const Field = forwardRef<HTMLInputElement, { placeholder: string }>(function Field(
+  { placeholder },
+  ref,
+) {
+  return <input ref={ref} placeholder={placeholder} />;
+});
+
+const Anonymous = forwardRef<HTMLElement>((_props, ref) => <i ref={ref} />);
+
+const Named = forwardRef<HTMLElement>((_props, ref) => <u ref={ref} />);
+Named.displayName = "Named";
+
+const Cached = memo(Plain);
+
+const CachedAnonymous = memo(() => <small>cached</small>);
+CachedAnonymous.displayName = "CachedAnonymous";
+
+const LabeledPlain = withLabel(Plain);
+const LabeledField = withLabel(Field);
+const LabeledAnonymous = withLabel(Anonymous);
+const LabeledNamed = withLabel(Named);
+const LabeledCached = withLabel(Cached);
+const LabeledCachedAnonymous = withLabel(CachedAnonymous);
+const LabeledMemoField = withLabel(memo(Field));
+
+const Root = styled("section", { label: "Card-root" })`
+  padding: 4px;
+`;
+Root.displayName = `Card${"Root"}`;
+
+const Nested = styled(Field)`
+  border: 0;
+`;
+Nested.displayName = "NestedField";
+
+const kindOf = (value: unknown): string => {
+  switch (typeof value) {
+    case "string":
+      return "text";
+    case "object":
+      return value === null ? "null" : "object";
+    default:
+      return "other";
+  }
+};
+
+export default function DisplayNames() {
+  return (
+    <Root>
+      <LabeledPlain>plain</LabeledPlain>
+      <LabeledField placeholder="field" />
+      <LabeledAnonymous />
+      <LabeledNamed />
+      <LabeledCached>cached</LabeledCached>
+      <LabeledCachedAnonymous />
+      <LabeledMemoField placeholder="memo field" />
+      <Nested placeholder="nested" />
+      <em>{kindOf(Field)}</em>
+      <em>{kindOf(null)}</em>
+    </Root>
+  );
+}

--- a/packages/parser/tests/fixtures/mui-theme/fixture.json
+++ b/packages/parser/tests/fixtures/mui-theme/fixture.json
@@ -1,0 +1,13 @@
+{
+  "expectedStatus": "exact",
+  "minCoverage": 1,
+  "externalPackages": [
+    "@mui/*",
+    "@babel/runtime/*",
+    "clsx",
+    "prop-types",
+    "react-is",
+    "react-transition-group"
+  ],
+  "notes": "MUI 5 over Emotion, interpreted from node_modules: ThemeProvider/createTheme, CssBaseline, Button/Typography/Box/Stack, styled() with theme callbacks and sx, useTheme/useMediaQuery, closed Dialog/Menu/Snackbar/Tooltip, TextField with useFormControl, plus AppBar/Drawer/List/Tabs/Table/Select/Accordion/Checkbox/Switch/Chip/Badge/Avatar/Alert."
+}

--- a/packages/parser/tests/fixtures/mui-theme/package.json
+++ b/packages/parser/tests/fixtures/mui-theme/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fixture-mui-theme",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@emotion/react": "11.14.0",
+    "@emotion/styled": "11.14.0",
+    "@mui/material": "5.16.14"
+  }
+}

--- a/packages/parser/tests/fixtures/mui-theme/src/app.tsx
+++ b/packages/parser/tests/fixtures/mui-theme/src/app.tsx
@@ -1,0 +1,199 @@
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Alert from "@mui/material/Alert";
+import AppBar from "@mui/material/AppBar";
+import Avatar from "@mui/material/Avatar";
+import Badge from "@mui/material/Badge";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Checkbox from "@mui/material/Checkbox";
+import Chip from "@mui/material/Chip";
+import CircularProgress from "@mui/material/CircularProgress";
+import CssBaseline from "@mui/material/CssBaseline";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import Divider from "@mui/material/Divider";
+import Drawer from "@mui/material/Drawer";
+import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import IconButton from "@mui/material/IconButton";
+import InputLabel from "@mui/material/InputLabel";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import Paper from "@mui/material/Paper";
+import Select from "@mui/material/Select";
+import Snackbar from "@mui/material/Snackbar";
+import Stack from "@mui/material/Stack";
+import SvgIcon from "@mui/material/SvgIcon";
+import Switch from "@mui/material/Switch";
+import Tab from "@mui/material/Tab";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Tabs from "@mui/material/Tabs";
+import Toolbar from "@mui/material/Toolbar";
+import Tooltip from "@mui/material/Tooltip";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { createTheme, styled, ThemeProvider, useTheme } from "@mui/material/styles";
+import { useFormControl } from "@mui/material/FormControl";
+
+const theme = createTheme({
+  palette: {
+    primary: { main: "#1a73e8" },
+    secondary: { main: "#d93025" },
+  },
+});
+
+const Panel = styled("section")(({ theme: current }) => ({
+  padding: current.spacing(2),
+  color: current.palette.primary.main,
+  border: `1px solid ${current.palette.divider}`,
+}));
+
+const Label = styled(Typography)`
+  font-weight: 700;
+`;
+
+const Viewport = () => {
+  const current = useTheme();
+  const isWide = useMediaQuery(current.breakpoints.up("md"));
+  return <Typography variant="caption">{isWide ? "wide" : "narrow"}</Typography>;
+};
+
+const FieldState = () => {
+  const control = useFormControl();
+  return <span data-filled={control?.filled ? "yes" : "no"} />;
+};
+
+const CloseIcon = () => (
+  <SvgIcon>
+    <path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+  </SvgIcon>
+);
+
+const rows = [
+  { id: 1, name: "Ada", role: "admin" },
+  { id: 2, name: "Grace", role: "editor" },
+];
+
+const Shell = () => (
+  <>
+    <AppBar position="static">
+      <Toolbar variant="dense">
+        <IconButton edge="start" color="inherit">
+          <Badge badgeContent={4} color="secondary">
+            <CloseIcon />
+          </Badge>
+        </IconButton>
+        <Typography variant="h6">Admin</Typography>
+        <Avatar>AB</Avatar>
+      </Toolbar>
+    </AppBar>
+    <Drawer variant="permanent" open>
+      <List dense>
+        <ListItemButton selected>
+          <ListItemIcon>
+            <CloseIcon />
+          </ListItemIcon>
+          <ListItemText primary="Users" secondary="2 rows" />
+        </ListItemButton>
+        <ListItemButton>
+          <ListItemText primary="Settings" />
+        </ListItemButton>
+      </List>
+    </Drawer>
+    <Tabs value={0}>
+      <Tab label="One" />
+      <Tab label="Two" />
+    </Tabs>
+    <Card>
+      <CardContent>
+        <Alert severity="info">Read only</Alert>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell align="right">Role</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell>{row.name}</TableCell>
+                <TableCell align="right">
+                  <Switch size="small" checked={row.role === "admin"} readOnly />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        <CircularProgress size={16} />
+      </CardContent>
+    </Card>
+    <Accordion>
+      <AccordionSummary>Details</AccordionSummary>
+      <AccordionDetails>Hidden until expanded</AccordionDetails>
+    </Accordion>
+    <FormControl size="small">
+      <InputLabel id="role-label">Role</InputLabel>
+      <Select labelId="role-label" label="Role" value="admin">
+        <MenuItem value="admin">Admin</MenuItem>
+        <MenuItem value="editor">Editor</MenuItem>
+      </Select>
+    </FormControl>
+    <Snackbar open={false} message="Saved" />
+  </>
+);
+
+export const App = () => (
+  <ThemeProvider theme={theme}>
+    <CssBaseline />
+    <Shell />
+    <Panel>
+      <Typography variant="h5" component="h1">
+        Settings
+      </Typography>
+      <Stack direction="row" spacing={2} divider={<Divider orientation="vertical" flexItem />}>
+        <Button variant="contained">Save</Button>
+        <Button variant="outlined" color="secondary">
+          Cancel
+        </Button>
+        <Tooltip title="Close">
+          <IconButton aria-label="close" size="small">
+            <CloseIcon />
+          </IconButton>
+        </Tooltip>
+      </Stack>
+      <Box sx={{ mt: 2, display: "flex", gap: 1 }}>
+        <Label variant="body2">badge</Label>
+        <Viewport />
+        <Chip label="beta" color="primary" size="small" />
+      </Box>
+      <Paper
+        elevation={3}
+        sx={(current) => ({ p: current.spacing(1), bgcolor: "background.paper" })}
+      >
+        <FormControlLabel control={<Checkbox defaultChecked />} label="Notify" />
+      </Paper>
+      <Dialog open={false}>
+        <DialogTitle>Closed</DialogTitle>
+      </Dialog>
+      <Menu open={false}>
+        <MenuItem>Item</MenuItem>
+      </Menu>
+      <TextField label="Name" defaultValue="Ada" helperText="Required" />
+      <TextField label="Notes" InputProps={{ endAdornment: <FieldState /> }} />
+    </Panel>
+  </ThemeProvider>
+);

--- a/packages/parser/tests/fixtures/mui-theme/src/main.tsx
+++ b/packages/parser/tests/fixtures/mui-theme/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/packages/parser/tests/fixtures/mui-theme/tsconfig.json
+++ b/packages/parser/tests/fixtures/mui-theme/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "strict": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1230,14 +1230,17 @@ importers:
         specifier: 11.14.0
         version: 11.14.0(@types/react@19.2.18)(react@19.2.8)
       '@emotion/styled':
-        specifier: 11.14.1
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
+        specifier: 11.14.0
+        version: 11.14.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
       '@lingui/core':
         specifier: 5.6.0
         version: 5.6.0(babel-plugin-macros@3.1.0)
       '@lingui/react':
         specifier: 5.6.0
         version: 5.6.0(babel-plugin-macros@3.1.0)(react@19.2.8)
+      '@mui/material':
+        specifier: 5.16.14
+        version: 5.16.14(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@reduxjs/toolkit':
         specifier: 2.12.0
         version: 2.12.0(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)
@@ -2212,6 +2215,16 @@ packages:
 
   '@emotion/sheet@1.4.0':
     resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
+
+  '@emotion/styled@11.14.0':
+    resolution: {integrity: sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==}
+    peerDependencies:
+      '@emotion/react': ^11.0.0-rc.0
+      '@types/react': '*'
+      react: ^19.2.4
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@emotion/styled@11.14.1':
     resolution: {integrity: sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==}
@@ -3530,8 +3543,28 @@ packages:
   '@mjackson/node-fetch-server@0.2.0':
     resolution: {integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==}
 
+  '@mui/core-downloads-tracker@5.18.0':
+    resolution: {integrity: sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==}
+
   '@mui/core-downloads-tracker@9.3.1':
     resolution: {integrity: sha512-IAyAFNQbT7hysJ9HXphiOmWJF7G1OglzHanqCgvQgH9LA2ydxtmaTBDbcBqw6euZesyShiwvpvbnYO1GY1AyXQ==}
+
+  '@mui/material@5.16.14':
+    resolution: {integrity: sha512-eSXQVCMKU2xc7EcTxe/X/rC9QsV2jUe8eLM3MUCPYbo6V52eCE436akRIvELq/AqZpxx2bwkq7HC0cRhLB+yaw==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.4
+      react-dom: ^19.2.4
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
 
   '@mui/material@9.3.1':
     resolution: {integrity: sha512-NahAEGIXqS1K0bA4th1jeFxBguS59NOcLbMA0vU+fSaPWKjtwGBGGHeTwlc9PSmzMjOZKceeFWESB8fVHr31hA==}
@@ -3553,6 +3586,16 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/private-theming@5.17.1':
+    resolution: {integrity: sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.4
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@mui/private-theming@9.3.0':
     resolution: {integrity: sha512-ERvqk5pejf9aRnQcDILSWGtFmsEMiVxlQ4+xsVCjsEvmK0fV9BiVP/cQwAF5dwyDFbve4lTrlcgeFEecVzTNiA==}
     engines: {node: '>=14.0.0'}
@@ -3561,6 +3604,19 @@ packages:
       react: ^19.2.4
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@mui/styled-engine@5.18.0':
+    resolution: {integrity: sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.4.1
+      '@emotion/styled': ^11.3.0
+      react: ^19.2.4
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
         optional: true
 
   '@mui/styled-engine@9.3.0':
@@ -3574,6 +3630,22 @@ packages:
       '@emotion/react':
         optional: true
       '@emotion/styled':
+        optional: true
+
+  '@mui/system@5.18.0':
+    resolution: {integrity: sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.4
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
         optional: true
 
   '@mui/system@9.3.0':
@@ -3592,10 +3664,36 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/types@7.2.24':
+    resolution: {integrity: sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/types@7.4.12':
+    resolution: {integrity: sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@mui/types@9.3.0':
     resolution: {integrity: sha512-2JSxyfpEFWNUB2vKs/T1BvkfyNisMHWph8bLMj8T0uHwmLl/0qfAwQkfwMT6kxLXN9uIum9AEbECXU8er3amIg==}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/utils@5.17.1':
+    resolution: {integrity: sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -14243,6 +14341,21 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
+  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/is-prop-valid': 1.4.0
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.8)
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.8)
+      '@emotion/utils': 1.4.2
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.18
+    transitivePeerDependencies:
+      - supports-color
+
   '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -15726,7 +15839,30 @@ snapshots:
 
   '@mjackson/node-fetch-server@0.2.0': {}
 
+  '@mui/core-downloads-tracker@5.18.0': {}
+
   '@mui/core-downloads-tracker@9.3.1': {}
+
+  '@mui/material@5.16.14(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/core-downloads-tracker': 5.18.0
+      '@mui/system': 5.18.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
+      '@mui/types': 7.4.12(@types/react@19.2.18)
+      '@mui/utils': 5.17.1(@types/react@19.2.18)(react@19.2.8)
+      '@popperjs/core': 2.11.8
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.18)
+      clsx: 2.1.1
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-is: 19.2.8
+      react-transition-group: 4.4.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.8)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
+      '@types/react': 19.2.18
 
   '@mui/material@9.3.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -15749,6 +15885,15 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
       '@types/react': 19.2.18
 
+  '@mui/private-theming@5.17.1(@types/react@19.2.18)(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/utils': 5.17.1(@types/react@19.2.18)(react@19.2.8)
+      prop-types: 15.8.1
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.18
+
   '@mui/private-theming@9.3.0(@types/react@19.2.18)(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -15757,6 +15902,18 @@ snapshots:
       react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.18
+
+  '@mui/styled-engine@5.18.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.8
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.8)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
 
   '@mui/styled-engine@9.3.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -15770,6 +15927,22 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.8)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
+
+  '@mui/system@5.18.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/private-theming': 5.17.1(@types/react@19.2.18)(react@19.2.8)
+      '@mui/styled-engine': 5.18.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
+      '@mui/types': 7.2.24(@types/react@19.2.18)
+      '@mui/utils': 5.17.1(@types/react@19.2.18)(react@19.2.8)
+      clsx: 2.1.1
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.8
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.8)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
+      '@types/react': 19.2.18
 
   '@mui/system@9.3.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)':
     dependencies:
@@ -15787,9 +15960,31 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
       '@types/react': 19.2.18
 
+  '@mui/types@7.2.24(@types/react@19.2.18)':
+    optionalDependencies:
+      '@types/react': 19.2.18
+
+  '@mui/types@7.4.12(@types/react@19.2.18)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+    optionalDependencies:
+      '@types/react': 19.2.18
+
   '@mui/types@9.3.0(@types/react@19.2.18)':
     dependencies:
       '@babel/runtime': 7.29.7
+    optionalDependencies:
+      '@types/react': 19.2.18
+
+  '@mui/utils@5.17.1(@types/react@19.2.18)(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/types': 7.2.24(@types/react@19.2.18)
+      '@types/prop-types': 15.7.15
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.8
+      react-is: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.18
 


### PR DESCRIPTION
## Summary

Adds `tests/fixtures/mui-theme`, a MUI 5.16.14 / Emotion 11.14.0 app (versions pinned to react-admin's lockfile) whose whole tree — `ThemeProvider → ThemeProviderNoVars → emotion ThemeProvider → RtlProvider → DefaultPropsProvider`, `Styled(...)`/`Insertion` wrappers, `ButtonBase`/`TouchRipple`, `Transition`/`Portal`, `useFormControl`, etc. — is interpreted from `node_modules` (`@mui/*`, `@babel/runtime/*`, `clsx`, `prop-types`, `react-is`, `react-transition-group` allowlisted). Result: `status: exact`, 661/661 nodes, zero branches/repeats/opaque/wildcards.

Generic evaluator gaps it exposed (all in `src/evaluate`, none MUI-specific):

- **Wrapper reflection**: `forwardRef` element types now keep `render: StaticFunctionValue`; `readComponentProperty` exposes `forwardRef.render` and `memo.type` (previously `$Unknown`). MUI's `getDisplayName` walks `Component.render`/`Component.type`, so `Styled(ForwardRef(Typography))`-style names were unknowable before.
- **`displayName` setter semantics** (from `react/src/ReactForwardRef.js` / `ReactMemo.js`): assigning `displayName` on a `memo`/`forwardRef` whose inner function is anonymous also names the inner function. `Named.displayName = "Named"` then `getDisplayName(Named)` → `ForwardRef(Named)`, not `ForwardRef()`. Stubs (Emotion styled) accept `displayName` writes too.
- **`switch` over known non-primitive cases**: `evaluateSwitch` now decides via `applyBinaryOperator("===")` + `getTruthiness` for any known discriminant/case values (symbols like `Symbol.for("react.forward_ref")`), instead of only primitives; stays a branch when any comparison is undecided.
- **`_objectWithoutPropertiesLoose(nullish, keys)`** returns `{}` (mirrors the helper's `if (null == source) return {}`) and distributes over branches via `mapValue`. MUI `Menu`/`Modal` rest `TransitionProps`/`slotProps` that are `undefined`, which previously produced `$Unknown` props on closed dialogs/menus.

Conformance: `tests/components/display-names.tsx` (wrapper reflection, setter naming, symbol switch, styled label/displayName) and a `Transitioned` case in `compiled-classic.js` (nullish Babel rest).

Not touched: `react-admin` corpus entry/manifest/`results.json`.

Link to Devin session: https://app.devin.ai/sessions/079604deac4949b8b9ac3cf5466e1f17
Open in Devin Desktop: https://app.devin.ai/desktop/session/079604deac4949b8b9ac3cf5466e1f17?variant=devin
Requested by: @aidenybai