### PR TITLE
parser: epic-stack live parity (React Router v7 framework mode)

### DIFF
--- a/packages/parser/corpus/manifest.json
+++ b/packages/parser/corpus/manifest.json
@@ -107,12 +107,20 @@
       "url": "http://localhost:3000/",
       "readyTimeoutMs": 600000,
       "settleMs": 6000,
+      "capturedGlobals": ["ENV"],
       "static": {
         "rootDirectory": ".",
         "entry": "app/routes.ts",
-        "route": "/"
+        "route": "/",
+        "externalPackageAllowList": [
+          "@radix-ui/*",
+          "remix-utils",
+          "openimg",
+          "sonner",
+          "spin-delay"
+        ]
       },
-      "notes": "routes.ts delegates to react-router-auto-routes; the static side mirrors its file conventions (_layout nesting, pathless _groups, $params, [.] escapes, trailing-underscore opt-outs) to rebuild the route table without running the generator. Loader data, honeypot and theme values stay unknown."
+      "notes": "routes.ts delegates to react-router-auto-routes; the static side mirrors its file conventions (_layout nesting, pathless _groups, $params, [.] escapes, trailing-underscore opt-outs) to rebuild the route table without running the generator. Loader data, honeypot and theme values stay unknown. @radix-ui, remix-utils, openimg, sonner and spin-delay are analyzed from source (each would otherwise leave opaque fibers or a branch); @conform-to, @epic-web and @nasa-gcn/remix-seo analyze cleanly but change no fiber, so they stay external."
     },
     {
       "id": "excalidraw",

--- a/packages/parser/corpus/results.json
+++ b/packages/parser/corpus/results.json
@@ -211,18 +211,27 @@
       "id": "epic-stack",
       "revision": "8473afd804b66dba6a23f317908dc35d1535e90d",
       "framework": "react-router",
-      "capturedAt": "2026-09-08T03:55:40.453Z",
-      "durationMs": 135,
-      "runtime": null,
+      "capturedAt": "2026-09-08T06:27:18.659Z",
+      "durationMs": 15881,
+      "runtime": {
+        "reactVersion": "19.2.4",
+        "rendererName": "react-dom",
+        "buildType": "development",
+        "roots": 1,
+        "fibers": 1989,
+        "commits": 8,
+        "pageErrors": [],
+        "title": "Epic Notes"
+      },
       "static": {
         "stats": {
-          "fiberCount": 480,
-          "textCount": 30,
-          "branchCount": 7,
+          "fiberCount": 695,
+          "textCount": 4,
+          "branchCount": 0,
           "repeatCount": 0,
-          "opaqueCount": 101,
-          "unknownCount": 2,
-          "modulesLoaded": 44
+          "opaqueCount": 0,
+          "unknownCount": 0,
+          "modulesLoaded": 91
         },
         "diagnostics": [
           {
@@ -231,9 +240,31 @@
           }
         ]
       },
-      "report": null,
+      "report": {
+        "matchedFibers": 689,
+        "matchedText": 4,
+        "opaqueSubtrees": 0,
+        "opaqueSkippedFibers": 0,
+        "slotsMatched": 0,
+        "slotsUnmatched": 0,
+        "opaqueRenamed": 0,
+        "unmatchedSlots": [],
+        "wildcardAbsorbedFibers": 0,
+        "wildcards": [],
+        "branchesResolved": 0,
+        "branchDeviations": [],
+        "repeatIterations": 0,
+        "status": "exact",
+        "runtimeFibers": 693,
+        "staticFibers": 693,
+        "coverage": 1,
+        "strictCoverage": 1,
+        "divergence": null,
+        "stepsUsed": 693,
+        "budgetExhausted": false
+      },
       "anchor": null,
-      "note": "static only",
+      "note": null,
       "failure": null
     },
     {

--- a/packages/parser/corpus/results.json
+++ b/packages/parser/corpus/results.json
@@ -211,8 +211,8 @@
       "id": "epic-stack",
       "revision": "8473afd804b66dba6a23f317908dc35d1535e90d",
       "framework": "react-router",
-      "capturedAt": "2026-09-08T06:27:18.659Z",
-      "durationMs": 15881,
+      "capturedAt": "2026-09-08T07:14:17.752Z",
+      "durationMs": 16528,
       "runtime": {
         "reactVersion": "19.2.4",
         "rendererName": "react-dom",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -22,7 +22,8 @@
     "esbuild": "^0.28.2",
     "oxc-parser": "^0.148.0",
     "oxc-resolver": "^11.24.2",
-    "playwright": "^1.63.0"
+    "playwright": "^1.63.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@babel/runtime": "^7.29.7",

--- a/packages/parser/src/corpus/manifest.ts
+++ b/packages/parser/src/corpus/manifest.ts
@@ -1,66 +1,92 @@
 import { readFileSync } from "node:fs";
-import type { ComparisonOptions, ComparisonReport } from "../harness/compare.js";
-import type { JsonValue, StaticRenderStats } from "../types.js";
+import { z } from "zod";
 import type { FrameworkKind } from "../frameworks/framework-profile.js";
+import type { ComparisonOptions, ComparisonReport } from "../harness/compare.js";
+import { jsonValueSchema } from "../observations.js";
+import type { StaticRenderStats } from "../types.js";
 
 // A corpus entry pins a real React repository at a revision so the static
 // renderer can be validated against the tree its dev server actually commits.
 
-export interface CorpusStaticTarget {
-  /** Directory holding the tsconfig used for path aliases; relative to the clone root. */
-  rootDirectory: string;
-  tsconfig?: string;
-  /** The bundler's `resolve.alias`, targets relative to `rootDirectory`. */
-  aliases?: Record<string, string>;
-  /** SPA only: module containing the `createRoot().render()` call. */
-  entry?: string;
-  /** Export of `entry` mounted by the boot code when the root render call is not literal. */
-  rootComponent?: string;
-  /** Framework routers: pathname whose route tree is composed statically. */
-  route?: string;
-  /** Next: `app/` or `pages/` directory relative to `rootDirectory` when it is not directly under it. */
-  appDirectory?: string;
-  /** Component name both trees are aligned on before matching. */
-  anchor?: string;
-  externalPackageAllowList?: string[];
-  /** `path#export` functions the boot code calls before mounting, in order. */
-  bootstrap?: string[];
-  /** `window` properties the served page defines (server-injected config); objects are partial. */
-  globals?: Record<string, JsonValue>;
-  /** Expressions the dev build inlines (`DefinePlugin`, Vite `define`), keyed by source text. */
-  defines?: Record<string, JsonValue>;
-  /** dotenv files the server loads, relative to `rootDirectory`; with them the environment is whole and other variables are unset. */
-  envFiles?: string[];
-  maxFiberCount?: number;
-  maxComponentDepth?: number;
-}
+const frameworkKindSchema: z.ZodType<FrameworkKind> = z.enum([
+  "spa",
+  "next-app",
+  "next-pages",
+  "react-router",
+]);
 
-export interface CorpusEntry {
-  id: string;
-  repository: string;
-  revision: string;
-  description: string;
-  framework: FrameworkKind;
+const stringRecordSchema = z.record(z.string(), z.string());
+
+const jsonRecordSchema = z.record(z.string(), jsonValueSchema);
+
+const corpusStaticTargetSchema = z.object({
+  /** Directory holding the tsconfig used for path aliases; relative to the clone root. */
+  rootDirectory: z.string(),
+  tsconfig: z.string().optional(),
+  /** The bundler's `resolve.alias`, targets relative to `rootDirectory`. */
+  aliases: stringRecordSchema.optional(),
+  /** SPA only: module containing the `createRoot().render()` call. */
+  entry: z.string().optional(),
+  /** Export of `entry` mounted by the boot code when the root render call is not literal. */
+  rootComponent: z.string().optional(),
+  /** Framework routers: pathname whose route tree is composed statically. */
+  route: z.string().optional(),
+  /** Next: `app/` or `pages/` directory relative to `rootDirectory` when it is not directly under it. */
+  appDirectory: z.string().optional(),
+  /** Component name both trees are aligned on before matching. */
+  anchor: z.string().optional(),
+  externalPackageAllowList: z.array(z.string()).optional(),
+  /** `path#export` functions the boot code calls before mounting, in order. */
+  bootstrap: z.array(z.string()).optional(),
+  /** `window` properties the served page defines (server-injected config); objects are partial. */
+  globals: jsonRecordSchema.optional(),
+  /** Expressions the dev build inlines (`DefinePlugin`, Vite `define`), keyed by source text. */
+  defines: jsonRecordSchema.optional(),
+  /** dotenv files the server loads, relative to `rootDirectory`; with them the environment is whole and other variables are unset. */
+  envFiles: z.array(z.string()).optional(),
+  maxFiberCount: z.number().optional(),
+  maxComponentDepth: z.number().optional(),
+});
+
+const comparisonOptionsSchema: z.ZodType<ComparisonOptions> = z.object({
+  compareKeys: z.boolean().optional(),
+  compareTags: z.boolean().optional(),
+  compareText: z.boolean().optional(),
+  maxSteps: z.number().optional(),
+});
+
+const corpusEntrySchema = z.object({
+  id: z.string(),
+  repository: z.string(),
+  revision: z.string(),
+  description: z.string(),
+  framework: frameworkKindSchema,
   /** Where the dev server is started; relative to the clone root. */
-  workingDirectory: string;
+  workingDirectory: z.string(),
   /** Run once at the clone root after cloning. */
-  install: string;
+  install: z.string(),
   /** Commands run once in `workingDirectory` after install (env files, migrations, seeds). */
-  setup?: string[];
+  setup: z.array(z.string()).optional(),
   /** Idempotent commands run at the clone root before every dev-server start (e.g. a database container). */
-  services?: string[];
-  dev: string;
-  env?: Record<string, string>;
-  url: string;
-  readyTimeoutMs?: number;
-  waitForSelector?: string;
-  settleMs?: number;
+  services: z.array(z.string()).optional(),
+  dev: z.string(),
+  env: stringRecordSchema.optional(),
+  url: z.string(),
+  readyTimeoutMs: z.number().optional(),
+  waitForSelector: z.string().optional(),
+  settleMs: z.number().optional(),
   /** `window` properties recorded from the settled page and handed to the static render as `globals` (bootstrap payloads the page fetched). */
-  capturedGlobals?: string[];
-  static: CorpusStaticTarget;
-  compare?: ComparisonOptions;
-  notes?: string;
-}
+  capturedGlobals: z.array(z.string()).optional(),
+  static: corpusStaticTargetSchema,
+  compare: comparisonOptionsSchema.optional(),
+  notes: z.string().optional(),
+});
+
+const corpusManifestSchema = z.object({ entries: z.array(corpusEntrySchema) });
+
+export interface CorpusStaticTarget extends z.infer<typeof corpusStaticTargetSchema> {}
+
+export interface CorpusEntry extends z.infer<typeof corpusEntrySchema> {}
 
 export interface CorpusManifest {
   entries: CorpusEntry[];
@@ -102,181 +128,7 @@ export interface CorpusResult {
 }
 
 export const readCorpusManifest = (manifestPath: string): CorpusManifest => {
-  const parsed: unknown = JSON.parse(readFileSync(manifestPath, "utf8"));
-  if (
-    typeof parsed !== "object" ||
-    parsed === null ||
-    !("entries" in parsed) ||
-    !Array.isArray(parsed.entries)
-  ) {
-    throw new Error(`${manifestPath}: expected { entries: CorpusEntry[] }`);
-  }
-  const entries: CorpusEntry[] = [];
-  for (const candidate of parsed.entries) entries.push(validateEntry(candidate, manifestPath));
-  return { entries };
-};
-
-const toJsonValue = (value: unknown, where: string): JsonValue => {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return value;
-  }
-  if (Array.isArray(value))
-    return value.map((item, index) => toJsonValue(item, `${where}[${index}]`));
-  if (typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [key, toJsonValue(item, `${where}.${key}`)]),
-    );
-  }
-  throw new Error(`${where} must be JSON`);
-};
-
-const FRAMEWORK_KINDS: FrameworkKind[] = ["spa", "next-app", "next-pages", "react-router"];
-
-class ManifestReader {
-  constructor(
-    private readonly record: Record<string, unknown>,
-    private readonly where: string,
-  ) {}
-
-  private fail(field: string, expected: string): never {
-    throw new Error(`${this.where}: "${field}" must be ${expected}`);
-  }
-
-  string(field: string): string {
-    const value = this.record[field];
-    return typeof value === "string" ? value : this.fail(field, "a string");
-  }
-
-  optionalString(field: string): string | undefined {
-    const value = this.record[field];
-    if (value === undefined) return undefined;
-    return typeof value === "string" ? value : this.fail(field, "a string");
-  }
-
-  optionalNumber(field: string): number | undefined {
-    const value = this.record[field];
-    if (value === undefined) return undefined;
-    return typeof value === "number" ? value : this.fail(field, "a number");
-  }
-
-  optionalBoolean(field: string): boolean | undefined {
-    const value = this.record[field];
-    if (value === undefined) return undefined;
-    return typeof value === "boolean" ? value : this.fail(field, "a boolean");
-  }
-
-  optionalStringList(field: string): string[] | undefined {
-    const value = this.record[field];
-    if (value === undefined) return undefined;
-    if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
-      this.fail(field, "a list of strings");
-    }
-    return value.filter((item): item is string => typeof item === "string");
-  }
-
-  optionalStringRecord(field: string): Record<string, string> | undefined {
-    const value = this.record[field];
-    if (value === undefined) return undefined;
-    if (typeof value !== "object" || value === null || Array.isArray(value)) {
-      this.fail(field, "an object of strings");
-    }
-    const result: Record<string, string> = {};
-    for (const [key, item] of Object.entries(value)) {
-      if (typeof item !== "string") this.fail(`${field}.${key}`, "a string");
-      result[key] = item;
-    }
-    return result;
-  }
-
-  optionalJsonRecord(field: string): Record<string, JsonValue> | undefined {
-    const value = this.record[field];
-    if (value === undefined) return undefined;
-    if (typeof value !== "object" || value === null || Array.isArray(value)) {
-      this.fail(field, "an object");
-    }
-    const result: Record<string, JsonValue> = {};
-    for (const [key, item] of Object.entries(value))
-      result[key] = toJsonValue(item, `${field}.${key}`);
-    return result;
-  }
-
-  object(field: string): ManifestReader {
-    const value = this.record[field];
-    if (typeof value !== "object" || value === null || Array.isArray(value)) {
-      this.fail(field, "an object");
-    }
-    return new ManifestReader({ ...value }, `${this.where}.${field}`);
-  }
-
-  optionalObject(field: string): ManifestReader | undefined {
-    return this.record[field] === undefined ? undefined : this.object(field);
-  }
-}
-
-const readFramework = (reader: ManifestReader): FrameworkKind => {
-  const value = reader.string("framework");
-  const kind = FRAMEWORK_KINDS.find((candidate) => candidate === value);
-  if (!kind)
-    throw new Error(`unknown framework "${value}"; expected ${FRAMEWORK_KINDS.join(", ")}`);
-  return kind;
-};
-
-const readStaticTarget = (reader: ManifestReader): CorpusStaticTarget => ({
-  rootDirectory: reader.string("rootDirectory"),
-  tsconfig: reader.optionalString("tsconfig"),
-  aliases: reader.optionalStringRecord("aliases"),
-  entry: reader.optionalString("entry"),
-  rootComponent: reader.optionalString("rootComponent"),
-  route: reader.optionalString("route"),
-  appDirectory: reader.optionalString("appDirectory"),
-  anchor: reader.optionalString("anchor"),
-  externalPackageAllowList: reader.optionalStringList("externalPackageAllowList"),
-  bootstrap: reader.optionalStringList("bootstrap"),
-  globals: reader.optionalJsonRecord("globals"),
-  defines: reader.optionalJsonRecord("defines"),
-  envFiles: reader.optionalStringList("envFiles"),
-  maxFiberCount: reader.optionalNumber("maxFiberCount"),
-  maxComponentDepth: reader.optionalNumber("maxComponentDepth"),
-});
-
-const readComparisonOptions = (reader: ManifestReader): ComparisonOptions => ({
-  compareKeys: reader.optionalBoolean("compareKeys"),
-  compareTags: reader.optionalBoolean("compareTags"),
-  compareText: reader.optionalBoolean("compareText"),
-  maxSteps: reader.optionalNumber("maxSteps"),
-});
-
-const validateEntry = (candidate: unknown, manifestPath: string): CorpusEntry => {
-  if (typeof candidate !== "object" || candidate === null || Array.isArray(candidate)) {
-    throw new Error(`${manifestPath}: corpus entry must be an object`);
-  }
-  const record: Record<string, unknown> = { ...candidate };
-  const reader = new ManifestReader(record, `${manifestPath} entry ${String(record.id)}`);
-  const compare = reader.optionalObject("compare");
-  return {
-    id: reader.string("id"),
-    repository: reader.string("repository"),
-    revision: reader.string("revision"),
-    description: reader.string("description"),
-    framework: readFramework(reader),
-    workingDirectory: reader.string("workingDirectory"),
-    install: reader.string("install"),
-    setup: reader.optionalStringList("setup"),
-    services: reader.optionalStringList("services"),
-    dev: reader.string("dev"),
-    env: reader.optionalStringRecord("env"),
-    url: reader.string("url"),
-    readyTimeoutMs: reader.optionalNumber("readyTimeoutMs"),
-    waitForSelector: reader.optionalString("waitForSelector"),
-    settleMs: reader.optionalNumber("settleMs"),
-    capturedGlobals: reader.optionalStringList("capturedGlobals"),
-    static: readStaticTarget(reader.object("static")),
-    compare: compare ? readComparisonOptions(compare) : undefined,
-    notes: reader.optionalString("notes"),
-  };
+  const manifest = corpusManifestSchema.safeParse(JSON.parse(readFileSync(manifestPath, "utf8")));
+  if (!manifest.success) throw new Error(`${manifestPath}: ${z.prettifyError(manifest.error)}`);
+  return manifest.data;
 };

--- a/packages/parser/src/corpus/run-entry.ts
+++ b/packages/parser/src/corpus/run-entry.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { z } from "zod";
 import { renderFramework } from "../frameworks/render-framework.js";
 import { flattenTransparentFibers } from "../frameworks/framework-profile.js";
 import { getFrameworkProfile } from "../frameworks/profiles.js";
@@ -153,11 +154,15 @@ const describeError = (error: unknown): string =>
 const capturePath = (outputDirectory: string, entry: CorpusEntry): string =>
   path.join(outputDirectory, `${entry.id}.capture.json`);
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const isStringArray = (value: unknown): value is string[] =>
-  Array.isArray(value) && value.every((item) => typeof item === "string");
+const savedCaptureSchema = z.object({
+  revision: z.string(),
+  commits: z.number(),
+  title: z.string(),
+  pageErrors: z.array(z.string()),
+  snapshot: z.unknown().transform(readSnapshot),
+  observations: z.unknown().optional(),
+  globals: z.unknown().optional(),
+});
 
 // A browser capture saved by an earlier live run; static-only passes replay it so
 // evaluator changes are re-verified against the same runtime tree without a dev server.
@@ -167,22 +172,15 @@ const readSavedCapture = (
 ): BrowserCaptureResult | null => {
   const filePath = capturePath(outputDirectory, entry);
   if (!existsSync(filePath)) return null;
-  const parsed: unknown = JSON.parse(readFileSync(filePath, "utf8"));
-  if (
-    !isRecord(parsed) ||
-    parsed.revision !== entry.revision ||
-    typeof parsed.commits !== "number" ||
-    typeof parsed.title !== "string" ||
-    !isStringArray(parsed.pageErrors)
-  ) {
-    return null;
-  }
+  const parsed = savedCaptureSchema.safeParse(JSON.parse(readFileSync(filePath, "utf8")));
+  if (!parsed.success || parsed.data.revision !== entry.revision) return null;
+  const { snapshot, commits, pageErrors, title, observations, globals } = parsed.data;
   return {
-    snapshot: readSnapshot(parsed.snapshot),
-    commits: parsed.commits,
-    pageErrors: parsed.pageErrors,
-    title: parsed.title,
-    observations: readObservationsJson(parsed.observations ?? { globals: parsed.globals }),
+    snapshot,
+    commits,
+    pageErrors,
+    title,
+    observations: readObservationsJson(observations ?? { globals }),
   };
 };
 

--- a/packages/parser/src/evaluate/interpreter.ts
+++ b/packages/parser/src/evaluate/interpreter.ts
@@ -482,9 +482,11 @@ const isNonProgressingRecursion = (
   );
 };
 
-/** An unknown, or a branch one of whose paths is: `paths.slice(0, -1)` of such a value is no more precise. */
+/** An unknown, a member/result of an unanalyzed external, or a branch holding one: further recursion cannot make it more precise. */
 const mayBeUnknown = (value: StaticValue): boolean =>
-  value.kind === "unknown" || (value.kind === "branch" && value.alternatives.some(mayBeUnknown));
+  value.kind === "unknown" ||
+  (value.kind === "external" && value.origin === "derived") ||
+  (value.kind === "branch" && value.alternatives.some(mayBeUnknown));
 
 const describeEscapedMutation = (name: string): string =>
   `"${name}" is mutated by code the analysis did not run`;
@@ -1066,7 +1068,9 @@ export class Interpreter {
       if (name === "module") return objectFromRecord({ exports: exportsValue });
     }
     return (
-      this.getGlobal(name, context.environment) ?? unknownValue(`unbound identifier "${name}"`)
+      this.getGlobal(name, context.environment) ??
+      this.windowGlobals.get(name) ??
+      unknownValue(`unbound identifier "${name}"`)
     );
   }
 

--- a/packages/parser/src/frameworks/framework-profile.ts
+++ b/packages/parser/src/frameworks/framework-profile.ts
@@ -13,8 +13,11 @@ export interface FrameworkProfile {
   transparentRuntimeFibers: ReadonlySet<string>;
   transparentStaticFibers: ReadonlySet<string>;
   /**
-   * Runtime fibers (with their subtrees) the framework injects with no
-   * application counterpart: outlet boundaries, route announcers, asset scripts.
+   * Runtime fibers (with their subtrees) the framework or its dev tooling
+   * injects with no application counterpart: outlet boundaries, route
+   * announcers, asset scripts, devtools panels. A tool that mounts one next to
+   * an application element does so from an anonymous wrapper of its own, which
+   * is spliced out along with the injection.
    */
   isInjectedRuntimeFiber: (fiber: RuntimeFiberSnapshot) => boolean;
   /** Fiber name both trees are aligned on when the corpus entry does not name one. */
@@ -27,7 +30,11 @@ const flattenFiber = (
 ): RuntimeFiberSnapshot[] => {
   if (profile.isInjectedRuntimeFiber(fiber)) return [];
   const children = flattenList(fiber.children, profile);
-  if (profile.transparentRuntimeFibers.has(fiber.name ?? fiber.tag)) return children;
+  const isInjectionWrapper =
+    fiber.name === null && fiber.children.some(profile.isInjectedRuntimeFiber);
+  if (isInjectionWrapper || profile.transparentRuntimeFibers.has(fiber.name ?? fiber.tag)) {
+    return children;
+  }
   return [{ ...fiber, children }];
 };
 

--- a/packages/parser/src/frameworks/profiles.ts
+++ b/packages/parser/src/frameworks/profiles.ts
@@ -158,11 +158,19 @@ const REACT_ROUTER_RUNTIME_WRAPPERS = [
   "RSCRouterGlobalErrorBoundary",
 ];
 
+// `react-router-devtools`' Vite plugin rewrites the root route module in
+// development so its default export renders next to the devtools panel
+// (`withViteDevTools` in `react-router-devtools/client`).
+const REACT_ROUTER_INJECTED_FIBERS = new Set(["TanStackDevtools"]);
+
+const isReactRouterInjectedFiber = (fiber: RuntimeFiberSnapshot): boolean =>
+  fiber.name !== null && REACT_ROUTER_INJECTED_FIBERS.has(fiber.name);
+
 export const REACT_ROUTER_PROFILE: FrameworkProfile = {
   kind: "react-router",
   transparentRuntimeFibers: new Set(REACT_ROUTER_RUNTIME_WRAPPERS),
   transparentStaticFibers: new Set(["Location"]),
-  isInjectedRuntimeFiber: neverInjected,
+  isInjectedRuntimeFiber: isReactRouterInjectedFiber,
   defaultAnchor: null,
 };
 

--- a/packages/parser/src/frameworks/react-router-observed.ts
+++ b/packages/parser/src/frameworks/react-router-observed.ts
@@ -8,7 +8,7 @@ import {
   unknownValue,
 } from "../evaluate/values.js";
 import { createSearchParamsValue } from "../evaluate/url-search-params.js";
-import type { CapturedRouterState, StaticValue } from "../types.js";
+import type { CapturedFetcher, CapturedRouterState, StaticValue } from "../types.js";
 
 /**
  * The data router's state as the page had it, replayed into the hooks that
@@ -22,22 +22,49 @@ export interface ObservedRouterState {
   searchParams: StaticValue;
   matches: StaticValue;
   loaderData: (routeId: string) => StaticValue;
+  /** `useFetchers()`: the fetchers that had loaded or submitted. */
+  fetchers: StaticValue;
+  /**
+   * `useFetcher()`'s own state: idle while no fetcher had been used, since a
+   * fetcher keyed by `useId` cannot be told apart from the captured ones.
+   */
+  fetcher: StaticValue;
 }
 
-const IDLE_NAVIGATION_FIELDS = [
-  "location",
-  "formMethod",
-  "formAction",
-  "formEncType",
-  "formData",
-  "json",
-  "text",
-];
+const SUBMISSION_FIELDS = ["formMethod", "formAction", "formEncType", "formData", "json", "text"];
+
+const undefinedFields = (fields: string[]): Record<string, StaticValue> =>
+  Object.fromEntries(fields.map((field) => [field, UNDEFINED_VALUE]));
 
 const idleNavigation = (): StaticValue =>
   objectFromRecord({
     state: primitiveValue("idle"),
-    ...Object.fromEntries(IDLE_NAVIGATION_FIELDS.map((field) => [field, UNDEFINED_VALUE])),
+    ...undefinedFields(["location", ...SUBMISSION_FIELDS]),
+  });
+
+const idleFetcher = (): StaticValue =>
+  objectFromRecord({
+    state: primitiveValue("idle"),
+    ...undefinedFields(["data", ...SUBMISSION_FIELDS]),
+  });
+
+const optionalString = (value: string | undefined): StaticValue =>
+  value === undefined ? UNDEFINED_VALUE : primitiveValue(value);
+
+const capturedFetcher = (fetcher: CapturedFetcher): StaticValue =>
+  objectFromRecord({
+    key: primitiveValue(fetcher.key),
+    state: primitiveValue(fetcher.state),
+    formMethod: optionalString(fetcher.formMethod),
+    formAction: optionalString(fetcher.formAction),
+    formEncType: optionalString(fetcher.formEncType),
+    formData: unknownValue(`FormData of fetcher ${fetcher.key} is not captured`),
+    json: unknownValue(`JSON body of fetcher ${fetcher.key} is not captured`),
+    text: unknownValue(`text body of fetcher ${fetcher.key} is not captured`),
+    data:
+      fetcher.data === undefined
+        ? UNDEFINED_VALUE
+        : capturedValue(fetcher.data, `fetcher ${fetcher.key} data`),
   });
 
 const stringRecordValue = (record: Record<string, string>): StaticValue =>
@@ -81,5 +108,12 @@ export const observeRouterState = (
       ),
     ),
     loaderData,
+    fetchers: state.fetchers
+      ? listValue(state.fetchers.map(capturedFetcher))
+      : unknownValue("react-router fetchers were not captured"),
+    fetcher:
+      state.fetchers?.length === 0
+        ? idleFetcher()
+        : unknownValue("react-router fetcher state is only known at runtime"),
   };
 };

--- a/packages/parser/src/frameworks/react-router.ts
+++ b/packages/parser/src/frameworks/react-router.ts
@@ -35,6 +35,7 @@ import type {
   ExternalValueProvider,
   ModuleRecord,
   StaticElementValue,
+  StaticObjectEntry,
   StaticObjectValue,
   StaticRenderResult,
   StaticValue,
@@ -79,8 +80,20 @@ export interface ReactRouterModel {
 interface FrameworkState extends FrameworkDocument {
   /** The matched route tree `HydratedRouter` mounts (root `RenderedRoute` inwards). */
   routeTree: StaticValue | null;
-  /** `ssr` from `react-router.config.ts`; `false` is SPA mode. Null outside framework mode. */
-  ssr: StaticValue | null;
+  /** `react-router.config.ts` settings; null outside framework mode. */
+  config: FrameworkConfig | null;
+  /** Dev-server URLs of the matched route modules, root first, as `<Scripts>` preloads them. */
+  routeModuleUrls: string[];
+}
+
+/** Config flags the document components branch on; null when not static. */
+interface FrameworkConfig {
+  /** `ssr`; `false` is SPA mode. */
+  isSsr: boolean | null;
+  /** `routeDiscovery.mode === "lazy"` under SSR: the route manifest is fetched on demand. */
+  isFogOfWar: boolean | null;
+  /** `future.unstable_subResourceIntegrity`. */
+  hasSubResourceIntegrity: boolean | null;
 }
 
 const CLIENT_ENTRY_NAMES = [
@@ -550,6 +563,33 @@ const FORM_STUB: StubComponent = {
     ),
 };
 
+const FETCHER_FORM_STUB: StubComponent = {
+  displayName: "fetcher.Form",
+  tag: ForwardRefTag,
+  render: (props) =>
+    element(
+      { kind: "stub", stub: FORM_STUB },
+      objectValue([
+        { kind: "spread", value: props },
+        { kind: "property", key: "navigate", value: primitiveValue(false) },
+      ]),
+    ),
+};
+
+const FETCHER_METHODS = ["submit", "load", "reset"];
+
+/** `useFetcher()`: a fixed `Form` and imperative API around whatever fetcher state the router holds. */
+const fetcherValue = (state: StaticValue): StaticValue =>
+  objectValue([
+    { kind: "spread", value: state },
+    { kind: "property", key: "Form", value: stubValue(FETCHER_FORM_STUB) },
+    ...FETCHER_METHODS.map((method): StaticObjectEntry => ({
+      kind: "property",
+      key: method,
+      value: nativeFunction(method, () => UNDEFINED_VALUE),
+    })),
+  ]);
+
 const createRouterFactory = (name: string): StaticValue =>
   nativeFunction(name, (args) => objectFromRecord({ routes: args[0] ?? listValue([]) }));
 
@@ -562,7 +602,6 @@ const RUNTIME_ONLY_HOOKS = new Set([
   "useMatch",
   "useNavigation",
   "useRevalidator",
-  "useFetcher",
   "useFetchers",
   "useRouteError",
   "useSearchParams",
@@ -620,6 +659,8 @@ const observedHookValue = (
           nativeFunction("setSearchParams", () => UNDEFINED_VALUE),
         ]),
       );
+    case "useFetchers":
+      return nativeFunction(importedName, () => observed.fetchers);
     default:
       return null;
   }
@@ -672,6 +713,12 @@ const routerHookValue = (
     case "useInRouterContext":
       return nativeFunction(importedName, (_args, tools) =>
         primitiveValue(tools.readContext(LOCATION_CONTEXT).kind !== "primitive"),
+      );
+    case "useFetcher":
+      return nativeFunction(importedName, () =>
+        fetcherValue(
+          observed?.fetcher ?? unknownValue("react-router fetcher state is only known at runtime"),
+        ),
       );
     default:
       if (!RUNTIME_ONLY_HOOKS.has(importedName)) return null;
@@ -731,7 +778,13 @@ export const createReactRouterModel = (
   pathname: string,
   routerState: CapturedRouterState | null = null,
 ): ReactRouterModel => {
-  const framework: FrameworkState = { routeTree: null, meta: null, links: null, ssr: null };
+  const framework: FrameworkState = {
+    routeTree: null,
+    meta: null,
+    links: null,
+    config: null,
+    routeModuleUrls: [],
+  };
   const observed = observeRouterState(routerState, pathname);
   // `RouterProvider$1` from `react-router/dom` wraps the core `RouterProvider`;
   // only the latter is kept as a fiber so SPA and framework trees line up.
@@ -774,25 +827,72 @@ export const createReactRouterModel = (
   const scrollRestorationStub: StubComponent = {
     displayName: "ScrollRestoration",
     render: (props) => {
-      if (!framework.ssr) return NULL_VALUE;
-      const isSpaMode = getTruthiness(framework.ssr);
-      if (isSpaMode === false) return NULL_VALUE;
-      const script = element(
-        { kind: "host", tagName: "script" },
-        objectValue([
-          { kind: "spread", value: omitProps(props, SCROLL_RESTORATION_PROPS) },
-          { kind: "property", key: "suppressHydrationWarning", value: primitiveValue(true) },
-          {
-            kind: "property",
-            key: "dangerouslySetInnerHTML",
-            value: objectFromRecord({
-              __html: unknownPrimitiveValue("string", "inline scroll restoration script"),
-            }),
-          },
-        ]),
+      if (!framework.config) return NULL_VALUE;
+      return whenFlag(
+        framework.config.isSsr,
+        inlineScript(
+          omitProps(props, SCROLL_RESTORATION_PROPS),
+          "inline scroll restoration script",
+        ),
+        "react-router.config `ssr` is not static",
       );
-      if (isSpaMode === true) return script;
-      return branchValue([script, NULL_VALUE], "react-router.config `ssr` is not static", null);
+    },
+  };
+  // `<Scripts>` renders the module preloads and boot scripts until the first
+  // hydration effect runs; the fibers stay until something re-renders it.
+  const scriptsStub: StubComponent = {
+    displayName: "Scripts",
+    render: (props) => {
+      const { config } = framework;
+      if (!config) return NULL_VALUE;
+      const preloadUrl = (asset: string) =>
+        unknownPrimitiveValue("string", `${asset} URL is assigned at build time`);
+      const modulePreload = (href: StaticValue, key: StaticValue | null = null) =>
+        element(
+          { kind: "host", tagName: "link" },
+          objectFromRecord({
+            rel: primitiveValue("modulepreload"),
+            href,
+            crossOrigin: getObjectProperty(props, "crossOrigin"),
+            nonce: getObjectProperty(props, "nonce"),
+            suppressHydrationWarning: primitiveValue(true),
+          }),
+          key,
+        );
+      return listValue([
+        whenFlag(
+          config.hasSubResourceIntegrity === false ? false : null,
+          inlineScript(props, "subresource integrity import map", {
+            "rr-importmap": primitiveValue(""),
+            type: primitiveValue("importmap"),
+          }),
+          "the subresource integrity manifest is only inlined by production builds",
+        ),
+        whenFlag(
+          config.isFogOfWar === null ? null : !config.isFogOfWar,
+          modulePreload(preloadUrl("route manifest")),
+          "react-router.config `routeDiscovery` is not static",
+        ),
+        modulePreload(preloadUrl("client entry")),
+        listValue(
+          framework.routeModuleUrls.map((url) => {
+            const href = primitiveValue(url);
+            return modulePreload(href, href);
+          }),
+        ),
+        element(
+          { kind: "fragment" },
+          objectFromRecord({
+            children: listValue([
+              inlineScript(props, "server handoff context"),
+              inlineScript(props, "route module imports", {
+                type: primitiveValue("module"),
+                async: primitiveValue(true),
+              }),
+            ]),
+          }),
+        ),
+      ]);
     },
   };
   const routerProviderStub: StubComponent = {
@@ -863,8 +963,9 @@ export const createReactRouterModel = (
         return stubValue(linksStub);
       case "ScrollRestoration":
         return stubValue(scrollRestorationStub);
-      case "Navigate":
       case "Scripts":
+        return stubValue(scriptsStub);
+      case "Navigate":
       case "PrefetchPageLinks":
         return stubValue(emptyStub(importedName));
       default:
@@ -890,15 +991,64 @@ export const createReactRouterModel = (
  * file; `app/root.tsx` is the implicit root route whose optional `Layout` export
  * wraps everything. Each route module's default export is its component.
  */
-/** `ssr` from the framework config; defaults to `true` like `@react-router/dev`. */
-const readSsrFlag = (interpreter: Interpreter, configModule: ModuleRecord | null): StaticValue => {
-  if (!configModule) return primitiveValue(true);
-  const config = interpreter.evaluateModuleExport(configModule, "default");
-  if (config.kind !== "object")
-    return unknownValue("react-router.config default export is not a static object");
+/** The `@react-router/dev` defaults: SSR on, lazy route discovery under SSR, no SRI. */
+const readFrameworkConfig = (
+  interpreter: Interpreter,
+  configModule: ModuleRecord | null,
+): FrameworkConfig => {
+  const config = configModule
+    ? interpreter.evaluateModuleExport(configModule, "default")
+    : objectValue();
+  if (config.kind !== "object") {
+    return { isSsr: null, isFogOfWar: null, hasSubResourceIntegrity: null };
+  }
   const ssr = getObjectProperty(config, "ssr");
-  return isDefined(ssr) ? ssr : primitiveValue(true);
+  const isSsr = isDefined(ssr) ? getTruthiness(ssr) : true;
+  const routeDiscovery = getObjectProperty(config, "routeDiscovery");
+  const mode =
+    routeDiscovery.kind === "object" ? readString(getObjectProperty(routeDiscovery, "mode")) : null;
+  const future = getObjectProperty(config, "future");
+  const subResourceIntegrity =
+    future.kind === "object"
+      ? getObjectProperty(future, "unstable_subResourceIntegrity")
+      : UNDEFINED_VALUE;
+  return {
+    isSsr,
+    isFogOfWar:
+      mode === "initial" ? false : !isDefined(routeDiscovery) || mode === "lazy" ? isSsr : null,
+    hasSubResourceIntegrity: isDefined(subResourceIntegrity)
+      ? getTruthiness(subResourceIntegrity)
+      : false,
+  };
 };
+
+const whenFlag = (flag: boolean | null, value: StaticValue, reason: string): StaticValue => {
+  if (flag === null) return branchValue([value, NULL_VALUE], reason, null);
+  return flag ? value : NULL_VALUE;
+};
+
+const inlineScript = (
+  scriptProps: StaticValue,
+  content: string,
+  attributes: Record<string, StaticValue> = {},
+): StaticValue =>
+  element(
+    { kind: "host", tagName: "script" },
+    objectValue([
+      { kind: "spread", value: scriptProps },
+      { kind: "property", key: "suppressHydrationWarning", value: primitiveValue(true) },
+      {
+        kind: "property",
+        key: "dangerouslySetInnerHTML",
+        value: objectFromRecord({ __html: unknownPrimitiveValue("string", content) }),
+      },
+      ...Object.entries(attributes).map(([key, value]): StaticObjectEntry => ({
+        kind: "property",
+        key,
+        value,
+      })),
+    ]),
+  );
 
 const renderFrameworkRoutes = (
   renderer: StaticRenderer,
@@ -1000,7 +1150,15 @@ const renderFrameworkRoutes = (
       });
       leafMeta = callExport(module, "meta", [metaArgs]) ?? leafMeta;
     }
-    model.framework.ssr = readSsrFlag(interpreter, configModule ?? null);
+    model.framework.config = readFrameworkConfig(interpreter, configModule ?? null);
+    model.framework.routeModuleUrls = [
+      ...new Set(
+        matchedModules.map(
+          ({ module }) =>
+            `/${path.relative(renderer.options.rootDirectory, module.filePath).split(path.sep).join("/")}`,
+        ),
+      ),
+    ];
     model.framework.meta = leafMeta ?? listValue([]);
     model.framework.links = dedupeLinkDescriptors(
       matchedModules.flatMap(({ module }) => callExport(module, "links", []) ?? []),

--- a/packages/parser/src/graph/module-record.ts
+++ b/packages/parser/src/graph/module-record.ts
@@ -3,9 +3,11 @@ import type {
   ExportDefaultDeclaration,
   ExportNamedDeclaration,
   Expression,
+  FunctionBody,
   ImportDeclaration,
   ModuleExportName,
   ObjectExpression,
+  ParamPattern,
   PropertyKey,
   Statement,
   VariableDeclaration,
@@ -24,6 +26,12 @@ import type {
   ReExportAll,
   TopLevelBinding,
 } from "../types.js";
+
+/** A function expression with a block body, as UMD/IIFE module wrappers are. */
+interface BlockFunction {
+  params: ParamPattern[];
+  body: FunctionBody;
+}
 
 const getModuleExportName = (name: ModuleExportName): string =>
   name.type === "Literal" ? name.value : name.name;
@@ -352,32 +360,119 @@ const getWrappedRequiredSpecifier = (node: Expression): string | null => {
 const isVoidZero = (node: Expression): boolean =>
   node.type === "UnaryExpression" && node.operator === "void";
 
-/** The body of a parameterless IIFE such as `(function () { ... })()` or `!function () { ... }()`. */
-const getModuleWrapperBody = (statement: Statement): Statement[] | null => {
-  if (statement.type !== "ExpressionStatement") return null;
-  let { expression } = statement;
-  while (expression.type === "UnaryExpression") expression = expression.argument;
-  if (expression.type !== "CallExpression" || expression.arguments.length !== 0) return null;
-  const callee = unwrapParentheses(expression.callee);
-  if (
-    (callee.type !== "FunctionExpression" && callee.type !== "ArrowFunctionExpression") ||
-    callee.params.length !== 0 ||
-    !callee.body ||
-    callee.body.type !== "BlockStatement"
-  ) {
-    return null;
-  }
-  return callee.body.body;
-};
-
 const unwrapParentheses = (node: Expression): Expression =>
   node.type === "ParenthesizedExpression" ? unwrapParentheses(node.expression) : node;
 
+const getBlockFunction = (node: Expression): BlockFunction | null => {
+  const unwrapped = unwrapParentheses(node);
+  if (unwrapped.type !== "FunctionExpression" && unwrapped.type !== "ArrowFunctionExpression") {
+    return null;
+  }
+  const { params, body } = unwrapped;
+  return body?.type === "BlockStatement" ? { params, body } : null;
+};
+
+const getWrapperCall = (statement: Statement): CallExpression | null => {
+  if (statement.type !== "ExpressionStatement") return null;
+  let expression = unwrapParentheses(statement.expression);
+  while (expression.type === "UnaryExpression") expression = unwrapParentheses(expression.argument);
+  return expression.type === "CallExpression" ? expression : null;
+};
+
+/** The body of a parameterless IIFE such as `(function () { ... })()` or `!function () { ... }()`. */
+const getModuleWrapperBody = (statement: Statement): Statement[] | null => {
+  const call = getWrapperCall(statement);
+  if (!call || call.arguments.length !== 0) return null;
+  const callee = getBlockFunction(call.callee);
+  return callee && callee.params.length === 0 ? callee.body.body : null;
+};
+
+/** The `factory(exports, require("x"), …)` call on the CommonJS path of a UMD wrapper body. */
+const findFactoryCall = (
+  node: Expression | Statement,
+  factoryName: string,
+): CallExpression | null => {
+  switch (node.type) {
+    case "ExpressionStatement":
+      return findFactoryCall(node.expression, factoryName);
+    case "IfStatement":
+      return (
+        findFactoryCall(node.consequent, factoryName) ??
+        (node.alternate ? findFactoryCall(node.alternate, factoryName) : null)
+      );
+    case "BlockStatement":
+      for (const statement of node.body) {
+        const call = findFactoryCall(statement, factoryName);
+        if (call) return call;
+      }
+      return null;
+    case "ConditionalExpression":
+      return (
+        findFactoryCall(node.consequent, factoryName) ??
+        findFactoryCall(node.alternate, factoryName)
+      );
+    case "SequenceExpression":
+      for (const expression of node.expressions) {
+        const call = findFactoryCall(expression, factoryName);
+        if (call) return call;
+      }
+      return null;
+    case "AssignmentExpression":
+      return findFactoryCall(node.right, factoryName);
+    case "CallExpression":
+      return node.callee.type === "Identifier" &&
+        node.callee.name === factoryName &&
+        node.arguments.some(
+          (argument) => argument.type !== "SpreadElement" && isExportsObject(argument),
+        )
+        ? node
+        : null;
+    default:
+      return null;
+  }
+};
+
+/**
+ * The factory body of a `(function (global, factory) { … })(this, function (exports, react) { … })`
+ * UMD wrapper, binding each factory parameter to the argument the CommonJS path passes it
+ * (`exports` to the exports object, `react` to `require("react")`).
+ */
+const getUmdFactoryBody = (
+  statement: Statement,
+  factoryArguments: Map<string, Expression>,
+): Statement[] | null => {
+  const call = getWrapperCall(statement);
+  if (!call || call.arguments.length !== 2) return null;
+  const wrapper = getBlockFunction(call.callee);
+  const [, factoryArgument] = call.arguments;
+  const factory =
+    factoryArgument.type === "SpreadElement" ? null : getBlockFunction(factoryArgument);
+  const factoryParameter = wrapper?.params[1];
+  if (!wrapper || !factory || factoryParameter?.type !== "Identifier") return null;
+  const factoryCall = findFactoryCall(wrapper.body, factoryParameter.name);
+  if (!factoryCall || factoryCall.arguments.length !== factory.params.length) return null;
+  const bound = new Map<string, Expression>();
+  for (const [index, parameter] of factory.params.entries()) {
+    const argument = factoryCall.arguments[index];
+    if (parameter.type !== "Identifier" || argument.type === "SpreadElement") return null;
+    if (isExportsObject(argument)) {
+      if (parameter.name !== "exports") return null;
+      continue;
+    }
+    bound.set(parameter.name, argument);
+  }
+  for (const [name, argument] of bound) factoryArguments.set(name, argument);
+  return factory.body.body;
+};
+
 /** Module-level statements, with UMD/IIFE wrappers flattened so their declarations become module bindings. */
-const getModuleStatements = (statements: Statement[]): Statement[] =>
+const getModuleStatements = (
+  statements: Statement[],
+  factoryArguments: Map<string, Expression>,
+): Statement[] =>
   statements.flatMap((statement) => {
-    const body = getModuleWrapperBody(statement);
-    return body ? getModuleStatements(body) : [statement];
+    const body = getModuleWrapperBody(statement) ?? getUmdFactoryBody(statement, factoryArguments);
+    return body ? getModuleStatements(body, factoryArguments) : [statement];
   });
 
 /** Return expression of a `get() { return x; }` accessor or `() => x`. */
@@ -647,7 +742,17 @@ export const createModuleRecord = (file: ParsedSourceFile): ModuleRecord => {
   const dependencies: string[] = [];
   const sideEffectStatements: Statement[] = [];
   const directives: string[] = [];
-  const statements = getModuleStatements(file.program.body);
+  const factoryArguments = new Map<string, Expression>();
+  const statements = getModuleStatements(file.program.body, factoryArguments);
+  for (const [name, argument] of factoryArguments) {
+    bindings.set(name, {
+      kind: "variable",
+      name,
+      init: argument,
+      declarationKind: "const",
+      span: argument,
+    });
+  }
   for (const statement of statements) {
     if (
       statement.type === "ExpressionStatement" &&

--- a/packages/parser/src/harness/compare.ts
+++ b/packages/parser/src/harness/compare.ts
@@ -14,6 +14,14 @@ const BUNDLER_PLACEHOLDER_NAME = /^_[a-z]\d*$/;
 
 const isBundlerPlaceholderName = (name: string): boolean => BUNDLER_PLACEHOLDER_NAME.test(name);
 
+// A binding that collides with another in the bundled scope is renamed with a
+// counter: `Toaster2` by esbuild (Vite dev pre-bundling), `Toaster$1` by rollup.
+const BUNDLER_DEDUPE_SUFFIX = /^\$?\d+$/;
+
+const isBundlerDedupedName = (sourceName: string, runtimeName: string): boolean =>
+  runtimeName.startsWith(sourceName) &&
+  BUNDLER_DEDUPE_SUFFIX.test(runtimeName.slice(sourceName.length));
+
 export interface ComparisonOptions {
   compareKeys?: boolean;
   compareTags?: boolean;
@@ -497,7 +505,10 @@ class Matcher {
     )
       return false;
     if (pattern.name === null || actual.name === null || pattern.name === actual.name) return true;
-    return isClassTag(actual.tag) && isBundlerPlaceholderName(actual.name);
+    return (
+      isBundlerDedupedName(pattern.name, actual.name) ||
+      (isClassTag(actual.tag) && isBundlerPlaceholderName(actual.name))
+    );
   }
 
   // An opaque component's runtime identity is whatever non-host fiber sits in its

--- a/packages/parser/src/harness/provider-state.ts
+++ b/packages/parser/src/harness/provider-state.ts
@@ -1,5 +1,7 @@
 import type { Fiber, FiberRoot } from "bippy";
 import { traverseFiber } from "bippy";
+import { z } from "zod";
+import { routerActivityStateSchema } from "../observations.js";
 import type {
   CapturedFetcher,
   CapturedLinguiCatalog,
@@ -12,92 +14,53 @@ import { type ExportIndex, NO_EXPORTS } from "./module-exports.js";
 import { readQueryCaches, toCapturedValue } from "./query-cache.js";
 import { captureStores, readProviderStores, type ReduxStoreLike } from "./redux-store.js";
 
-interface LinguiContextLike {
-  i18n: { locale: string; messages: Record<string, unknown> };
-}
+const unknownRecordSchema = z.record(z.string(), z.unknown());
 
-interface RouterLocationLike {
-  pathname: string;
-  search: string;
-  hash: string;
-}
+const functionSchema = z.custom<(...args: never[]) => unknown>(
+  (value) => typeof value === "function",
+);
 
-interface RouterMatchLike {
-  route: { id: string };
-  pathname: string;
-  params: Record<string, string | undefined>;
-}
+const providerPropsSchema = z.object({ value: z.unknown().optional() });
 
-interface FetcherLike {
-  state: CapturedFetcher["state"];
-  formMethod?: string;
-  formAction?: string;
-  formEncType?: string;
-  data?: unknown;
-}
+const linguiContextSchema = z.object({
+  i18n: z.object({ locale: z.string(), messages: unknownRecordSchema, _: functionSchema }),
+});
 
-interface DataRouterStateLike {
-  location: RouterLocationLike;
-  matches: RouterMatchLike[];
-  loaderData: Record<string, unknown>;
-  navigation: { state: CapturedRouterState["navigationState"] };
-  revalidation: CapturedRouterState["revalidationState"];
-  fetchers: Map<string, FetcherLike>;
-}
+const routeMatchSchema = z.object({
+  route: z.object({ id: z.string() }),
+  pathname: z.string(),
+  params: z.record(z.string(), z.string().optional()),
+});
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
+const fetcherSchema = z.object({
+  state: routerActivityStateSchema,
+  formMethod: z.string().optional(),
+  formAction: z.string().optional(),
+  formEncType: z.string().optional(),
+  data: z.unknown().optional(),
+});
 
-const isLinguiContext = (value: unknown): value is LinguiContextLike =>
-  isRecord(value) &&
-  isRecord(value.i18n) &&
-  typeof value.i18n.locale === "string" &&
-  isRecord(value.i18n.messages) &&
-  typeof value.i18n._ === "function";
+const dataRouterStateSchema = z.object({
+  location: z.object({ pathname: z.string(), search: z.string(), hash: z.string() }),
+  matches: z.array(routeMatchSchema),
+  loaderData: unknownRecordSchema,
+  navigation: z.object({ state: routerActivityStateSchema }),
+  revalidation: z.enum(["idle", "loading"]),
+  fetchers: z.map(z.string(), fetcherSchema),
+});
 
-const isLocation = (value: unknown): value is RouterLocationLike =>
-  isRecord(value) &&
-  typeof value.pathname === "string" &&
-  typeof value.search === "string" &&
-  typeof value.hash === "string";
+interface LinguiContextLike extends z.infer<typeof linguiContextSchema> {}
 
-const isRouteMatch = (value: unknown): value is RouterMatchLike =>
-  isRecord(value) &&
-  isRecord(value.route) &&
-  typeof value.route.id === "string" &&
-  typeof value.pathname === "string" &&
-  isRecord(value.params);
+interface RouterMatchLike extends z.infer<typeof routeMatchSchema> {}
 
-const isOptionalString = (value: unknown): value is string | undefined =>
-  value === undefined || typeof value === "string";
+interface FetcherLike extends z.infer<typeof fetcherSchema> {}
 
-const isRouterActivityState = (value: unknown): value is CapturedFetcher["state"] =>
-  value === "idle" || value === "loading" || value === "submitting";
+interface DataRouterStateLike extends z.infer<typeof dataRouterStateSchema> {}
 
-const isFetcher = (value: unknown): value is FetcherLike =>
-  isRecord(value) &&
-  isRouterActivityState(value.state) &&
-  isOptionalString(value.formMethod) &&
-  isOptionalString(value.formAction) &&
-  isOptionalString(value.formEncType);
-
-const isFetcherMap = (value: unknown): value is Map<string, FetcherLike> =>
-  value instanceof Map &&
-  [...value].every(([key, fetcher]) => typeof key === "string" && isFetcher(fetcher));
-
-const isDataRouterState = (value: unknown): value is DataRouterStateLike =>
-  isRecord(value) &&
-  isLocation(value.location) &&
-  Array.isArray(value.matches) &&
-  value.matches.every(isRouteMatch) &&
-  isRecord(value.loaderData) &&
-  isRecord(value.navigation) &&
-  isRouterActivityState(value.navigation.state) &&
-  (value.revalidation === "idle" || value.revalidation === "loading") &&
-  isFetcherMap(value.fetchers);
-
-const getProviderValue = (fiber: Fiber): unknown =>
-  isRecord(fiber.memoizedProps) ? fiber.memoizedProps.value : undefined;
+const getProviderValue = (fiber: Fiber): unknown => {
+  const props = providerPropsSchema.safeParse(fiber.memoizedProps);
+  return props.success ? props.data.value : undefined;
+};
 
 const captureRecord = (record: Record<string, unknown>): Record<string, CapturedValue> => {
   const entries: Record<string, CapturedValue> = {};
@@ -164,10 +127,13 @@ export const readRootObservations = (
   for (const root of roots) {
     traverseFiber(root.current, (fiber) => {
       const value = getProviderValue(fiber);
-      if (!observations.lingui && isLinguiContext(value))
-        observations.lingui = captureLingui(value);
-      if (!observations.router && isDataRouterState(value)) {
-        observations.router = captureRouterState(value);
+      if (!observations.lingui) {
+        const lingui = linguiContextSchema.safeParse(value);
+        if (lingui.success) observations.lingui = captureLingui(lingui.data);
+      }
+      if (!observations.router) {
+        const router = dataRouterStateSchema.safeParse(value);
+        if (router.success) observations.router = captureRouterState(router.data);
       }
       return false;
     });

--- a/packages/parser/src/harness/provider-state.ts
+++ b/packages/parser/src/harness/provider-state.ts
@@ -1,6 +1,7 @@
 import type { Fiber, FiberRoot } from "bippy";
 import { traverseFiber } from "bippy";
 import type {
+  CapturedFetcher,
   CapturedLinguiCatalog,
   CapturedRouteMatch,
   CapturedRouterState,
@@ -27,12 +28,21 @@ interface RouterMatchLike {
   params: Record<string, string | undefined>;
 }
 
+interface FetcherLike {
+  state: CapturedFetcher["state"];
+  formMethod?: string;
+  formAction?: string;
+  formEncType?: string;
+  data?: unknown;
+}
+
 interface DataRouterStateLike {
   location: RouterLocationLike;
   matches: RouterMatchLike[];
   loaderData: Record<string, unknown>;
   navigation: { state: CapturedRouterState["navigationState"] };
   revalidation: CapturedRouterState["revalidationState"];
+  fetchers: Map<string, FetcherLike>;
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -58,6 +68,23 @@ const isRouteMatch = (value: unknown): value is RouterMatchLike =>
   typeof value.pathname === "string" &&
   isRecord(value.params);
 
+const isOptionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === "string";
+
+const isRouterActivityState = (value: unknown): value is CapturedFetcher["state"] =>
+  value === "idle" || value === "loading" || value === "submitting";
+
+const isFetcher = (value: unknown): value is FetcherLike =>
+  isRecord(value) &&
+  isRouterActivityState(value.state) &&
+  isOptionalString(value.formMethod) &&
+  isOptionalString(value.formAction) &&
+  isOptionalString(value.formEncType);
+
+const isFetcherMap = (value: unknown): value is Map<string, FetcherLike> =>
+  value instanceof Map &&
+  [...value].every(([key, fetcher]) => typeof key === "string" && isFetcher(fetcher));
+
 const isDataRouterState = (value: unknown): value is DataRouterStateLike =>
   isRecord(value) &&
   isLocation(value.location) &&
@@ -65,10 +92,9 @@ const isDataRouterState = (value: unknown): value is DataRouterStateLike =>
   value.matches.every(isRouteMatch) &&
   isRecord(value.loaderData) &&
   isRecord(value.navigation) &&
-  (value.navigation.state === "idle" ||
-    value.navigation.state === "loading" ||
-    value.navigation.state === "submitting") &&
-  (value.revalidation === "idle" || value.revalidation === "loading");
+  isRouterActivityState(value.navigation.state) &&
+  (value.revalidation === "idle" || value.revalidation === "loading") &&
+  isFetcherMap(value.fetchers);
 
 const getProviderValue = (fiber: Fiber): unknown =>
   isRecord(fiber.memoizedProps) ? fiber.memoizedProps.value : undefined;
@@ -90,6 +116,15 @@ const captureMatch = (match: RouterMatchLike): CapturedRouteMatch => {
   return { id: match.route.id, pathname: match.pathname, params };
 };
 
+const captureFetcher = (key: string, fetcher: FetcherLike): CapturedFetcher => ({
+  key,
+  state: fetcher.state,
+  formMethod: fetcher.formMethod,
+  formAction: fetcher.formAction,
+  formEncType: fetcher.formEncType,
+  data: toCapturedValue(fetcher.data),
+});
+
 const captureLingui = (context: LinguiContextLike): CapturedLinguiCatalog => ({
   locale: context.i18n.locale,
   messages: captureRecord(context.i18n.messages),
@@ -105,6 +140,7 @@ const captureRouterState = (state: DataRouterStateLike): CapturedRouterState => 
   loaderData: captureRecord(state.loaderData),
   navigationState: state.navigation.state,
   revalidationState: state.revalidation,
+  fetchers: [...state.fetchers].map(([key, fetcher]) => captureFetcher(key, fetcher)),
 });
 
 /**

--- a/packages/parser/src/harness/snapshot.ts
+++ b/packages/parser/src/harness/snapshot.ts
@@ -2,6 +2,7 @@
 // runtime capture. Keeping this file free of Node imports lets the browser
 // injection bundle reuse it.
 
+import { z } from "zod";
 import type { WorkTagName } from "../work-tags.js";
 
 export type SnapshotWorkTag =
@@ -17,63 +18,7 @@ export type SnapshotWorkTag =
 
 export type SnapshotPropValue = string | number | boolean | null;
 
-export interface RuntimeFiberSnapshot {
-  tag: SnapshotWorkTag;
-  name: string | null;
-  key: string | null;
-  text: string | null;
-  props: Record<string, SnapshotPropValue>;
-  children: RuntimeFiberSnapshot[];
-}
-
-export interface RuntimeSnapshot {
-  reactVersion: string | null;
-  rendererName: string | null;
-  buildType: "development" | "production" | null;
-  roots: RuntimeFiberSnapshot[];
-  capturedAt: string;
-}
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const isPropValue = (value: unknown): value is SnapshotPropValue =>
-  value === null ||
-  typeof value === "string" ||
-  typeof value === "number" ||
-  typeof value === "boolean";
-
-const readNullableString = (value: unknown, path: string): string | null => {
-  if (value === null || typeof value === "string") return value;
-  throw new Error(`snapshot ${path}: expected string | null`);
-};
-
-const readFiber = (value: unknown, path: string): RuntimeFiberSnapshot => {
-  if (!isRecord(value)) throw new Error(`snapshot ${path}: expected a fiber object`);
-  if (typeof value.tag !== "string") throw new Error(`snapshot ${path}.tag: expected a string`);
-  if (!isRecord(value.props)) throw new Error(`snapshot ${path}.props: expected an object`);
-  if (!Array.isArray(value.children)) {
-    throw new Error(`snapshot ${path}.children: expected an array`);
-  }
-  const props: Record<string, SnapshotPropValue> = {};
-  for (const [name, prop] of Object.entries(value.props)) {
-    if (!isPropValue(prop)) throw new Error(`snapshot ${path}.props.${name}: unsupported value`);
-    props[name] = prop;
-  }
-  // The recorder writes tag names from the same union; an unfamiliar tag from a
-  // newer React degrades to "Unknown" rather than failing the whole capture.
-  const tag: SnapshotWorkTag = isKnownTag(value.tag) ? value.tag : "Unknown";
-  return {
-    tag,
-    name: readNullableString(value.name, `${path}.name`),
-    key: readNullableString(value.key, `${path}.key`),
-    text: readNullableString(value.text, `${path}.text`),
-    props,
-    children: value.children.map((child, index) => readFiber(child, `${path}.children[${index}]`)),
-  };
-};
-
-const KNOWN_TAGS: ReadonlySet<string> = new Set<SnapshotWorkTag>([
+const snapshotWorkTagSchema = z.enum([
   "FunctionComponent",
   "ClassComponent",
   "HostRoot",
@@ -106,23 +51,50 @@ const KNOWN_TAGS: ReadonlySet<string> = new Set<SnapshotWorkTag>([
   "Unknown",
 ]);
 
-const isKnownTag = (tag: string): tag is SnapshotWorkTag => KNOWN_TAGS.has(tag);
+export interface RuntimeFiberSnapshot {
+  tag: SnapshotWorkTag;
+  name: string | null;
+  key: string | null;
+  text: string | null;
+  props: Record<string, SnapshotPropValue>;
+  children: RuntimeFiberSnapshot[];
+}
+
+export interface RuntimeSnapshot {
+  reactVersion: string | null;
+  rendererName: string | null;
+  buildType: "development" | "production" | null;
+  roots: RuntimeFiberSnapshot[];
+  capturedAt: string;
+}
+
+// The recorder writes tag names from the same union; an unfamiliar tag from a
+// newer React degrades to "Unknown" rather than failing the whole capture.
+const fiberSnapshotSchema: z.ZodType<RuntimeFiberSnapshot> = z.lazy(() =>
+  z.object({
+    tag: z.string().pipe(snapshotWorkTagSchema.catch("Unknown")),
+    name: z.string().nullable(),
+    key: z.string().nullable(),
+    text: z.string().nullable(),
+    props: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()])),
+    children: z.array(fiberSnapshotSchema),
+  }),
+);
+
+const snapshotSchema: z.ZodType<RuntimeSnapshot> = z.object({
+  reactVersion: z.string().nullable().default(null),
+  rendererName: z.string().nullable().default(null),
+  buildType: z.enum(["development", "production"]).nullable().catch(null),
+  roots: z.array(fiberSnapshotSchema),
+  capturedAt: z.string().catch(() => new Date().toISOString()),
+});
 
 export const parseSnapshot = (json: string): RuntimeSnapshot => readSnapshot(JSON.parse(json));
 
 export const readSnapshot = (value: unknown): RuntimeSnapshot => {
-  if (!isRecord(value) || !Array.isArray(value.roots)) {
-    throw new Error("snapshot: expected { roots: [...] }");
-  }
-  const buildType =
-    value.buildType === "development" || value.buildType === "production" ? value.buildType : null;
-  return {
-    reactVersion: readNullableString(value.reactVersion ?? null, "reactVersion"),
-    rendererName: readNullableString(value.rendererName ?? null, "rendererName"),
-    buildType,
-    roots: value.roots.map((root, index) => readFiber(root, `roots[${index}]`)),
-    capturedAt: typeof value.capturedAt === "string" ? value.capturedAt : new Date().toISOString(),
-  };
+  const snapshot = snapshotSchema.safeParse(value);
+  if (!snapshot.success) throw new Error(`snapshot: ${z.prettifyError(snapshot.error)}`);
+  return snapshot.data;
 };
 
 export const countSnapshotFibers = (fiber: RuntimeFiberSnapshot): number => {

--- a/packages/parser/src/observations.ts
+++ b/packages/parser/src/observations.ts
@@ -1,5 +1,6 @@
 import type {
   CapturedExportReference,
+  CapturedFetcher,
   CapturedLinguiCatalog,
   CapturedMutation,
   CapturedPageState,
@@ -97,8 +98,22 @@ const isCapturedRouteMatch = (value: unknown): value is CapturedRouteMatch =>
   typeof value.pathname === "string" &&
   isStringRecord(value.params);
 
+const isOptionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === "string";
+
+const isCapturedFetcher = (value: unknown): value is CapturedFetcher =>
+  isRecord(value) &&
+  typeof value.key === "string" &&
+  (value.state === "idle" || value.state === "loading" || value.state === "submitting") &&
+  isOptionalString(value.formMethod) &&
+  isOptionalString(value.formAction) &&
+  isOptionalString(value.formEncType) &&
+  isOptionalCapturedValue(value.data);
+
 const isCapturedRouterState = (value: unknown): value is CapturedRouterState =>
   isRecord(value) &&
+  (value.fetchers === undefined ||
+    (Array.isArray(value.fetchers) && value.fetchers.every(isCapturedFetcher))) &&
   isStringRecord(value.location) &&
   typeof value.location.pathname === "string" &&
   typeof value.location.search === "string" &&

--- a/packages/parser/src/observations.ts
+++ b/packages/parser/src/observations.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type {
   CapturedExportReference,
   CapturedFetcher,
@@ -9,6 +10,7 @@ import type {
   CapturedRouteMatch,
   CapturedRouterState,
   CapturedValue,
+  JsonValue,
   RuntimeObservations,
 } from "./types.js";
 
@@ -38,109 +40,109 @@ export const hashKey = (key: unknown): string =>
       : value,
   );
 
-const isCapturedValue = (value: unknown): value is CapturedValue =>
-  value === null ||
-  typeof value === "string" ||
-  typeof value === "number" ||
-  typeof value === "boolean" ||
-  (Array.isArray(value) && value.every(isCapturedValue)) ||
-  (isRecord(value) && Object.values(value).every(isCapturedValue));
+export const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.null(),
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.array(jsonValueSchema),
+    z.record(z.string(), jsonValueSchema),
+  ]),
+);
 
-const isCapturedQuery = (value: unknown): value is CapturedQuery =>
-  isRecord(value) &&
-  typeof value.queryHash === "string" &&
-  (value.status === "pending" || value.status === "error" || value.status === "success") &&
-  (value.fetchStatus === "fetching" ||
-    value.fetchStatus === "paused" ||
-    value.fetchStatus === "idle") &&
-  (value.data === undefined || isCapturedValue(value.data)) &&
-  isCapturedValue(value.error) &&
-  typeof value.dataUpdateCount === "number" &&
-  typeof value.dataUpdatedAt === "number" &&
-  typeof value.errorUpdateCount === "number" &&
-  typeof value.errorUpdatedAt === "number" &&
-  typeof value.fetchFailureCount === "number" &&
-  isCapturedValue(value.fetchFailureReason) &&
-  typeof value.isInvalidated === "boolean" &&
-  typeof value.isStale === "boolean";
+const capturedValueRecordSchema = z.record(z.string(), jsonValueSchema);
 
-const isOptionalCapturedValue = (value: unknown): value is CapturedValue | undefined =>
-  value === undefined || isCapturedValue(value);
+const stringRecordSchema = z.record(z.string(), z.string());
 
-const isCapturedMutation = (value: unknown): value is CapturedMutation =>
-  isRecord(value) &&
-  (value.mutationHash === null || typeof value.mutationHash === "string") &&
-  (value.status === "idle" ||
-    value.status === "pending" ||
-    value.status === "success" ||
-    value.status === "error") &&
-  isOptionalCapturedValue(value.data) &&
-  isCapturedValue(value.error) &&
-  isOptionalCapturedValue(value.variables) &&
-  isOptionalCapturedValue(value.context) &&
-  typeof value.failureCount === "number" &&
-  isCapturedValue(value.failureReason) &&
-  typeof value.isPaused === "boolean" &&
-  typeof value.submittedAt === "number";
+const capturedQuerySchema: z.ZodType<CapturedQuery> = z.object({
+  queryHash: z.string(),
+  status: z.enum(["pending", "error", "success"]),
+  fetchStatus: z.enum(["fetching", "paused", "idle"]),
+  data: jsonValueSchema.optional(),
+  error: jsonValueSchema,
+  dataUpdateCount: z.number(),
+  dataUpdatedAt: z.number(),
+  errorUpdateCount: z.number(),
+  errorUpdatedAt: z.number(),
+  fetchFailureCount: z.number(),
+  fetchFailureReason: jsonValueSchema,
+  isInvalidated: z.boolean(),
+  isStale: z.boolean(),
+});
 
-const isCapturedValueRecord = (value: unknown): value is Record<string, CapturedValue> =>
-  isRecord(value) && Object.values(value).every(isCapturedValue);
+const capturedMutationSchema: z.ZodType<CapturedMutation> = z.object({
+  mutationHash: z.string().nullable(),
+  status: z.enum(["idle", "pending", "success", "error"]),
+  data: jsonValueSchema.optional(),
+  error: jsonValueSchema,
+  variables: jsonValueSchema.optional(),
+  context: jsonValueSchema.optional(),
+  failureCount: z.number(),
+  failureReason: jsonValueSchema,
+  isPaused: z.boolean(),
+  submittedAt: z.number(),
+});
 
-const isStringRecord = (value: unknown): value is Record<string, string> =>
-  isRecord(value) && Object.values(value).every((item) => typeof item === "string");
+const capturedLinguiCatalogSchema: z.ZodType<CapturedLinguiCatalog> = z.object({
+  locale: z.string(),
+  messages: capturedValueRecordSchema,
+});
 
-const isCapturedLinguiCatalog = (value: unknown): value is CapturedLinguiCatalog =>
-  isRecord(value) && typeof value.locale === "string" && isCapturedValueRecord(value.messages);
+const capturedRouteMatchSchema: z.ZodType<CapturedRouteMatch> = z.object({
+  id: z.string(),
+  pathname: z.string(),
+  params: stringRecordSchema,
+});
 
-const isCapturedRouteMatch = (value: unknown): value is CapturedRouteMatch =>
-  isRecord(value) &&
-  typeof value.id === "string" &&
-  typeof value.pathname === "string" &&
-  isStringRecord(value.params);
+export const routerActivityStateSchema = z.enum(["idle", "loading", "submitting"]);
 
-const isOptionalString = (value: unknown): value is string | undefined =>
-  value === undefined || typeof value === "string";
+const capturedFetcherSchema: z.ZodType<CapturedFetcher> = z.object({
+  key: z.string(),
+  state: routerActivityStateSchema,
+  formMethod: z.string().optional(),
+  formAction: z.string().optional(),
+  formEncType: z.string().optional(),
+  data: jsonValueSchema.optional(),
+});
 
-const isCapturedFetcher = (value: unknown): value is CapturedFetcher =>
-  isRecord(value) &&
-  typeof value.key === "string" &&
-  (value.state === "idle" || value.state === "loading" || value.state === "submitting") &&
-  isOptionalString(value.formMethod) &&
-  isOptionalString(value.formAction) &&
-  isOptionalString(value.formEncType) &&
-  isOptionalCapturedValue(value.data);
+const capturedRouterStateSchema: z.ZodType<CapturedRouterState> = z.object({
+  location: z.object({ pathname: z.string(), search: z.string(), hash: z.string() }),
+  matches: z.array(capturedRouteMatchSchema),
+  loaderData: capturedValueRecordSchema,
+  navigationState: routerActivityStateSchema,
+  revalidationState: z.enum(["idle", "loading"]),
+  fetchers: z.array(capturedFetcherSchema).optional(),
+});
 
-const isCapturedRouterState = (value: unknown): value is CapturedRouterState =>
-  isRecord(value) &&
-  (value.fetchers === undefined ||
-    (Array.isArray(value.fetchers) && value.fetchers.every(isCapturedFetcher))) &&
-  isStringRecord(value.location) &&
-  typeof value.location.pathname === "string" &&
-  typeof value.location.search === "string" &&
-  typeof value.location.hash === "string" &&
-  Array.isArray(value.matches) &&
-  value.matches.every(isCapturedRouteMatch) &&
-  isCapturedValueRecord(value.loaderData) &&
-  (value.navigationState === "idle" ||
-    value.navigationState === "loading" ||
-    value.navigationState === "submitting") &&
-  (value.revalidationState === "idle" || value.revalidationState === "loading");
+const capturedRequestSchema: z.ZodType<CapturedRequest> = z.object({
+  headers: stringRecordSchema,
+});
 
-const isCapturedRequest = (value: unknown): value is CapturedRequest =>
-  isRecord(value) && isStringRecord(value.headers);
+const capturedPageStateSchema: z.ZodType<CapturedPageState> = z.object({
+  cookie: z.string(),
+  name: z.string().optional(),
+  historyState: jsonValueSchema.optional(),
+  windowKeys: z.array(z.string()).optional(),
+  userAgent: z.string().optional(),
+  language: z.string().optional(),
+  localStorage: stringRecordSchema,
+  sessionStorage: stringRecordSchema,
+});
 
-const isCapturedPageState = (value: unknown): value is CapturedPageState =>
-  isRecord(value) &&
-  typeof value.cookie === "string" &&
-  (value.name === undefined || typeof value.name === "string") &&
-  isOptionalCapturedValue(value.historyState) &&
-  (value.windowKeys === undefined ||
-    (Array.isArray(value.windowKeys) &&
-      value.windowKeys.every((key) => typeof key === "string"))) &&
-  (value.userAgent === undefined || typeof value.userAgent === "string") &&
-  (value.language === undefined || typeof value.language === "string") &&
-  isStringRecord(value.localStorage) &&
-  isStringRecord(value.sessionStorage);
+/** Every element of `value` that parses; a non-array is no elements. */
+const parseEach = <T>(schema: z.ZodType<T>, value: unknown): T[] =>
+  Array.isArray(value)
+    ? value.flatMap((item) => {
+        const result = schema.safeParse(item);
+        return result.success ? [result.data] : [];
+      })
+    : [];
+
+const parseOptional = <T>(schema: z.ZodType<T>, value: unknown): T | undefined => {
+  const result = schema.safeParse(value);
+  return result.success ? result.data : undefined;
+};
 
 /** Reads observations back from JSON (a page's serialized result or a saved capture), dropping malformed parts. */
 export const readObservationsJson = (value: unknown): RuntimeObservations => {
@@ -148,21 +150,26 @@ export const readObservationsJson = (value: unknown): RuntimeObservations => {
   const globals: Record<string, CapturedValue> = {};
   if (isRecord(value.globals)) {
     for (const [name, item] of Object.entries(value.globals)) {
-      if (isCapturedValue(item)) globals[name] = item;
+      const global = parseOptional(jsonValueSchema, item);
+      if (global !== undefined) globals[name] = global;
     }
   }
   const observations: RuntimeObservations = {
     globals,
-    queries: Array.isArray(value.queries) ? value.queries.filter(isCapturedQuery) : [],
+    queries: parseEach(capturedQuerySchema, value.queries),
   };
   if (Array.isArray(value.mutations)) {
-    observations.mutations = value.mutations.filter(isCapturedMutation);
+    observations.mutations = parseEach(capturedMutationSchema, value.mutations);
   }
-  if (isCapturedLinguiCatalog(value.lingui)) observations.lingui = value.lingui;
-  if (isCapturedRouterState(value.router)) observations.router = value.router;
-  if (Array.isArray(value.stores)) observations.stores = value.stores.filter(isCapturedValue);
-  if (isCapturedPageState(value.page)) observations.page = value.page;
-  if (isCapturedRequest(value.request)) observations.request = value.request;
+  if (Array.isArray(value.stores)) observations.stores = parseEach(jsonValueSchema, value.stores);
+  const lingui = parseOptional(capturedLinguiCatalogSchema, value.lingui);
+  if (lingui) observations.lingui = lingui;
+  const router = parseOptional(capturedRouterStateSchema, value.router);
+  if (router) observations.router = router;
+  const page = parseOptional(capturedPageStateSchema, value.page);
+  if (page) observations.page = page;
+  const request = parseOptional(capturedRequestSchema, value.request);
+  if (request) observations.request = request;
   return observations;
 };
 

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -395,6 +395,16 @@ export interface CapturedLocation {
   hash: string;
 }
 
+/** A fetcher in `state.fetchers`: one that has loaded or submitted since mounting. */
+export interface CapturedFetcher {
+  key: string;
+  state: "idle" | "loading" | "submitting";
+  formMethod?: string;
+  formAction?: string;
+  formEncType?: string;
+  data?: CapturedValue;
+}
+
 /** React Router's `DataRouterStateContext` value once the page settled. */
 export interface CapturedRouterState {
   location: CapturedLocation;
@@ -402,6 +412,8 @@ export interface CapturedRouterState {
   loaderData: Record<string, CapturedValue>;
   navigationState: "idle" | "loading" | "submitting";
   revalidationState: "idle" | "loading";
+  /** Absent in captures taken before it was recorded. */
+  fetchers?: CapturedFetcher[];
 }
 
 /** What the harness reads off the live roots besides the fiber tree: library state the page's code reads at render. */

--- a/packages/parser/tests/corpus-manifest.test.ts
+++ b/packages/parser/tests/corpus-manifest.test.ts
@@ -1,0 +1,33 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { readCorpusManifest } from "../src/corpus/manifest.js";
+
+const MANIFEST_PATH = path.resolve(import.meta.dirname, "../corpus/manifest.json");
+
+const writeManifest = (entries: unknown[]): string => {
+  const manifestPath = path.join(mkdtempSync(path.join(tmpdir(), "bippy-manifest-")), "m.json");
+  writeFileSync(manifestPath, JSON.stringify({ entries }));
+  return manifestPath;
+};
+
+describe("corpus manifest", () => {
+  it("reads the checked-in manifest", () => {
+    const { entries } = readCorpusManifest(MANIFEST_PATH);
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries.every((entry) => entry.static.rootDirectory.length > 0)).toBe(true);
+  });
+
+  it("names the offending field of a malformed entry", () => {
+    const [entry] = readCorpusManifest(MANIFEST_PATH).entries;
+    expect(() => readCorpusManifest(writeManifest([{ ...entry, framework: "gatsby" }]))).toThrow(
+      /entries\[0\]\.framework/,
+    );
+    expect(() =>
+      readCorpusManifest(
+        writeManifest([{ ...entry, static: { ...entry?.static, globals: ["ENV"] } }]),
+      ),
+    ).toThrow(/entries\[0\]\.static\.globals/);
+  });
+});

--- a/packages/parser/tests/fixtures.test.ts
+++ b/packages/parser/tests/fixtures.test.ts
@@ -19,7 +19,9 @@ describe("synthetic fixtures: static fiber tree vs react-dom", () => {
       const detail = describeFixtureRun(fixture, run);
       if (process.env.BIPPY_PARSER_DEBUG) process.stdout.write(`${detail}\n`);
       expect(
-        run.staticResult.diagnostics.filter((diagnostic) => diagnostic.severity === "error"),
+        run.staticResult.diagnostics.filter(
+          (diagnostic) => diagnostic.severity === "error" || diagnostic.code === "max-call-depth",
+        ),
         detail,
       ).toEqual([]);
       if (!run.comparison) return;

--- a/packages/parser/tests/fixtures/commonjs-package/fixture.json
+++ b/packages/parser/tests/fixtures/commonjs-package/fixture.json
@@ -1,4 +1,4 @@
 {
-  "externalPackages": ["cjs-kit"],
-  "notes": "A dependency shipped as compiled CommonJS: Babel output (interop/extends/objectWithoutProperties helpers, `exports.x =`, `Object.keys(...).forEach` re-exports) and tsc output (inline `__importDefault`, `exports.default =`), analyzed from source through the CommonJS export model."
+  "externalPackages": ["cjs-kit", "umd-kit"],
+  "notes": "A dependency shipped as compiled CommonJS: Babel output (interop/extends/objectWithoutProperties helpers, `exports.x =`, `Object.keys(...).forEach` re-exports) and tsc output (inline `__importDefault`, `exports.default =`), analyzed from source through the CommonJS export model; and a rollup UMD build whose factory receives `exports` and `require(...)`d dependencies as parameters."
 }

--- a/packages/parser/tests/fixtures/commonjs-package/node_modules/umd-kit/index.d.ts
+++ b/packages/parser/tests/fixtures/commonjs-package/node_modules/umd-kit/index.d.ts
@@ -1,0 +1,2 @@
+export declare const useDelayed: (isActive: boolean) => boolean;
+export declare const Spinner: (props: { isActive: boolean }) => JSX.Element;

--- a/packages/parser/tests/fixtures/commonjs-package/node_modules/umd-kit/index.js
+++ b/packages/parser/tests/fixtures/commonjs-package/node_modules/umd-kit/index.js
@@ -1,0 +1,26 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('react'), require('react/jsx-runtime')) :
+  typeof define === 'function' && define.amd ? define(['exports', 'react', 'react/jsx-runtime'], factory) :
+  (global = global || self, factory(global.umdKit = {}, global.React, global.jsxRuntime));
+}(this, (function (exports, react, jsxRuntime) {
+  const defaultOptions = { delay: 500 };
+
+  function useDelayed(isActive, options) {
+    options = Object.assign({}, defaultOptions, options);
+    const [state, setState] = react.useState(isActive ? 'DISPLAY' : 'IDLE');
+    react.useEffect(() => {
+      if (!isActive && state !== 'IDLE') setState('IDLE');
+    }, [isActive, state, options.delay]);
+    return state === 'DISPLAY';
+  }
+
+  function Spinner(props) {
+    const isShown = useDelayed(props.isActive);
+    return jsxRuntime.jsx('output', { className: 'spinner', children: isShown ? 'loading' : null });
+  }
+
+  exports.defaultOptions = defaultOptions;
+  exports.useDelayed = useDelayed;
+  exports.Spinner = Spinner;
+
+})));

--- a/packages/parser/tests/fixtures/commonjs-package/node_modules/umd-kit/package.json
+++ b/packages/parser/tests/fixtures/commonjs-package/node_modules/umd-kit/package.json
@@ -1,0 +1,1 @@
+{ "name": "umd-kit", "version": "0.0.0", "main": "index.js", "types": "index.d.ts" }

--- a/packages/parser/tests/fixtures/commonjs-package/src/app.tsx
+++ b/packages/parser/tests/fixtures/commonjs-package/src/app.tsx
@@ -1,10 +1,15 @@
 import { Badge, Card, LabelContext } from "cjs-kit";
+import { Spinner, useDelayed } from "umd-kit";
 
-export const App = () => (
-  <LabelContext.Provider value="pokedex">
-    <Card title="Bulbasaur" className="card">
-      <p>Grass</p>
-      <Badge label="seen" count={3} />
-    </Card>
-  </LabelContext.Provider>
-);
+export const App = () => {
+  const isDelayed = useDelayed(false);
+  return (
+    <LabelContext.Provider value="pokedex">
+      <Card title="Bulbasaur" className="card">
+        <p>Grass</p>
+        <Badge label="seen" count={3} />
+        {isDelayed ? <em>late</em> : <Spinner isActive />}
+      </Card>
+    </LabelContext.Provider>
+  );
+};

--- a/packages/parser/tests/fixtures/external-recursion/fixture.json
+++ b/packages/parser/tests/fixtures/external-recursion/fixture.json
@@ -1,0 +1,5 @@
+{
+  "expectedStatus": "partial",
+  "minCoverage": 1,
+  "notes": "A recursive walk over a value built by an opaque package (a schema's `_def.innerType` chain), caching each level in a Map as it goes. Every level is as opaque as the last, so the walk must stop with an explicit unknown instead of following ever-longer derived member chains to the call-depth limit."
+}

--- a/packages/parser/tests/fixtures/external-recursion/node_modules/schema-kit/index.d.ts
+++ b/packages/parser/tests/fixtures/external-recursion/node_modules/schema-kit/index.d.ts
@@ -1,0 +1,7 @@
+export interface Schema {
+  _def: { typeName: string; innerType?: Schema; shape?: Record<string, Schema> };
+}
+export declare const string: () => Schema;
+export declare const optional: (innerType: Schema) => Schema;
+export declare const nullable: (innerType: Schema) => Schema;
+export declare const object: (shape: Record<string, Schema>) => Schema;

--- a/packages/parser/tests/fixtures/external-recursion/node_modules/schema-kit/index.js
+++ b/packages/parser/tests/fixtures/external-recursion/node_modules/schema-kit/index.js
@@ -1,0 +1,4 @@
+export const string = () => ({ _def: { typeName: "String" } });
+export const optional = (innerType) => ({ _def: { typeName: "Optional", innerType } });
+export const nullable = (innerType) => ({ _def: { typeName: "Nullable", innerType } });
+export const object = (shape) => ({ _def: { typeName: "Object", shape } });

--- a/packages/parser/tests/fixtures/external-recursion/node_modules/schema-kit/package.json
+++ b/packages/parser/tests/fixtures/external-recursion/node_modules/schema-kit/package.json
@@ -1,0 +1,1 @@
+{ "name": "schema-kit", "version": "0.0.0", "type": "module", "main": "./index.js", "types": "./index.d.ts" }

--- a/packages/parser/tests/fixtures/external-recursion/package.json
+++ b/packages/parser/tests/fixtures/external-recursion/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-external-recursion",
+  "private": true,
+  "type": "module"
+}

--- a/packages/parser/tests/fixtures/external-recursion/src/app.tsx
+++ b/packages/parser/tests/fixtures/external-recursion/src/app.tsx
@@ -1,0 +1,31 @@
+import { nullable, object, optional, type Schema, string } from "schema-kit";
+
+interface Walk {
+  cache: Map<Schema, Schema>;
+  visited: number;
+}
+
+const SCHEMA = object({ name: optional(nullable(string())) });
+
+const unwrap = (type: Schema, walk: Walk): Schema => {
+  const cached = walk.cache.get(type);
+  if (cached) return cached;
+  walk.visited += 1;
+  const def = type._def;
+  const inner =
+    def.typeName === "Optional" || def.typeName === "Nullable" ? def.innerType : undefined;
+  const result = inner ? unwrap(inner, walk) : type;
+  walk.cache.set(type, result);
+  return result;
+};
+
+export const App = () => {
+  const field = SCHEMA._def.shape?.name;
+  const walk: Walk = { cache: new Map(), visited: 0 };
+  const base = field ? unwrap(field, walk) : null;
+  return (
+    <form data-visited={walk.visited}>
+      <label>{base ? base._def.typeName : "none"}</label>
+    </form>
+  );
+};

--- a/packages/parser/tests/fixtures/external-recursion/src/main.tsx
+++ b/packages/parser/tests/fixtures/external-recursion/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/packages/parser/tests/fixtures/external-recursion/tsconfig.json
+++ b/packages/parser/tests/fixtures/external-recursion/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] },
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "strict": true
+  }
+}

--- a/packages/parser/tests/fixtures/react-router-observed/fixture.json
+++ b/packages/parser/tests/fixtures/react-router-observed/fixture.json
@@ -3,7 +3,7 @@
   "route": "/posts/hello",
   "expectedStatus": "exact",
   "minCoverage": 1,
-  "notes": "Data router with loaders. The static side cannot run loaders, so the captured router state (loaderData keyed by route id, matches, navigation/revalidation state, location) is replayed into useLoaderData/useRouteLoaderData/useMatches/useNavigation/useRevalidator/useSearchParams/useLocation. The observations below must equal what the runtime capture records.",
+  "notes": "Data router with loaders. The static side cannot run loaders, so the captured router state (loaderData keyed by route id, matches, navigation/revalidation state, location) is replayed into useLoaderData/useRouteLoaderData/useMatches/useNavigation/useRevalidator/useSearchParams/useLocation, and the (empty) fetcher map into useFetchers/useFetcher so an idle fetcher.Form renders as the real one does. The observations below must equal what the runtime capture records.",
   "observations": {
     "globals": {},
     "queries": [],
@@ -18,7 +18,8 @@
         "0-0": { "title": "Post hello", "tags": ["react", "router"], "publishedAt": null }
       },
       "navigationState": "idle",
-      "revalidationState": "idle"
+      "revalidationState": "idle",
+      "fetchers": []
     }
   }
 }

--- a/packages/parser/tests/fixtures/react-router-observed/src/post.tsx
+++ b/packages/parser/tests/fixtures/react-router-observed/src/post.tsx
@@ -1,4 +1,11 @@
-import { useLoaderData, useMatches, useRouteLoaderData, useSearchParams } from "react-router";
+import {
+  useFetcher,
+  useFetchers,
+  useLoaderData,
+  useMatches,
+  useRouteLoaderData,
+  useSearchParams,
+} from "react-router";
 
 interface PostData {
   title: string;
@@ -16,6 +23,8 @@ export const Post = () => {
   const matches = useMatches();
   const [searchParams] = useSearchParams();
   const tab = searchParams.get("tab") ?? "overview";
+  const fetcher = useFetcher<{ liked: boolean }>();
+  const pendingFetchers = useFetchers().filter((inflight) => inflight.state !== "idle");
 
   return (
     <article data-tab={tab}>
@@ -32,6 +41,13 @@ export const Post = () => {
           <li key={match.id}>{match.pathname}</li>
         ))}
       </ol>
+      <fetcher.Form method="post" action="/posts/hello/like">
+        <input type="hidden" name="slug" value="hello" />
+        <button type="submit" disabled={fetcher.state !== "idle"}>
+          {fetcher.data?.liked ? "Liked" : "Like"}
+        </button>
+        {pendingFetchers.length > 0 && <output>{pendingFetchers.length} pending</output>}
+      </fetcher.Form>
     </article>
   );
 };

--- a/packages/parser/tests/fixtures/window-globals/fixture.json
+++ b/packages/parser/tests/fixtures/window-globals/fixture.json
@@ -1,0 +1,6 @@
+{
+  "entry": "src/main.tsx",
+  "expectedStatus": "exact",
+  "minCoverage": 1,
+  "notes": "A bootstrap script assigns a payload to `window` and components read it as a bare global (`ENV`), the way a server-rendered document inlines its public environment."
+}

--- a/packages/parser/tests/fixtures/window-globals/package.json
+++ b/packages/parser/tests/fixtures/window-globals/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-window-globals",
+  "private": true,
+  "type": "module"
+}

--- a/packages/parser/tests/fixtures/window-globals/src/app.tsx
+++ b/packages/parser/tests/fixtures/window-globals/src/app.tsx
@@ -1,0 +1,18 @@
+interface PublicEnvironment {
+  MODE: string;
+  ALLOW_INDEXING?: string;
+}
+
+declare global {
+  var ENV: PublicEnvironment;
+}
+
+export const App = () => {
+  const isIndexable = ENV.ALLOW_INDEXING !== "false";
+  return (
+    <main data-mode={ENV.MODE}>
+      {isIndexable ? null : <meta name="robots" content="noindex" />}
+      <p>{ENV.MODE}</p>
+    </main>
+  );
+};

--- a/packages/parser/tests/fixtures/window-globals/src/main.tsx
+++ b/packages/parser/tests/fixtures/window-globals/src/main.tsx
@@ -1,0 +1,6 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+
+window.ENV = { MODE: "development", ALLOW_INDEXING: "true" };
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/packages/parser/tests/fixtures/window-globals/tsconfig.json
+++ b/packages/parser/tests/fixtures/window-globals/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "strict": true
+  }
+}

--- a/packages/parser/tests/framework-fixtures/react-router-auto/app/routes/_marketing/about.tsx
+++ b/packages/parser/tests/framework-fixtures/react-router-auto/app/routes/_marketing/about.tsx
@@ -1,3 +1,15 @@
+import { useFetcher } from "react-router";
+
 export default function About() {
-  return <article>about</article>;
+  const fetcher = useFetcher<{ subscribed: boolean }>();
+  return (
+    <article>
+      about
+      <fetcher.Form method="post" action="/newsletter">
+        <input name="email" type="email" />
+        <button type="submit">{fetcher.state === "idle" ? "Subscribe" : "Subscribing…"}</button>
+        {fetcher.data?.subscribed && <output>Thanks!</output>}
+      </fetcher.Form>
+    </article>
+  );
 }

--- a/packages/parser/tests/framework-fixtures/react-router-initial/app/entry.client.tsx
+++ b/packages/parser/tests/framework-fixtures/react-router-initial/app/entry.client.tsx
@@ -1,0 +1,7 @@
+import { startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
+import { HydratedRouter } from "react-router/dom";
+
+startTransition(() => {
+  hydrateRoot(document, <HydratedRouter />);
+});

--- a/packages/parser/tests/framework-fixtures/react-router-initial/app/root.tsx
+++ b/packages/parser/tests/framework-fixtures/react-router-initial/app/root.tsx
@@ -1,0 +1,15 @@
+import { Outlet, Scripts, ScrollRestoration } from "react-router";
+
+export const Layout = ({ children }: { children: React.ReactNode }) => (
+  <html lang="en">
+    <body>
+      {children}
+      <ScrollRestoration nonce="abc" />
+      <Scripts nonce="abc" />
+    </body>
+  </html>
+);
+
+export default function App() {
+  return <Outlet />;
+}

--- a/packages/parser/tests/framework-fixtures/react-router-initial/app/routes.ts
+++ b/packages/parser/tests/framework-fixtures/react-router-initial/app/routes.ts
@@ -1,0 +1,3 @@
+import { index, type RouteConfig } from "@react-router/dev/routes";
+
+export default [index("routes/home.tsx")] satisfies RouteConfig;

--- a/packages/parser/tests/framework-fixtures/react-router-initial/app/routes/home.tsx
+++ b/packages/parser/tests/framework-fixtures/react-router-initial/app/routes/home.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <main>home</main>;
+}

--- a/packages/parser/tests/framework-fixtures/react-router-initial/package.json
+++ b/packages/parser/tests/framework-fixtures/react-router-initial/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "framework-fixture-react-router-initial",
+  "private": true,
+  "type": "module"
+}

--- a/packages/parser/tests/framework-fixtures/react-router-initial/react-router.config.ts
+++ b/packages/parser/tests/framework-fixtures/react-router-initial/react-router.config.ts
@@ -1,0 +1,7 @@
+import type { Config } from "@react-router/dev/config";
+
+export default {
+  ssr: true,
+  routeDiscovery: { mode: "initial" },
+  future: { unstable_subResourceIntegrity: true },
+} satisfies Config;

--- a/packages/parser/tests/framework-fixtures/react-router-initial/tsconfig.json
+++ b/packages/parser/tests/framework-fixtures/react-router-initial/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] },
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "strict": true
+  }
+}

--- a/packages/parser/tests/frameworks.test.ts
+++ b/packages/parser/tests/frameworks.test.ts
@@ -164,7 +164,7 @@ describe("react router framework mode with react-router-auto-routes", () => {
     expect(post).toMatch(
       /<Meta>\n\s+<title> key="title"\n\s+<meta> key="\{\\"name\\":\\"description\\",\\"content\\":\\"A post\\"\}"\n\s+<link> key="\{\\"rel\\":\\"alternate\\",\\"href\\":\\"\/feed.xml\\"\}"/,
     );
-    const links = lines(post).filter((line) => line.startsWith("<link>"));
+    const links = lines(post).filter((line) => line.startsWith('<link> key="{'));
     expect(links).toEqual([
       '<link> key="{\\"rel\\":\\"alternate\\",\\"href\\":\\"/feed.xml\\"}"',
       '<link> key="{\\"href\\":\\"https://fonts.example\\",\\"rel\\":\\"preconnect\\"}"',
@@ -177,5 +177,40 @@ describe("react router framework mode with react-router-auto-routes", () => {
     const { tree, errors } = await target("/robots.txt");
     expect(errors).toEqual([]);
     expect(tree).not.toContain("?unknown");
+  });
+
+  it("renders <Scripts> as the pre-hydration preloads and boot scripts, lazy route discovery by default", async () => {
+    const { tree } = await target("/");
+    expect(tree).toMatch(
+      /<Scripts>\n\s+<link>\n\s+<Fragment>\n\s+<link> key="\/app\/root.tsx"\n\s+<link> key="\/app\/routes\/_marketing\/index.tsx"\n\s+<Fragment>\n\s+<script>\n\s+<script>\n/,
+    );
+    expect(tree).not.toContain("subresource integrity");
+  });
+
+  it("renders useFetcher()'s Form through <Form> while its state stays a runtime branch", async () => {
+    const { tree, errors } = await target("/about");
+    expect(errors).toEqual([]);
+    expect(tree).toMatch(
+      /<fetcher\.Form>\n\s+<Form>\n\s+<form>\n\s+<input>\n\s+<button>\n\s+\?branch/,
+    );
+    expect(tree).toContain("react-router fetcher state is only known at runtime");
+    expect(tree).not.toContain("?unknown");
+  });
+});
+
+describe("react router framework mode config", () => {
+  it("preloads the route manifest under initial route discovery and branches on the SRI import map", async () => {
+    const { tree, errors } = await render("react-router-initial", {
+      framework: "react-router",
+      route: "/",
+      entry: "app/routes.ts",
+    });
+    expect(errors).toEqual([]);
+    expect(tree).toMatch(
+      /<ScrollRestoration>\n\s+<script>\n\s+<Scripts>\n\s+\?branch\(the subresource integrity/,
+    );
+    expect(tree).toMatch(
+      /<Scripts>\n\s+\?branch[^\n]*\n\s+\|0 \(preferred\)\n\s+<script>\n\s+\|1\n\s+<link>\n\s+<link>\n\s+<Fragment>\n\s+<link> key="\/app\/root.tsx"\n\s+<link> key="\/app\/routes\/home.tsx"\n\s+<Fragment>\n\s+<script>\n\s+<script>\n/,
+    );
   });
 });

--- a/packages/parser/tests/harness.test.ts
+++ b/packages/parser/tests/harness.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  flattenTransparentFibers,
+  REACT_ROUTER_PROFILE,
+  SPA_PROFILE,
+} from "../src/frameworks/index.js";
+import {
+  comparePatternToRuntime,
+  type PatternFiber,
+  type RuntimeFiberSnapshot,
+  type RuntimeSnapshot,
+  type SnapshotWorkTag,
+} from "../src/harness/index.js";
+
+const fiber = (
+  name: string | null,
+  children: RuntimeFiberSnapshot[] = [],
+  tag: SnapshotWorkTag = name === null ? "Fragment" : "FunctionComponent",
+): RuntimeFiberSnapshot => ({ tag, name, key: null, text: null, props: {}, children });
+
+const pattern = (
+  name: string,
+  children: PatternFiber[] = [],
+  tag: SnapshotWorkTag = "FunctionComponent",
+): PatternFiber => ({ kind: "fiber", tag, name, key: null, children });
+
+const host = (name: string, children: RuntimeFiberSnapshot[] = []) =>
+  fiber(name, children, "HostComponent");
+
+const snapshot = (roots: RuntimeFiberSnapshot[]): RuntimeSnapshot => ({
+  reactVersion: null,
+  rendererName: null,
+  buildType: "development",
+  roots,
+  capturedAt: "",
+});
+
+const names = (fibers: RuntimeFiberSnapshot[]): unknown[] =>
+  fibers.map((child) => [child.name, names(child.children)]);
+
+describe("fiber comparison", () => {
+  it("matches a component the bundler renamed to avoid a scope collision", () => {
+    for (const runtimeName of ["Toaster2", "Toaster$1", "Toaster"]) {
+      const report = comparePatternToRuntime(
+        [pattern("App", [pattern("Toaster", [pattern("section", [], "HostComponent")])])],
+        [fiber("App", [fiber(runtimeName, [host("section")])])],
+      );
+      expect(report.status, runtimeName).toBe("exact");
+      expect(report.strictCoverage, runtimeName).toBe(1);
+    }
+  });
+
+  it("does not treat an unrelated longer name as a renamed binding", () => {
+    for (const runtimeName of ["Toaster2Wrapper", "ToasterX", "toaster2"]) {
+      const report = comparePatternToRuntime(
+        [pattern("App", [pattern("Toaster")])],
+        [fiber("App", [fiber(runtimeName)])],
+      );
+      expect(report.status, runtimeName).toBe("mismatch");
+    }
+  });
+});
+
+describe("framework profiles", () => {
+  const routeModule = fiber("Layout", [
+    fiber("App", [host("main")]),
+    fiber(null, [fiber("TanStackDevtools", [host("div"), fiber(null, [fiber("Portal")])])]),
+  ]);
+
+  it("drops dev tooling the framework injects, along with its anonymous wrapper", () => {
+    const flattened = flattenTransparentFibers(snapshot([routeModule]), REACT_ROUTER_PROFILE);
+    expect(names(flattened.roots)).toEqual([["Layout", [["App", [["main", []]]]]]]);
+  });
+
+  it("keeps anonymous fragments that wrap only application fibers", () => {
+    const tree = fiber("Layout", [fiber(null, [fiber("App"), fiber("Footer")])]);
+    const flattened = flattenTransparentFibers(snapshot([tree]), REACT_ROUTER_PROFILE);
+    expect(names(flattened.roots)).toEqual([
+      [
+        "Layout",
+        [
+          [
+            null,
+            [
+              ["App", []],
+              ["Footer", []],
+            ],
+          ],
+        ],
+      ],
+    ]);
+  });
+
+  it("leaves everything in place for plain SPAs", () => {
+    const flattened = flattenTransparentFibers(snapshot([routeModule]), SPA_PROFILE);
+    expect(flattened.roots).toEqual([routeModule]);
+  });
+
+  it("splices out react-router's runtime wrappers", () => {
+    const tree = fiber("RouterProvider", [
+      fiber("DataRouter", [fiber("Location", [fiber("RenderErrorBoundary", [fiber("Home")])])]),
+    ]);
+    const flattened = flattenTransparentFibers(snapshot([tree]), REACT_ROUTER_PROFILE);
+    expect(names(flattened.roots)).toEqual([["RouterProvider", [["Home", []]]]]);
+  });
+});

--- a/packages/parser/tests/harness.test.ts
+++ b/packages/parser/tests/harness.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   comparePatternToRuntime,
   type PatternFiber,
+  readSnapshot,
   type RuntimeFiberSnapshot,
   type RuntimeSnapshot,
   type SnapshotWorkTag,
@@ -37,6 +38,27 @@ const snapshot = (roots: RuntimeFiberSnapshot[]): RuntimeSnapshot => ({
 
 const names = (fibers: RuntimeFiberSnapshot[]): unknown[] =>
   fibers.map((child) => [child.name, names(child.children)]);
+
+describe("snapshot reading", () => {
+  it("fills absent metadata and degrades unfamiliar tags to Unknown", () => {
+    const root = { ...fiber("App", [fiber("Leaf")]), tag: "FutureComponent" };
+    const read = readSnapshot({ roots: [root], buildType: "staging" });
+    expect(read.roots[0]?.tag).toBe("Unknown");
+    expect(read.roots[0]?.children[0]?.tag).toBe("FunctionComponent");
+    expect(read.reactVersion).toBeNull();
+    expect(read.buildType).toBeNull();
+    expect(typeof read.capturedAt).toBe("string");
+  });
+
+  it("rejects malformed fibers with their path", () => {
+    const leaf: unknown = { ...fiber("Leaf"), props: { onClick: {} } };
+    expect(() => readSnapshot({ roots: [{ ...fiber("App"), children: [leaf] }] })).toThrow(
+      /roots\[0\]\.children\[0\]\.props/,
+    );
+    expect(() => readSnapshot({ roots: [{ ...fiber("App"), tag: 3 }] })).toThrow(/roots\[0\]\.tag/);
+    expect(() => readSnapshot({})).toThrow(/roots/);
+  });
+});
 
 describe("fiber comparison", () => {
   it("matches a component the bundler renamed to avoid a scope collision", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1222,6 +1222,9 @@ importers:
       playwright:
         specifier: ^1.63.0
         version: 1.63.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@babel/runtime':
         specifier: ^7.29.7


### PR DESCRIPTION
## Summary

Brings `epic-stack` (React Router v7 framework mode, live capture) from static-only `partial` (480 fibers, br=7 op=101 unk=2) to live `exact`: 689 fibers + 4 text of 693 runtime nodes, strict coverage 100%, branches/repeats/opaque/unknown = 0. Every change is a generic evaluator/framework/resolver/comparator improvement with its own fixture or test; Epic Stack source is untouched.

### Corpus entry
- `setup`: `.env` from `.env.example`, `prisma migrate deploy`, `prisma generate --sql`. The parser never sees the DB; loader data stays an observed runtime value.
- `externalPackageAllowList`: `@radix-ui/*`, `remix-utils`, `openimg`, `sonner`, `spin-delay` — each one measurably removed opaque fibers. `@conform-to/*`, `@epic-web/*`, `@nasa-gcn/remix-seo` were tried and changed nothing, so they stay external.
- `capturedGlobals: ["ENV"]`: the server inlines `window.ENV`; the capture records it and the static side reads it.

### React Router framework model (`src/frameworks/react-router.ts`, checked against `node_modules/react-router` 7.16.0)
- `<Scripts>` was `emptyStub`; the runtime renders `link[modulepreload]` × (manifest? + entry + one per matched route module) plus a fragment with two inline `<script>`s. Now modeled from `react-router.config` (`ssr`, `routeDiscovery.mode`, `future.unstable_subResourceIntegrity`, defaults per `@react-router/dev`) and the matched route files:
  ```
  <Scripts>
    [branch: SRI import-map <script>]      // only when SRI flag not statically false
    [link manifest]                         // when fog-of-war is off (initial discovery)
    <link modulepreload entry>              // href unknown (build-time URL)
    <link key="/app/root.tsx"> …            // one per matched route module, dev-server URL
    <Fragment><script/><script/></Fragment>
  ```
  `readSsrFlag` → `readFrameworkConfig(): FrameworkConfig { isSsr, isFogOfWar, hasSubResourceIntegrity }` (each `boolean | null`; `null` renders as a branch via `whenFlag`).
- `useFetcher()` is no longer runtime-only: returns `{ ...state, Form: fetcher.Form, submit, load, reset }` where `fetcher.Form` is a forwardRef stub rendering `<Form navigate={false}>` (matches `react-router`'s memoized `FetcherForm`). State is idle when the captured fetcher map is empty, else `unknown` (a `useId`-keyed fetcher can't be correlated). `useFetchers()` replays captured fetchers. Harness captures `router.state.fetchers` (`CapturedFetcher` in `types.ts`, validated in `observations.ts`, optional for old captures).

### Evaluator / resolver / comparator
- `module-record.ts`: UMD wrappers `(function (global, factory) { … })(this, function (exports, React) { … })` — locate the CommonJS-path `factory(exports, require("react"))` call and bind factory params to their arguments; `getWrapperCall` unwraps parentheses around/inside `!function(){}()` wrappers. (`sonner`/`spin-delay`-style dist builds.)
- `interpreter.ts` `mayBeUnknown`: a `derived` external counts as possibly-unknown, so recursion over `external.member.member…` (Conform/Zod `_def.innerType` unwrapping) stops with an explicit `?unknown(recursive call …)` instead of blowing the call-depth budget / stack.
- `interpreter.ts` `lookupIdentifier`: unbound identifiers fall back to captured `window` globals (`ENV.ALLOW_INDEXING` as a bare global).
- `compare.ts`: runtime names deduped by the bundler (`Toaster2`, `Toaster$1`) match static `Toaster`; `Toaster2Wrapper`/`ToasterX` don't.
- `framework-profile.ts` / `profiles.ts`: `FrameworkProfile.isInjectedRuntimeFiber` — fibers a dev tool injects into the runtime tree (and their anonymous wrapper) are spliced out before comparison. React Router's profile lists `TanStackDevtools` (what `react-router-devtools` mounts in dev). This is the one name-keyed rule in the change; it is keyed on the dev-tool library, not the app.

### Tests
New fixtures: `commonjs-package/node_modules/umd-kit` (UMD), `external-recursion` (recursive derived-external unwrapping, exact), `window-globals` (bare `ENV`, exact), `framework-fixtures/react-router-initial` (initial route discovery + SRI + `<Scripts>`/`<ScrollRestoration>`). Extended `react-router-observed` (fetchers) and `react-router-auto` (`useFetcher`/`fetcher.Form`). Harness tests for deduped names and injected-fiber flattening. 134 parser tests green; root `lint`/`typecheck`/`fmt --check` green.

### Validation with `zod` (second commit)
`@bippy/parser` now depends on `zod` (already in the workspace via `bippy`). Data-shape validation is schemas typed against the existing interfaces, replacing hand-rolled type guards:
- `observations.ts`: `jsonValueSchema: z.ZodType<JsonValue>` (recursive) and per-observation schemas; `readObservationsJson` keeps its drop-malformed-parts semantics via `safeParse` per element.
- `harness/provider-state.ts`: live `DataRouterState` / Lingui context read through `z.object`/`z.map` schemas (`FetcherLike` etc. are `z.infer` of those schemas). This runs inside the injected browser bundle; verified by a live epic-stack rerun.
- `harness/snapshot.ts`: `snapshotSchema`; unfamiliar tags still degrade to `"Unknown"` (`z.string().pipe(snapshotWorkTagSchema.catch("Unknown"))`), errors carry the fiber path (`roots[0].children[2].props.onClick`).
- `corpus/manifest.ts`: the `ManifestReader` class is gone; `CorpusEntry`/`CorpusStaticTarget` are `interface … extends z.infer<typeof …Schema>`, field docs moved onto the schema. Errors read `manifest.json: ✖ Invalid option … → at entries[3].framework`.
- `corpus/run-entry.ts`: `savedCaptureSchema` for `.capture.json` replay.
Live-object duck typing that must keep identity (`isReduxStore`, `isQueryClient`, module exports — methods are called on the originals; `z.object` would return a stripped clone) is intentionally left as `typeof` guards.

### Residuals (none affect the `exact` status)
- Informational `dynamic-key` diagnostic on the theme-switch `<fetcher.Form key={JSON.stringify(...)}>`: the key is a stringified runtime descriptor; the fiber matches regardless.
- Loader data (theme cookie, honeypot, user session, toasts) is replayed from the captured router state, not derived statically — a static-only run keeps them as unknown/branches by design.


Link to Devin session: https://app.devin.ai/sessions/8ecd652b253e4dfe9e9362d06784e742
Open in Devin Desktop: https://app.devin.ai/desktop/session/8ecd652b253e4dfe9e9362d06784e742?variant=devin
Requested by: @aidenybai