### PR TITLE
feat(parser): misc-apps corpus batch + generic resolver/evaluator/framework fixes

### DIFF
--- a/packages/parser/corpus/manifest.json
+++ b/packages/parser/corpus/manifest.json
@@ -646,6 +646,244 @@
         "maxFiberCount": 20000
       },
       "notes": "Django normally renders index.html with window.POSTHOG_APP_CONTEXT and points the module scripts at the Vite dev server; corpus/scripts/posthog-app-server.ts stands in for it with an anonymous app context and the checked-in _preflight fixture, answering the API calls the login scene makes. The kea store the page builds is captured through the Redux DevTools compose hook and replayed into the static render; the app server's stand-in API returns 404 for the endpoints it does not model, which the page logs."
+    },
+    {
+      "id": "lobe-chat",
+      "repository": "https://github.com/lobehub/lobe-chat",
+      "revision": "36c4be46f07aa45a10d186871b6fd6265a2ecbf3",
+      "description": "LobeChat SPA shell (Vite + react-router-dom data router, antd-style) served without its Next.js API backend",
+      "framework": "react-router",
+      "workingDirectory": ".",
+      "install": "pnpm install",
+      "dev": "pnpm exec vite --port 9878",
+      "url": "http://localhost:9878/",
+      "readyTimeoutMs": 600000,
+      "settleMs": 10000,
+      "static": {
+        "rootDirectory": ".",
+        "entry": "src/spa/entry.web.tsx",
+        "route": "/",
+        "externalPackageAllowList": [
+          "@lobehub/*",
+          "@lobechat/*",
+          "antd-style",
+          "zustand",
+          "swr",
+          "react-i18next",
+          "i18next"
+        ],
+        "maxFiberCount": 20000
+      }
+    },
+    {
+      "id": "copilotkit",
+      "repository": "https://github.com/CopilotKit/CopilotKit",
+      "revision": "fbe488869949f5b7300945ed54c88ef6b8b16df1",
+      "description": "CopilotKit examples/v2/react/demo (Next 15 app router, CopilotKitProvider + CopilotChat from workspace packages)",
+      "framework": "next-app",
+      "workingDirectory": "examples/v2/react/demo",
+      "install": "pnpm install",
+      "setup": [
+        "cd ../../../.. && NODE_OPTIONS=--max-old-space-size=8192 NX_DAEMON=false pnpm nx run-many -t build --projects=@copilotkit/react-core,@copilotkit/runtime,@copilotkit/voice --parallel=2"
+      ],
+      "dev": "pnpm dev",
+      "url": "http://localhost:3000/",
+      "readyTimeoutMs": 600000,
+      "settleMs": 8000,
+      "static": {
+        "rootDirectory": "examples/v2/react/demo",
+        "route": "/",
+        "externalPackageAllowList": ["@copilotkit/*", "@ag-ui/*", "@radix-ui/*", "lucide-react"]
+      }
+    },
+    {
+      "id": "react-three-next",
+      "repository": "https://github.com/pmndrs/react-three-next",
+      "revision": "bb29a61949601e1c563688faf33a12d062ec3710",
+      "description": "react-three-next starter (Next app router, @react-three/fiber canvas tunnel, dynamic() imports)",
+      "framework": "next-app",
+      "workingDirectory": ".",
+      "install": "npm install",
+      "dev": "npm run dev",
+      "url": "http://localhost:3000/",
+      "settleMs": 8000,
+      "static": {
+        "rootDirectory": ".",
+        "route": "/",
+        "externalPackageAllowList": ["@react-three/*", "its-fine", "tunnel-rat", "three"]
+      }
+    },
+    {
+      "id": "openchakra",
+      "repository": "https://github.com/premieroctet/openchakra",
+      "revision": "5605d412cb7570fb4b261655a88d2abb229352bb",
+      "description": "OpenChakra visual editor (Next pages router, Chakra UI v1, redux + redux-persist, react-dnd)",
+      "framework": "next-pages",
+      "workingDirectory": ".",
+      "install": "yarn install",
+      "dev": "yarn dev",
+      "url": "http://localhost:3000/",
+      "settleMs": 8000,
+      "static": {
+        "rootDirectory": ".",
+        "route": "/",
+        "externalPackageAllowList": [
+          "@chakra-ui/*",
+          "@emotion/*",
+          "next-redux-wrapper",
+          "react-redux",
+          "redux",
+          "redux-undo",
+          "redux-persist",
+          "redux-persist/*",
+          "react-dnd",
+          "react-dnd-html5-backend",
+          "@rematch/*"
+        ]
+      }
+    },
+    {
+      "id": "craft-js",
+      "repository": "https://github.com/prevwong/craft.js",
+      "revision": "23f44f3208ebf78d1632ec4aa7094001f513eb41",
+      "description": "craft.js examples/landing (Next pages router, @craftjs/core Editor/Frame from workspace packages, MUI v4)",
+      "notes": "Cannot serve on Node 22: the Next 12 server bundle of examples/landing imports `@mui/utils/formatMuiErrorMessage` as an ESM directory import (ERR_UNSUPPORTED_DIR_IMPORT), so every page request 500s; `esmExternals: 'loose'` and `false` do not help. Recorded static-only.",
+      "framework": "next-pages",
+      "workingDirectory": "examples/landing",
+      "install": "yarn install && yarn build",
+      "dev": "yarn start",
+      "url": "http://localhost:3001/",
+      "readyTimeoutMs": 600000,
+      "settleMs": 8000,
+      "static": {
+        "rootDirectory": "examples/landing",
+        "route": "/",
+        "externalPackageAllowList": ["@craftjs/*", "@material-ui/*", "styled-components"]
+      }
+    },
+    {
+      "id": "pdfme",
+      "repository": "https://github.com/pdfme/pdfme",
+      "revision": "5a6376a824fb8ab4f989841564b61cbb771100d2",
+      "description": "pdfme playground (Vite + react-router-dom declarative routes, @pdfme/ui Designer embedded via ref)",
+      "framework": "react-router",
+      "workingDirectory": "playground",
+      "install": "npm install && npm run build && cd playground && npm install",
+      "dev": "npm run dev",
+      "url": "http://localhost:5173/",
+      "readyTimeoutMs": 900000,
+      "settleMs": 8000,
+      "static": {
+        "rootDirectory": "playground",
+        "entry": "src/index.tsx",
+        "route": "/",
+        "externalPackageAllowList": [
+          "@pdfme/*",
+          "@headlessui/react",
+          "lucide-react",
+          "react-toastify",
+          "@sentry/react"
+        ]
+      }
+    },
+    {
+      "id": "socialecho",
+      "repository": "https://github.com/nz-m/SocialEcho",
+      "revision": "4dc6c7822bfff5c0b13e1b8098e8d7ae0084939a",
+      "description": "SocialEcho client sign-in page (CRA, react-router-dom v6 declarative routes, react-redux) without its Express backend",
+      "framework": "react-router",
+      "workingDirectory": "client",
+      "install": "cd client && npm install",
+      "dev": "npm start",
+      "env": {
+        "BROWSER": "none",
+        "PORT": "3006"
+      },
+      "url": "http://localhost:3006/signin",
+      "readyTimeoutMs": 600000,
+      "settleMs": 8000,
+      "static": {
+        "rootDirectory": "client",
+        "entry": "src/index.jsx",
+        "route": "/signin",
+        "externalPackageAllowList": ["react-redux", "react-icons", "react-icons/*"]
+      }
+    },
+    {
+      "id": "react-starter-kit",
+      "repository": "https://github.com/kriasoft/react-starter-kit",
+      "revision": "3c5132eb3d0a02dc8090eb6248f8959744e18d12",
+      "description": "React Starter Kit apps/app (Vite SPA, TanStack Router file routes, TanStack Query, shadcn/ui) without its Hono API",
+      "framework": "spa",
+      "workingDirectory": "apps/app",
+      "install": "bun install",
+      "dev": "bun run dev",
+      "url": "http://localhost:5173/",
+      "settleMs": 8000,
+      "static": {
+        "rootDirectory": "apps/app",
+        "entry": "index.tsx",
+        "externalPackageAllowList": [
+          "@tanstack/react-router",
+          "@tanstack/router-core",
+          "@tanstack/history",
+          "@tanstack/react-store",
+          "@tanstack/store",
+          "@tanstack/react-query",
+          "@tanstack/react-query-devtools",
+          "@radix-ui/*",
+          "lucide-react",
+          "better-auth",
+          "better-auth/*"
+        ]
+      }
+    },
+    {
+      "id": "nextjs-starter",
+      "repository": "https://github.com/weijunext/nextjs-starter",
+      "revision": "c33149454f19f74651f73245d63b1cfab187f7d3",
+      "description": "weijunext/nextjs-starter landing page (Next app router, next-themes, next-intl, shadcn/ui)",
+      "framework": "next-app",
+      "workingDirectory": ".",
+      "install": "pnpm install --ignore-workspace",
+      "setup": ["cp -n .env.example .env; true"],
+      "dev": "pnpm dev",
+      "url": "http://localhost:3000/en",
+      "settleMs": 8000,
+      "static": {
+        "rootDirectory": ".",
+        "route": "/en",
+        "externalPackageAllowList": [
+          "next-themes",
+          "next-intl",
+          "next-intl/*",
+          "use-intl",
+          "use-intl/*",
+          "@radix-ui/*",
+          "lucide-react",
+          "react-icons",
+          "react-icons/*"
+        ],
+        "envFiles": [".env"]
+      }
+    },
+    {
+      "id": "foxel",
+      "repository": "https://github.com/DrizzleTime/Foxel",
+      "revision": "d5a24c69e180711e55abeddb4e31ce06e60a456f",
+      "description": "Foxel web client (Vite SPA, react-router v7 declarative routes, antd) without its FastAPI backend",
+      "framework": "react-router",
+      "workingDirectory": "web",
+      "install": "cd web && bun install",
+      "dev": "bun run dev",
+      "url": "http://localhost:5173/",
+      "settleMs": 8000,
+      "static": {
+        "rootDirectory": "web",
+        "entry": "src/main.tsx",
+        "route": "/",
+        "externalPackageAllowList": ["antd", "@ant-design/*"]
+      }
     }
   ]
 }

--- a/packages/parser/corpus/results.json
+++ b/packages/parser/corpus/results.json
@@ -140,6 +140,157 @@
       "failure": null
     },
     {
+      "id": "copilotkit",
+      "revision": "fbe488869949f5b7300945ed54c88ef6b8b16df1",
+      "framework": "next-app",
+      "capturedAt": "2026-09-08T08:10:21.274Z",
+      "durationMs": 1292,
+      "runtime": {
+        "reactVersion": "19.3.0-canary-f93b9fd4-20251217",
+        "rendererName": "react-dom",
+        "buildType": "development",
+        "roots": 2,
+        "fibers": 355,
+        "commits": 128,
+        "pageErrors": [],
+        "title": "Create Next App"
+      },
+      "static": {
+        "stats": {
+          "fiberCount": 942,
+          "textCount": 0,
+          "branchCount": 35,
+          "repeatCount": 7,
+          "opaqueCount": 5,
+          "unknownCount": 18,
+          "modulesLoaded": 1723
+        },
+        "diagnostics": [
+          {
+            "code": "dynamic-key",
+            "count": 8
+          }
+        ]
+      },
+      "report": {
+        "matchedFibers": 162,
+        "matchedText": 0,
+        "opaqueSubtrees": 1,
+        "opaqueSkippedFibers": 2,
+        "slotsMatched": 0,
+        "slotsUnmatched": 0,
+        "opaqueRenamed": 0,
+        "unmatchedSlots": [],
+        "wildcardAbsorbedFibers": 15,
+        "wildcards": [
+          {
+            "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent] > <div> [HostComponent] > <Chat> [FunctionComponent] > <div> [HostComponent] > <div> [HostComponent] > <CopilotChat> key=\"stateless\" [FunctionComponent] > <CopilotChatConfigurationProvider> [FunctionComponent] > <div> [HostComponent] > <MemoizedSlotWrapper> [MemoComponent] > <MemoizedSlotWrapper> [ForwardRef] > <CopilotChatView> [FunctionComponent] > <div> [HostComponent] > <MemoizedSlotWrapper> [MemoComponent] > <MemoizedSlotWrapper> [ForwardRef] > <FunctionComponent> [FunctionComponent] > <div> [HostComponent] > <div> [HostComponent] > <div> [HostComponent] > <MemoizedSlotWrapper> [MemoComponent] > <MemoizedSlotWrapper> [ForwardRef] > <CopilotChatSuggestionView> [ForwardRef] > <MemoizedSlotWrapper> [MemoComponent] > <MemoizedSlotWrapper> [ForwardRef] > <DefaultContainer> [ForwardRef] > <div> [HostComponent]",
+            "reason": "call of call of Object.values of {...}",
+            "absorbedFibers": 15,
+            "heads": [
+              "<MemoizedSlotWrapper> key=\"Generate a simple UI-0\" [MemoComponent]",
+              "<MemoizedSlotWrapper> key=\"Build an interactive form-1\" [MemoComponent]",
+              "<MemoizedSlotWrapper> key=\"Test the sayHello tool-2\" [MemoComponent]"
+            ]
+          }
+        ],
+        "branchesResolved": 12,
+        "branchDeviations": [
+          {
+            "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent] > <CopilotKitInspector> [FunctionComponent]",
+            "reason": "if (<boolean: negation of unknown>)",
+            "preferredIndex": 0,
+            "chosenIndex": 1,
+            "divergence": {
+              "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent] > <CopilotKitInspector> [FunctionComponent][0]",
+              "expected": "<end of children>",
+              "actual": "<WebInspectorElement> [ForwardRef]"
+            }
+          },
+          {
+            "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent]",
+            "reason": "&& on branch(true | false)",
+            "preferredIndex": 0,
+            "chosenIndex": 1,
+            "divergence": {
+              "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent][4]",
+              "expected": "<LicenseWarningBanner> [FunctionComponent]",
+              "actual": "<end of children>"
+            }
+          },
+          {
+            "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent]",
+            "reason": "&& on <boolean: === on dynamic values>",
+            "preferredIndex": 0,
+            "chosenIndex": 1,
+            "divergence": {
+              "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent][4]",
+              "expected": "<LicenseWarningBanner> [FunctionComponent]",
+              "actual": "<end of children>"
+            }
+          },
+          {
+            "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent]",
+            "reason": "&& on <boolean: === on dynamic values>",
+            "preferredIndex": 0,
+            "chosenIndex": 1,
+            "divergence": {
+              "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent][4]",
+              "expected": "<LicenseWarningBanner> [FunctionComponent]",
+              "actual": "<end of children>"
+            }
+          },
+          {
+            "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent]",
+            "reason": "&& on <boolean: === on dynamic values>",
+            "preferredIndex": 0,
+            "chosenIndex": 1,
+            "divergence": {
+              "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent][4]",
+              "expected": "<LicenseWarningBanner> [FunctionComponent]",
+              "actual": "<end of children>"
+            }
+          }
+        ],
+        "repeatIterations": 0,
+        "status": "partial",
+        "runtimeFibers": 179,
+        "staticFibers": 264,
+        "coverage": 1,
+        "strictCoverage": 0.9050279329608939,
+        "divergence": null,
+        "stepsUsed": 735,
+        "budgetExhausted": false
+      },
+      "anchor": "body",
+      "note": "runtime replayed from 2026-09-08T08:02:55.873Z",
+      "failure": null
+    },
+    {
+      "id": "craft-js",
+      "revision": "23f44f3208ebf78d1632ec4aa7094001f513eb41",
+      "framework": "next-pages",
+      "capturedAt": "2026-09-08T08:11:27.601Z",
+      "durationMs": 1047,
+      "runtime": null,
+      "static": {
+        "stats": {
+          "fiberCount": 111,
+          "textCount": 1,
+          "branchCount": 4,
+          "repeatCount": 0,
+          "opaqueCount": 6,
+          "unknownCount": 9,
+          "modulesLoaded": 35
+        },
+        "diagnostics": []
+      },
+      "report": null,
+      "anchor": null,
+      "note": "static only",
+      "failure": null
+    },
+    {
       "id": "documenso",
       "revision": "2cac63a000e22422bdea449f68b8025e709aa73a",
       "framework": "react-router",
@@ -271,6 +422,83 @@
       "report": null,
       "anchor": null,
       "note": "static only",
+      "failure": null
+    },
+    {
+      "id": "foxel",
+      "revision": "d5a24c69e180711e55abeddb4e31ce06e60a456f",
+      "framework": "react-router",
+      "capturedAt": "2026-09-08T08:12:02.275Z",
+      "durationMs": 8619,
+      "runtime": {
+        "reactVersion": "19.2.4",
+        "rendererName": "react-dom",
+        "buildType": "development",
+        "roots": 1,
+        "fibers": 18,
+        "commits": 1,
+        "pageErrors": [
+          "Failed to load resource: net::ERR_CONNECTION_REFUSED",
+          "Failed to load resource: net::ERR_CONNECTION_REFUSED",
+          "Failed to check initialization status: TypeError: Failed to fetch\n    at request (http://localhost:5173/src/api/client.ts:25:22)\n    at status (http://localhost:5173/src/api/config.ts:18:10)\n    at checkInitialization (http://localhost:5173/src/App.tsx:62:34)\n    at http://localhost:5173/src/App.tsx:78:5\n    at Object.react_stack_bottom_frame (http://localhost:5173/node_modules/.vite/deps/chunk-UTQ67KV7.js?v=7db57128:18567:20)\n    at runWithFiberInDEV (http://localhost:5173/node_modules/.vite/deps/chunk-UTQ67KV7.js?v=7db57128:997:72)\n    at commitHookEffectListMount (http://localhost:5173/node_modules/.vite/deps/chunk-UTQ67KV7.js?v=7db57128:9411:163)\n    at commitHookPassiveMountEffects (http://localhost:5173/node_modules/.vite/deps/chunk-UTQ67KV7.js?v=7db57128:9465:60)\n    at commitPassiveMountOnFiber (http://localhost:5173/node_modules/.vite/deps/chunk-UTQ67KV7.js?v=7db57128:11040:29)\n    at recursivelyTraversePassiveMountEffects (http://localhost:5173/node_modules/.vite/deps/chunk-UTQ67KV7.js?v=7db57128:11010:13)"
+        ],
+        "title": "Foxel"
+      },
+      "static": {
+        "stats": {
+          "fiberCount": 12,
+          "textCount": 0,
+          "branchCount": 1,
+          "repeatCount": 0,
+          "opaqueCount": 0,
+          "unknownCount": 2,
+          "modulesLoaded": 2512
+        },
+        "diagnostics": [
+          {
+            "code": "budget-exhausted",
+            "count": 23
+          },
+          {
+            "code": "max-call-depth",
+            "count": 3
+          }
+        ]
+      },
+      "report": {
+        "matchedFibers": 4,
+        "matchedText": 0,
+        "opaqueSubtrees": 0,
+        "opaqueSkippedFibers": 0,
+        "slotsMatched": 0,
+        "slotsUnmatched": 0,
+        "opaqueRenamed": 0,
+        "unmatchedSlots": [],
+        "wildcardAbsorbedFibers": 10,
+        "wildcards": [
+          {
+            "path": "root > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Spin> [FunctionComponent]",
+            "reason": "step budget exhausted",
+            "absorbedFibers": 10,
+            "heads": [
+              "<div> [HostComponent]"
+            ]
+          }
+        ],
+        "branchesResolved": 1,
+        "branchDeviations": [],
+        "repeatIterations": 0,
+        "status": "partial",
+        "runtimeFibers": 14,
+        "staticFibers": 4,
+        "coverage": 1,
+        "strictCoverage": 0.2857142857142857,
+        "divergence": null,
+        "stepsUsed": 7,
+        "budgetExhausted": false
+      },
+      "anchor": null,
+      "note": "runtime replayed from 2026-09-08T07:24:29.116Z",
       "failure": null
     },
     {
@@ -422,6 +650,88 @@
       "failure": null
     },
     {
+      "id": "lobe-chat",
+      "revision": "36c4be46f07aa45a10d186871b6fd6265a2ecbf3",
+      "framework": "react-router",
+      "capturedAt": "2026-09-08T08:12:12.356Z",
+      "durationMs": 8338,
+      "runtime": {
+        "reactVersion": "19.2.8",
+        "rendererName": "react-dom",
+        "buildType": "development",
+        "roots": 1,
+        "fibers": 357,
+        "commits": 15,
+        "pageErrors": [
+          "Failed to load resource: the server responded with a status of 502 (Bad Gateway)",
+          "Failed to load resource: the server responded with a status of 502 (Bad Gateway)",
+          "TRPCClientError: Failed to execute 'json' on 'Response': Unexpected end of JSON input\n    at TRPCClientError.from (http://localhost:9878/node_modules/.vite/deps/dist-CoR6I6sU.js?v=319fa08a:1100:10)\n    at http://localhost:9878/node_modules/.vite/deps/dist-CoR6I6sU.js?v=319fa08a:1312:37",
+          "%o\n\n%s\n\n%s\n SyntaxError: The requested module '/node_modules/.vite/deps/@lobehub_editor_react.js?v=319fa08a' does not provide an export named 'FloatMenu' The above error occurred in one of your React components. React will try to recreate this component tree from scratch using the error boundary you provided, RenderErrorBoundary.",
+          "React Router caught the following error during render SyntaxError: The requested module '/node_modules/.vite/deps/@lobehub_editor_react.js?v=319fa08a' does not provide an export named 'FloatMenu'",
+          "Failed to load resource: the server responded with a status of 502 (Bad Gateway)",
+          "TRPCClientError: Failed to execute 'json' on 'Response': Unexpected end of JSON input\n    at TRPCClientError.from (http://localhost:9878/node_modules/.vite/deps/dist-CoR6I6sU.js?v=319fa08a:1100:10)\n    at http://localhost:9878/node_modules/.vite/deps/dist-CoR6I6sU.js?v=319fa08a:1312:37",
+          "Failed to load resource: the server responded with a status of 502 (Bad Gateway)",
+          "TRPCClientError: Failed to execute 'json' on 'Response': Unexpected end of JSON input\n    at TRPCClientError.from (http://localhost:9878/node_modules/.vite/deps/dist-CoR6I6sU.js?v=319fa08a:1100:10)\n    at http://localhost:9878/node_modules/.vite/deps/dist-CoR6I6sU.js?v=319fa08a:1312:37"
+        ],
+        "title": ""
+      },
+      "static": {
+        "stats": {
+          "fiberCount": 0,
+          "textCount": 0,
+          "branchCount": 0,
+          "repeatCount": 0,
+          "opaqueCount": 0,
+          "unknownCount": 0,
+          "modulesLoaded": 8754
+        },
+        "diagnostics": [
+          {
+            "code": "dynamic-key",
+            "count": 11
+          },
+          {
+            "code": "max-recursion",
+            "count": 4
+          },
+          {
+            "code": "dynamic-props",
+            "count": 1
+          },
+          {
+            "code": "render-error",
+            "count": 1
+          }
+        ]
+      },
+      "report": {
+        "status": "unresolved",
+        "matchedFibers": 0,
+        "matchedText": 0,
+        "opaqueSubtrees": 0,
+        "opaqueSkippedFibers": 0,
+        "slotsMatched": 0,
+        "slotsUnmatched": 0,
+        "opaqueRenamed": 0,
+        "unmatchedSlots": [],
+        "branchDeviations": [],
+        "wildcardAbsorbedFibers": 0,
+        "wildcards": [],
+        "branchesResolved": 0,
+        "repeatIterations": 0,
+        "runtimeFibers": 0,
+        "staticFibers": 0,
+        "coverage": 0,
+        "strictCoverage": 0,
+        "divergence": null,
+        "stepsUsed": 0,
+        "budgetExhausted": false
+      },
+      "anchor": null,
+      "note": "React failed to render the materialized tree; runtime replayed from 2026-09-08T07:20:29.476Z",
+      "failure": null
+    },
+    {
       "id": "nextjs-boilerplate",
       "revision": "1dffa39a32450300c8b01d8cfd3819f9b6e95842",
       "framework": "next-app",
@@ -503,6 +813,266 @@
       },
       "anchor": "body",
       "note": "runtime replayed from 2026-09-06T04:55:26.311Z",
+      "failure": null
+    },
+    {
+      "id": "nextjs-starter",
+      "revision": "c33149454f19f74651f73245d63b1cfab187f7d3",
+      "framework": "next-app",
+      "capturedAt": "2026-09-08T08:12:00.420Z",
+      "durationMs": 526,
+      "runtime": {
+        "reactVersion": "19.3.0-canary-f93b9fd4-20251217",
+        "rendererName": "react-dom",
+        "buildType": "production",
+        "roots": 2,
+        "fibers": 928,
+        "commits": 16,
+        "pageErrors": [],
+        "title": "Next.js Starter - Multilingual Next.js 16 Starter"
+      },
+      "static": {
+        "stats": {
+          "fiberCount": 2,
+          "textCount": 0,
+          "branchCount": 0,
+          "repeatCount": 0,
+          "opaqueCount": 0,
+          "unknownCount": 1,
+          "modulesLoaded": 1644
+        },
+        "diagnostics": []
+      },
+      "report": {
+        "status": "unresolved",
+        "matchedFibers": 0,
+        "matchedText": 0,
+        "opaqueSubtrees": 0,
+        "opaqueSkippedFibers": 0,
+        "slotsMatched": 0,
+        "slotsUnmatched": 0,
+        "opaqueRenamed": 0,
+        "unmatchedSlots": [],
+        "branchDeviations": [],
+        "wildcardAbsorbedFibers": 0,
+        "wildcards": [],
+        "branchesResolved": 0,
+        "repeatIterations": 0,
+        "runtimeFibers": 0,
+        "staticFibers": 0,
+        "coverage": 0,
+        "strictCoverage": 0,
+        "divergence": null,
+        "stepsUsed": 0,
+        "budgetExhausted": false
+      },
+      "anchor": null,
+      "note": "static render did not resolve to a component tree; runtime replayed from 2026-09-08T07:50:14.781Z",
+      "failure": null
+    },
+    {
+      "id": "openchakra",
+      "revision": "5605d412cb7570fb4b261655a88d2abb229352bb",
+      "framework": "next-pages",
+      "capturedAt": "2026-09-08T08:11:19.594Z",
+      "durationMs": 6594,
+      "runtime": {
+        "reactVersion": "18.2.0",
+        "rendererName": "react-dom",
+        "buildType": "development",
+        "roots": 1,
+        "fibers": 2010,
+        "commits": 13,
+        "pageErrors": [
+          "Warning: React does not recognize the `%s` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `%s` instead. If you accidentally passed it from a parent component, remove it from the DOM element.%s isExternal isexternal \n    at a\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at eval (webpack-internal:///./node_modules/@chakra-ui/menu/dist/index.esm.js:746:11)\n    at eval (webpack-internal:///./node_modules/@chakra-ui/menu/dist/index.esm.js:800:5)\n    at MenuItemLink\n    at div\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at VisualElementHandler (webpack-internal:///./node_modules/framer-motion/dist/es/motion/utils/VisualElementHandler.mjs:8:1)\n    at MotionComponent (webpack-internal:///./node_modules/framer-motion/dist/es/motion/index.mjs:48:65)\n    at div\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at eval (webpack-internal:///./node_modules/@chakra-ui/menu/dist/index.esm.js:859:11)\n    at LightMode (webpack-internal:///./node_modules/@chakra-ui/color-mode/dist/index.esm.js:227:65)\n    at DefaultPortal (webpack-internal:///./node_modules/@chakra-ui/portal/dist/index.esm.js:52:11)\n    at Portal (webpack-internal:///./node_modules/@chakra-ui/portal/dist/index.esm.js:117:11)\n    at Menu (webpack-internal:///./node_modules/@chakra-ui/menu/dist/index.esm.js:626:11)\n    at HeaderMenu\n    at div\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at div\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at eval (webpack-internal:///./node_modules/@chakra-ui/layout/dist/index.esm.js:714:5)\n    at HStack\n    at div\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at Flex2 (webpack-internal:///./node_modules/@chakra-ui/layout/dist/index.esm.js:273:11)\n    at header\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at Flex2 (webpack-internal:///./node_modules/@chakra-ui/layout/dist/index.esm.js:273:11)\n    at DarkMode (webpack-internal:///./node_modules/@chakra-ui/color-mode/dist/index.esm.js:215:65)\n    at Header (webpack-internal:///./src/components/Header.tsx:216:78)\n    at App (webpack-internal:///./src/pages/index.tsx:36:68)\n    at AppErrorBoundary (webpack-internal:///./src/components/errorBoundaries/AppErrorBoundary.tsx:36:90)\n    at EnvironmentProvider (webpack-internal:///./node_modules/@chakra-ui/react-env/dist/index.esm.js:121:11)\n    at ColorModeProvider (webpack-internal:///./node_modules/@chakra-ui/color-mode/dist/index.esm.js:158:5)\n    at ThemeProvider (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:96:64)\n    at ThemeProvider (webpack-internal:///./node_modules/@chakra-ui/system/dist/index.esm.js:112:11)\n    at ChakraProvider (webpack-internal:///./node_modules/@chakra-ui/provider/dist/index.esm.js:21:5)\n    at ChakraProvider (webpack-internal:///./node_modules/@chakra-ui/react/dist/index.esm.js:245:3)\n    at ErrorBoundary (webpack-internal:///./node_modules/@bugsnag/plugin-react/dist/bugsnag-react.js:22:34)\n    at Main (webpack-internal:///./src/pages/_app.tsx:28:27)\n    at Provider (webpack-internal:///./node_modules/react-redux/es/components/Provider.js:16:20)\n    at Wrapper (webpack-internal:///./node_modules/next-redux-wrapper/es6/index.js:184:35)\n    at ErrorBoundary (webpack-internal:///./node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:20740)\n    at ReactDevOverlay (webpack-internal:///./node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:23632)\n    at Container (webpack-internal:///./node_modules/next/dist/client/index.js:71:9)\n    at AppContainer (webpack-internal:///./node_modules/next/dist/client/index.js:592:26)\n    at Root (webpack-internal:///./node_modules/next/dist/client/index.js:703:27)",
+          "Warning: Expected server HTML to contain a matching <%s> in <%s>.%s span div \n    at span\n    at DefaultPortal (webpack-internal:///./node_modules/@chakra-ui/portal/dist/index.esm.js:52:11)\n    at Portal (webpack-internal:///./node_modules/@chakra-ui/portal/dist/index.esm.js:117:11)\n    at Menu (webpack-internal:///./node_modules/@chakra-ui/menu/dist/index.esm.js:626:11)\n    at HeaderMenu\n    at div\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at div\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at eval (webpack-internal:///./node_modules/@chakra-ui/layout/dist/index.esm.js:714:5)\n    at HStack\n    at div\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at Flex2 (webpack-internal:///./node_modules/@chakra-ui/layout/dist/index.esm.js:273:11)\n    at header\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at Flex2 (webpack-internal:///./node_modules/@chakra-ui/layout/dist/index.esm.js:273:11)\n    at DarkMode (webpack-internal:///./node_modules/@chakra-ui/color-mode/dist/index.esm.js:215:65)\n    at Header (webpack-internal:///./src/components/Header.tsx:216:78)\n    at App (webpack-internal:///./src/pages/index.tsx:36:68)\n    at AppErrorBoundary (webpack-internal:///./src/components/errorBoundaries/AppErrorBoundary.tsx:36:90)\n    at EnvironmentProvider (webpack-internal:///./node_modules/@chakra-ui/react-env/dist/index.esm.js:121:11)\n    at ColorModeProvider (webpack-internal:///./node_modules/@chakra-ui/color-mode/dist/index.esm.js:158:5)\n    at ThemeProvider (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:96:64)\n    at ThemeProvider (webpack-internal:///./node_modules/@chakra-ui/system/dist/index.esm.js:112:11)\n    at ChakraProvider (webpack-internal:///./node_modules/@chakra-ui/provider/dist/index.esm.js:21:5)\n    at ChakraProvider (webpack-internal:///./node_modules/@chakra-ui/react/dist/index.esm.js:245:3)\n    at ErrorBoundary (webpack-internal:///./node_modules/@bugsnag/plugin-react/dist/bugsnag-react.js:22:34)\n    at Main (webpack-internal:///./src/pages/_app.tsx:28:27)\n    at Provider (webpack-internal:///./node_modules/react-redux/es/components/Provider.js:16:20)\n    at Wrapper (webpack-internal:///./node_modules/next-redux-wrapper/es6/index.js:184:35)\n    at ErrorBoundary (webpack-internal:///./node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:20740)\n    at ReactDevOverlay (webpack-internal:///./node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:23632)\n    at Container (webpack-internal:///./node_modules/next/dist/client/index.js:71:9)\n    at AppContainer (webpack-internal:///./node_modules/next/dist/client/index.js:592:26)\n    at Root (webpack-internal:///./node_modules/next/dist/client/index.js:703:27)",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Warning: An error occurred during hydration. The server HTML was replaced with client content in <%s>. div \n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+          "Warning: React does not recognize the `%s` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `%s` instead. If you accidentally passed it from a parent component, remove it from the DOM element.%s isExternal isexternal \n    at a\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at eval (webpack-internal:///./node_modules/@chakra-ui/menu/dist/index.esm.js:746:11)\n    at eval (webpack-internal:///./node_modules/@chakra-ui/menu/dist/index.esm.js:800:5)\n    at MenuItemLink\n    at div\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at VisualElementHandler (webpack-internal:///./node_modules/framer-motion/dist/es/motion/utils/VisualElementHandler.mjs:8:1)\n    at MotionComponent (webpack-internal:///./node_modules/framer-motion/dist/es/motion/index.mjs:48:65)\n    at div\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at eval (webpack-internal:///./node_modules/@chakra-ui/menu/dist/index.esm.js:859:11)\n    at LightMode (webpack-internal:///./node_modules/@chakra-ui/color-mode/dist/index.esm.js:227:65)\n    at DefaultPortal (webpack-internal:///./node_modules/@chakra-ui/portal/dist/index.esm.js:52:11)\n    at Portal (webpack-internal:///./node_modules/@chakra-ui/portal/dist/index.esm.js:117:11)\n    at Menu (webpack-internal:///./node_modules/@chakra-ui/menu/dist/index.esm.js:626:11)\n    at HeaderMenu\n    at div\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at div\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at eval (webpack-internal:///./node_modules/@chakra-ui/layout/dist/index.esm.js:714:5)\n    at HStack\n    at div\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at Flex2 (webpack-internal:///./node_modules/@chakra-ui/layout/dist/index.esm.js:273:11)\n    at header\n    at eval (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66)\n    at Flex2 (webpack-internal:///./node_modules/@chakra-ui/layout/dist/index.esm.js:273:11)\n    at DarkMode (webpack-internal:///./node_modules/@chakra-ui/color-mode/dist/index.esm.js:215:65)\n    at Header (webpack-internal:///./src/components/Header.tsx:216:78)\n    at App (webpack-internal:///./src/pages/index.tsx:36:68)\n    at AppErrorBoundary (webpack-internal:///./src/components/errorBoundaries/AppErrorBoundary.tsx:36:90)\n    at EnvironmentProvider (webpack-internal:///./node_modules/@chakra-ui/react-env/dist/index.esm.js:121:11)\n    at ColorModeProvider (webpack-internal:///./node_modules/@chakra-ui/color-mode/dist/index.esm.js:158:5)\n    at ThemeProvider (webpack-internal:///./node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:96:64)\n    at ThemeProvider (webpack-internal:///./node_modules/@chakra-ui/system/dist/index.esm.js:112:11)\n    at ChakraProvider (webpack-internal:///./node_modules/@chakra-ui/provider/dist/index.esm.js:21:5)\n    at ChakraProvider (webpack-internal:///./node_modules/@chakra-ui/react/dist/index.esm.js:245:3)\n    at ErrorBoundary (webpack-internal:///./node_modules/@bugsnag/plugin-react/dist/bugsnag-react.js:22:34)\n    at Main (webpack-internal:///./src/pages/_app.tsx:28:27)\n    at Provider (webpack-internal:///./node_modules/react-redux/es/components/Provider.js:16:20)\n    at Wrapper (webpack-internal:///./node_modules/next-redux-wrapper/es6/index.js:184:35)\n    at ErrorBoundary (webpack-internal:///./node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:20740)\n    at ReactDevOverlay (webpack-internal:///./node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:23632)\n    at Container (webpack-internal:///./node_modules/next/dist/client/index.js:71:9)\n    at AppContainer (webpack-internal:///./node_modules/next/dist/client/index.js:592:26)\n    at Root (webpack-internal:///./node_modules/next/dist/client/index.js:703:27)"
+        ],
+        "title": "OpenChakra"
+      },
+      "static": {
+        "stats": {
+          "fiberCount": 3,
+          "textCount": 0,
+          "branchCount": 0,
+          "repeatCount": 0,
+          "opaqueCount": 0,
+          "unknownCount": 1,
+          "modulesLoaded": 334
+        },
+        "diagnostics": [
+          {
+            "code": "budget-exhausted",
+            "count": 32
+          },
+          {
+            "code": "dynamic-props",
+            "count": 2
+          },
+          {
+            "code": "dynamic-key",
+            "count": 1
+          }
+        ]
+      },
+      "report": {
+        "matchedFibers": 1,
+        "matchedText": 0,
+        "opaqueSubtrees": 0,
+        "opaqueSkippedFibers": 0,
+        "slotsMatched": 0,
+        "slotsUnmatched": 0,
+        "opaqueRenamed": 0,
+        "unmatchedSlots": [],
+        "wildcardAbsorbedFibers": 1960,
+        "wildcards": [
+          {
+            "path": "root > <withRedux(Main)> [FunctionComponent]",
+            "reason": "step budget exhausted",
+            "absorbedFibers": 1960,
+            "heads": [
+              "<Provider> [FunctionComponent]"
+            ]
+          }
+        ],
+        "branchesResolved": 0,
+        "branchDeviations": [],
+        "repeatIterations": 0,
+        "status": "partial",
+        "runtimeFibers": 1961,
+        "staticFibers": 1,
+        "coverage": 1,
+        "strictCoverage": 0.0005099439061703213,
+        "divergence": null,
+        "stepsUsed": 2,
+        "budgetExhausted": false
+      },
+      "anchor": null,
+      "note": "runtime replayed from 2026-09-08T07:23:05.031Z",
+      "failure": null
+    },
+    {
+      "id": "pdfme",
+      "revision": "5a6376a824fb8ab4f989841564b61cbb771100d2",
+      "framework": "react-router",
+      "capturedAt": "2026-09-08T08:11:29.992Z",
+      "durationMs": 5618,
+      "runtime": {
+        "reactVersion": "18.3.1",
+        "rendererName": "react-dom",
+        "buildType": "development",
+        "roots": 1,
+        "fibers": 1460,
+        "commits": 6,
+        "pageErrors": [
+          "Failed to load resource: the server responded with a status of 403 ()",
+          "Failed to load resource: the server responded with a status of 403 ()",
+          "Failed to load resource: the server responded with a status of 403 ()",
+          "Failed to load resource: the server responded with a status of 403 ()",
+          "Failed to load resource: the server responded with a status of 403 ()",
+          "Failed to load resource: the server responded with a status of 403 ()",
+          "Failed to load resource: the server responded with a status of 403 ()",
+          "Failed to load resource: the server responded with a status of 403 ()",
+          "Failed to load resource: net::ERR_BLOCKED_BY_RESPONSE.NotSameOrigin"
+        ],
+        "title": "pdfme Playground"
+      },
+      "static": {
+        "stats": {
+          "fiberCount": 134,
+          "textCount": 7,
+          "branchCount": 3,
+          "repeatCount": 1,
+          "opaqueCount": 0,
+          "unknownCount": 2,
+          "modulesLoaded": 1721
+        },
+        "diagnostics": [
+          {
+            "code": "dynamic-key",
+            "count": 1
+          }
+        ]
+      },
+      "report": {
+        "matchedFibers": 170,
+        "matchedText": 7,
+        "opaqueSubtrees": 0,
+        "opaqueSkippedFibers": 0,
+        "slotsMatched": 0,
+        "slotsUnmatched": 0,
+        "opaqueRenamed": 0,
+        "unmatchedSlots": [],
+        "wildcardAbsorbedFibers": 1279,
+        "wildcards": [
+          {
+            "path": "root > <StrictMode> [Mode] > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Suspense> [SuspenseComponent] > <Offscreen> [OffscreenComponent] > <Routes> [FunctionComponent] > <RenderedRoute> [FunctionComponent] > <Route> [ContextProvider] > <TemplatesApp> [FunctionComponent] > <div> [HostComponent] > <div> [HostComponent] > <section> [HostComponent] > <div> [HostComponent]",
+            "reason": "call of call of updated state of useState",
+            "absorbedFibers": 1279,
+            "heads": [
+              "<Fragment> [Fragment]"
+            ]
+          }
+        ],
+        "branchesResolved": 3,
+        "branchDeviations": [
+          {
+            "path": "root > <StrictMode> [Mode] > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Navigation> [FunctionComponent] > <div> [HostComponent] > <nav> [HostComponent] > <HelpModal> [FunctionComponent] > <$e> [ForwardRef] > <j> [FunctionComponent] > <ContextProvider> [ContextProvider]",
+            "reason": "&& on branch(true | <boolean>)",
+            "preferredIndex": 0,
+            "chosenIndex": 1,
+            "divergence": {
+              "path": "root > <StrictMode> [Mode] > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Navigation> [FunctionComponent] > <div> [HostComponent] > <nav> [HostComponent] > <HelpModal> [FunctionComponent] > <$e> [ForwardRef] > <j> [FunctionComponent] > <ContextProvider> [ContextProvider][1]",
+              "expected": "<l> [ForwardRef]",
+              "actual": "<end of children>"
+            }
+          },
+          {
+            "path": "root > <StrictMode> [Mode] > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Suspense> [SuspenseComponent] > <Offscreen> [OffscreenComponent] > <Routes> [FunctionComponent] > <RenderedRoute> [FunctionComponent] > <Route> [ContextProvider] > <TemplatesApp> [FunctionComponent] > <div> [HostComponent] > <div> [HostComponent] > <section> [HostComponent] > <div> [HostComponent]",
+            "reason": "callback for an item that may not occur",
+            "preferredIndex": 0,
+            "chosenIndex": 1,
+            "divergence": {
+              "path": "root > <StrictMode> [Mode] > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Suspense> [SuspenseComponent] > <Offscreen> [OffscreenComponent] > <Routes> [FunctionComponent] > <RenderedRoute> [FunctionComponent] > <Route> [ContextProvider] > <TemplatesApp> [FunctionComponent] > <div> [HostComponent] > <div> [HostComponent] > <section> [HostComponent] > <div> [HostComponent] > <Fragment> [Fragment][0]",
+              "expected": "<end of children>",
+              "actual": "<Fragment> key=\"invoice\" [Fragment]"
+            }
+          },
+          {
+            "path": "root > <StrictMode> [Mode] > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Suspense> [SuspenseComponent] > <Offscreen> [OffscreenComponent] > <Routes> [FunctionComponent] > <RenderedRoute> [FunctionComponent] > <Route> [ContextProvider] > <TemplatesApp> [FunctionComponent] > <div> [HostComponent] > <div> [HostComponent] > <section> [HostComponent] > <div> [HostComponent]",
+            "reason": "&& on branch(true | <boolean>)",
+            "preferredIndex": 0,
+            "chosenIndex": 1,
+            "divergence": {
+              "path": "root > <StrictMode> [Mode] > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Suspense> [SuspenseComponent] > <Offscreen> [OffscreenComponent] > <Routes> [FunctionComponent] > <RenderedRoute> [FunctionComponent] > <Route> [ContextProvider] > <TemplatesApp> [FunctionComponent] > <div> [HostComponent] > <div> [HostComponent] > <section> [HostComponent] > <div> [HostComponent][1]",
+              "expected": "<div> [HostComponent]",
+              "actual": "<end of children>"
+            }
+          }
+        ],
+        "repeatIterations": 32,
+        "status": "partial",
+        "runtimeFibers": 1456,
+        "staticFibers": 119,
+        "coverage": 1,
+        "strictCoverage": 0.12156593406593406,
+        "divergence": null,
+        "stepsUsed": 220,
+        "budgetExhausted": false
+      },
+      "anchor": null,
+      "note": "runtime replayed from 2026-09-08T07:35:03.692Z",
       "failure": null
     },
     {
@@ -770,6 +1340,146 @@
       "failure": null
     },
     {
+      "id": "react-starter-kit",
+      "revision": "3c5132eb3d0a02dc8090eb6248f8959744e18d12",
+      "framework": "spa",
+      "capturedAt": "2026-09-08T08:11:39.327Z",
+      "durationMs": 19783,
+      "runtime": {
+        "reactVersion": "19.2.4",
+        "rendererName": "react-dom",
+        "buildType": "development",
+        "roots": 1,
+        "fibers": 41,
+        "commits": 4,
+        "pageErrors": [
+          "Failed to load resource: the server responded with a status of 500 (Internal Server Error)",
+          "Failed to load resource: the server responded with a status of 500 (Internal Server Error)",
+          "Failed to load resource: the server responded with a status of 500 (Internal Server Error)",
+          "Failed to load resource: the server responded with a status of 500 (Internal Server Error)",
+          "%o\n\n%s\n\n%s\n {status: 500, statusText: Internal Server Error, routerCode: BEFORE_LOAD} The above error occurred in the <MatchInnerImpl> component. React will try to recreate this component tree from scratch using the error boundary you provided, m.",
+          "Uncaught error: {status: 500, statusText: Internal Server Error, routerCode: BEFORE_LOAD}"
+        ],
+        "title": "Acme Co."
+      },
+      "static": {
+        "stats": {
+          "fiberCount": 23,
+          "textCount": 0,
+          "branchCount": 1,
+          "repeatCount": 0,
+          "opaqueCount": 0,
+          "unknownCount": 2,
+          "modulesLoaded": 1866
+        },
+        "diagnostics": [
+          {
+            "code": "budget-exhausted",
+            "count": 36
+          }
+        ]
+      },
+      "report": {
+        "matchedFibers": 7,
+        "matchedText": 0,
+        "opaqueSubtrees": 0,
+        "opaqueSkippedFibers": 0,
+        "slotsMatched": 0,
+        "slotsUnmatched": 0,
+        "opaqueRenamed": 0,
+        "unmatchedSlots": [],
+        "wildcardAbsorbedFibers": 33,
+        "wildcards": [
+          {
+            "path": "root > <StrictMode> [Mode] > <QueryClientProvider> [FunctionComponent] > <ContextProvider> [ContextProvider] > <RouterProvider> [FunctionComponent] > <RouterContextProvider> [FunctionComponent]",
+            "reason": "<provider>: window.__TSR_ROUTER_CONTEXT__",
+            "absorbedFibers": 33,
+            "heads": [
+              "<ContextProvider> [ContextProvider]"
+            ]
+          }
+        ],
+        "branchesResolved": 1,
+        "branchDeviations": [],
+        "repeatIterations": 0,
+        "status": "partial",
+        "runtimeFibers": 40,
+        "staticFibers": 16,
+        "coverage": 1,
+        "strictCoverage": 0.175,
+        "divergence": null,
+        "stepsUsed": 19,
+        "budgetExhausted": false
+      },
+      "anchor": null,
+      "note": "runtime replayed from 2026-09-08T07:23:55.274Z",
+      "failure": null
+    },
+    {
+      "id": "react-three-next",
+      "revision": "bb29a61949601e1c563688faf33a12d062ec3710",
+      "framework": "next-app",
+      "capturedAt": "2026-09-08T08:11:17.176Z",
+      "durationMs": 977,
+      "runtime": {
+        "reactVersion": "18.3.0-canary-178c267a4e-20241218",
+        "rendererName": "@react-three/fiber",
+        "buildType": "development",
+        "roots": 2,
+        "fibers": 249,
+        "commits": 19,
+        "pageErrors": [
+          "Hydration failed because the initial UI does not match what was rendered on the server.\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Warning: An error occurred during hydration. The server HTML was replaced with client content in <%s>. #document",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "Hydration failed because the initial UI does not match what was rendered on the server.\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error",
+          "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error"
+        ],
+        "title": "Next.js + Three.js"
+      },
+      "static": {
+        "stats": {
+          "fiberCount": 62,
+          "textCount": 0,
+          "branchCount": 0,
+          "repeatCount": 0,
+          "opaqueCount": 0,
+          "unknownCount": 0,
+          "modulesLoaded": 171
+        },
+        "diagnostics": []
+      },
+      "report": {
+        "matchedFibers": 54,
+        "matchedText": 0,
+        "opaqueSubtrees": 0,
+        "opaqueSkippedFibers": 0,
+        "slotsMatched": 0,
+        "slotsUnmatched": 0,
+        "opaqueRenamed": 0,
+        "unmatchedSlots": [],
+        "wildcardAbsorbedFibers": 0,
+        "wildcards": [],
+        "branchesResolved": 0,
+        "branchDeviations": [],
+        "repeatIterations": 0,
+        "status": "exact",
+        "runtimeFibers": 54,
+        "staticFibers": 54,
+        "coverage": 1,
+        "strictCoverage": 1,
+        "divergence": null,
+        "stepsUsed": 54,
+        "budgetExhausted": false
+      },
+      "anchor": "body",
+      "note": "runtime replayed from 2026-09-08T07:22:45.011Z",
+      "failure": null
+    },
+    {
       "id": "redux-toolkit",
       "revision": "e99fe6135188219f031c5028f653fb82e671de24",
       "framework": "spa",
@@ -918,6 +1628,76 @@
       "report": null,
       "anchor": null,
       "note": "static only",
+      "failure": null
+    },
+    {
+      "id": "socialecho",
+      "revision": "4dc6c7822bfff5c0b13e1b8098e8d7ae0084939a",
+      "framework": "react-router",
+      "capturedAt": "2026-09-08T08:11:36.992Z",
+      "durationMs": 979,
+      "runtime": {
+        "reactVersion": "18.2.0",
+        "rendererName": "react-dom",
+        "buildType": "development",
+        "roots": 1,
+        "fibers": 9,
+        "commits": 3,
+        "pageErrors": [
+          "Failed to load resource: the server responded with a status of 500 (Internal Server Error)",
+          "Failed to load resource: the server responded with a status of 500 (Internal Server Error)"
+        ],
+        "title": "Sign In | SocialEcho"
+      },
+      "static": {
+        "stats": {
+          "fiberCount": 109,
+          "textCount": 0,
+          "branchCount": 6,
+          "repeatCount": 0,
+          "opaqueCount": 2,
+          "unknownCount": 5,
+          "modulesLoaded": 92
+        },
+        "diagnostics": []
+      },
+      "report": {
+        "matchedFibers": 5,
+        "matchedText": 0,
+        "opaqueSubtrees": 0,
+        "opaqueSkippedFibers": 0,
+        "slotsMatched": 0,
+        "slotsUnmatched": 0,
+        "opaqueRenamed": 0,
+        "unmatchedSlots": [],
+        "wildcardAbsorbedFibers": 0,
+        "wildcards": [],
+        "branchesResolved": 2,
+        "branchDeviations": [
+          {
+            "path": "root > <BrowserRouter> [FunctionComponent] > <AppContainer> [FunctionComponent] > <div> [HostComponent]",
+            "reason": "conditional on branch(true | unknown)",
+            "preferredIndex": 0,
+            "chosenIndex": 1,
+            "divergence": {
+              "path": "root > <BrowserRouter> [FunctionComponent] > <AppContainer> [FunctionComponent] > <div> [HostComponent][0]",
+              "expected": "<CommonLoading> [FunctionComponent]",
+              "actual": "<ErrorComponent> [FunctionComponent]"
+            }
+          }
+        ],
+        "repeatIterations": 0,
+        "status": "partial",
+        "runtimeFibers": 5,
+        "staticFibers": 77,
+        "coverage": 1,
+        "strictCoverage": 1,
+        "divergence": null,
+        "stepsUsed": 8,
+        "budgetExhausted": false
+      },
+      "anchor": null,
+      "note": "runtime replayed from 2026-09-08T07:23:34.754Z",
       "failure": null
     },
     {

--- a/packages/parser/src/evaluate/interpreter.ts
+++ b/packages/parser/src/evaluate/interpreter.ts
@@ -1668,8 +1668,15 @@ export class Interpreter {
   ): void {
     const object = this.evaluateExpression(objectNode, context);
     const reassigned = this.assignProperty(object, key, value, context);
-    if (reassigned !== object && objectNode.type === "Identifier") {
+    if (reassigned === object) return;
+    if (objectNode.type === "Identifier") {
       this.assignIdentifier(objectNode.name, reassigned, context);
+    } else if (
+      objectNode.type === "MemberExpression" &&
+      !objectNode.computed &&
+      objectNode.property.type === "Identifier"
+    ) {
+      this.assignMember(objectNode.object, objectNode.property.name, reassigned, context);
     }
   }
 

--- a/packages/parser/src/frameworks/framework-profile.ts
+++ b/packages/parser/src/frameworks/framework-profile.ts
@@ -7,10 +7,13 @@ export type FrameworkKind = "spa" | "next-app" | "next-pages" | "react-router";
 // application plus whatever the route adapter synthesizes; the profile names
 // the fibers to splice out on each side so both describe the same hierarchy.
 // Anonymous fibers are matched by their work tag name (e.g. "ContextProvider"
-// for a provider whose context has no displayName).
+// for a provider whose context has no displayName). Context providers are kept
+// apart from components because their displayNames (`Navigation`, `Location`,
+// `Router`) are common application component names.
 export interface FrameworkProfile {
   kind: FrameworkKind;
   transparentRuntimeFibers: ReadonlySet<string>;
+  transparentRuntimeProviders: ReadonlySet<string>;
   transparentStaticFibers: ReadonlySet<string>;
   /**
    * Runtime fibers (with their subtrees) the framework injects with no
@@ -21,13 +24,23 @@ export interface FrameworkProfile {
   defaultAnchor: string | null;
 }
 
+const isTransparentRuntimeFiber = (
+  fiber: RuntimeFiberSnapshot,
+  profile: FrameworkProfile,
+): boolean => {
+  const name = fiber.name ?? fiber.tag;
+  return fiber.tag === "ContextProvider"
+    ? profile.transparentRuntimeProviders.has(name)
+    : profile.transparentRuntimeFibers.has(name);
+};
+
 const flattenFiber = (
   fiber: RuntimeFiberSnapshot,
   profile: FrameworkProfile,
 ): RuntimeFiberSnapshot[] => {
   if (profile.isInjectedRuntimeFiber(fiber)) return [];
   const children = flattenList(fiber.children, profile);
-  if (profile.transparentRuntimeFibers.has(fiber.name ?? fiber.tag)) return children;
+  if (isTransparentRuntimeFiber(fiber, profile)) return children;
   return [{ ...fiber, children }];
 };
 
@@ -57,6 +70,7 @@ export const neverInjected = (): boolean => false;
 export const SPA_PROFILE: FrameworkProfile = {
   kind: "spa",
   transparentRuntimeFibers: new Set(),
+  transparentRuntimeProviders: new Set(),
   transparentStaticFibers: new Set(),
   isInjectedRuntimeFiber: neverInjected,
   defaultAnchor: null,

--- a/packages/parser/src/frameworks/profiles.ts
+++ b/packages/parser/src/frameworks/profiles.ts
@@ -48,6 +48,10 @@ const NEXT_APP_RUNTIME_WRAPPERS = [
   "InnerScrollAndFocusHandler",
   "InnerScrollAndFocusHandlerOld",
   "LoadingBoundary",
+  "Fragment",
+];
+
+const NEXT_APP_RUNTIME_PROVIDERS = [
   "TemplateContext",
   "LayoutRouterContext",
   "GlobalLayoutRouterContext",
@@ -58,7 +62,6 @@ const NEXT_APP_RUNTIME_WRAPPERS = [
   "SearchParamsContext",
   "HeadManagerContext",
   "SegmentStateContext",
-  "Fragment",
   "ContextProvider",
 ];
 
@@ -87,6 +90,7 @@ const isNextAppInjectedFiber = (fiber: RuntimeFiberSnapshot): boolean =>
 export const NEXT_APP_PROFILE: FrameworkProfile = {
   kind: "next-app",
   transparentRuntimeFibers: new Set(NEXT_APP_RUNTIME_WRAPPERS),
+  transparentRuntimeProviders: new Set(NEXT_APP_RUNTIME_PROVIDERS),
   transparentStaticFibers: new Set(["Fragment", "ContextProvider"]),
   isInjectedRuntimeFiber: isNextAppInjectedFiber,
   defaultAnchor: "body",
@@ -97,13 +101,6 @@ const NEXT_PAGES_RUNTIME_WRAPPERS = [
   "AppContainer",
   "Container",
   "PathnameContextProviderAdapter",
-  "RouterContext",
-  "HeadManagerContext",
-  "ImageConfigContext",
-  "AppRouterContext",
-  "SearchParamsContext",
-  "PathnameContext",
-  "PathParamsContext",
   "ErrorBoundary",
   "HotReload",
   "ReactDevOverlay",
@@ -112,11 +109,32 @@ const NEXT_PAGES_RUNTIME_WRAPPERS = [
   "Fragment",
 ];
 
+const NEXT_PAGES_RUNTIME_PROVIDERS = [
+  "RouterContext",
+  "HeadManagerContext",
+  "ImageConfigContext",
+  "AppRouterContext",
+  "SearchParamsContext",
+  "PathnameContext",
+  "PathParamsContext",
+];
+
+// `next/dist/client/index.js` mounts a dummy `<Head callback>` (renders null,
+// times the head commit) and the route announcer portal next to `AppContainer`.
+const isNextPagesInjectedFiber = (fiber: RuntimeFiberSnapshot): boolean => {
+  if (fiber.tag !== "FunctionComponent") return false;
+  if (fiber.name === "Head") {
+    return fiber.children.length === 0 && Object.keys(fiber.props).join() === "callback";
+  }
+  return fiber.name === "Portal" && fiber.props.type === "next-route-announcer";
+};
+
 export const NEXT_PAGES_PROFILE: FrameworkProfile = {
   kind: "next-pages",
   transparentRuntimeFibers: new Set(NEXT_PAGES_RUNTIME_WRAPPERS),
+  transparentRuntimeProviders: new Set(NEXT_PAGES_RUNTIME_PROVIDERS),
   transparentStaticFibers: new Set(["Fragment"]),
-  isInjectedRuntimeFiber: neverInjected,
+  isInjectedRuntimeFiber: isNextPagesInjectedFiber,
   defaultAnchor: null,
 };
 
@@ -132,13 +150,6 @@ const REACT_ROUTER_RUNTIME_WRAPPERS = [
   "DataRoutes",
   "DataRoutes2",
   "RenderErrorBoundary",
-  "DataRouter",
-  "DataRouterState",
-  "Fetchers",
-  "ViewTransition",
-  "Navigation",
-  "Location",
-  "RouteError",
   "AwaitContextProvider",
   // framework mode (`@react-router/dev`); `HydratedRouter` and the core
   // `RouterProvider` stay as fibers because the static side renders them. The
@@ -146,7 +157,6 @@ const REACT_ROUTER_RUNTIME_WRAPPERS = [
   // esbuild (Vite dev pre-bundling).
   "RouterProvider$1",
   "RouterProvider2",
-  "FrameworkContext",
   "RemixErrorBoundary",
   "WithComponentProps",
   "WithComponentProps2",
@@ -154,13 +164,25 @@ const REACT_ROUTER_RUNTIME_WRAPPERS = [
   "WithHydrateFallbackProps2",
   "WithErrorBoundaryProps",
   "WithErrorBoundaryProps2",
-  "RSCRouterContext",
   "RSCRouterGlobalErrorBoundary",
+];
+
+const REACT_ROUTER_RUNTIME_PROVIDERS = [
+  "DataRouter",
+  "DataRouterState",
+  "Fetchers",
+  "ViewTransition",
+  "Navigation",
+  "Location",
+  "RouteError",
+  "FrameworkContext",
+  "RSCRouterContext",
 ];
 
 export const REACT_ROUTER_PROFILE: FrameworkProfile = {
   kind: "react-router",
   transparentRuntimeFibers: new Set(REACT_ROUTER_RUNTIME_WRAPPERS),
+  transparentRuntimeProviders: new Set(REACT_ROUTER_RUNTIME_PROVIDERS),
   transparentStaticFibers: new Set(["Location"]),
   isInjectedRuntimeFiber: neverInjected,
   defaultAnchor: null,

--- a/packages/parser/src/graph/module-resolver.ts
+++ b/packages/parser/src/graph/module-resolver.ts
@@ -1,9 +1,11 @@
+import { existsSync } from "node:fs";
 import { isBuiltin } from "node:module";
 import path from "node:path";
 import { ResolverFactory } from "oxc-resolver";
 import type { ModuleResolution } from "../types.js";
 
 export interface ModuleResolverOptions {
+  /** Path alias config; a sibling `jsconfig.json` stands in when this file does not exist. */
   tsconfigPath?: string;
   /** Bundler `resolve.alias`: a specifier (or its subpaths) resolved from another absolute path. */
   aliases?: Record<string, string>;
@@ -32,6 +34,13 @@ const DEFAULT_REQUIRE_CONDITION_NAMES = ["browser", "require", "module", "defaul
 export type ImporterKind = "esm" | "commonjs";
 
 const NODE_MODULES_SEGMENT = "/node_modules/";
+const JAVASCRIPT_CONFIG_FILE = "jsconfig.json";
+
+const getPathAliasConfigFile = (tsconfigPath: string): string => {
+  if (existsSync(tsconfigPath)) return tsconfigPath;
+  const jsconfigPath = path.join(path.dirname(tsconfigPath), JAVASCRIPT_CONFIG_FILE);
+  return existsSync(jsconfigPath) ? jsconfigPath : tsconfigPath;
+};
 
 export const getPackageNameFromSpecifier = (specifier: string): string | null => {
   if (specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("#")) {
@@ -82,7 +91,7 @@ export class ModuleResolver {
         primary: new ResolverFactory({
           ...baseOptions,
           tsconfig: options.tsconfigPath
-            ? { configFile: options.tsconfigPath, references: "auto" }
+            ? { configFile: getPathAliasConfigFile(options.tsconfigPath), references: "auto" }
             : "auto",
         }),
         fallback: new ResolverFactory(baseOptions),

--- a/packages/parser/src/harness/compare.ts
+++ b/packages/parser/src/harness/compare.ts
@@ -14,6 +14,13 @@ const BUNDLER_PLACEHOLDER_NAME = /^_[a-z]\d*$/;
 
 const isBundlerPlaceholderName = (name: string): boolean => BUNDLER_PLACEHOLDER_NAME.test(name);
 
+// Rollup and Rolldown (Vite's dependency pre-bundler) deconflict same-named
+// top-level bindings from different modules by appending `$1`, `$2`, ….
+const BUNDLER_DECONFLICT_SUFFIX = /\$\d+$/;
+
+const namesAgree = (patternName: string, actualName: string): boolean =>
+  patternName === actualName || patternName === actualName.replace(BUNDLER_DECONFLICT_SUFFIX, "");
+
 export interface ComparisonOptions {
   compareKeys?: boolean;
   compareTags?: boolean;
@@ -496,7 +503,9 @@ class Matcher {
       pattern.key !== actual.key
     )
       return false;
-    if (pattern.name === null || actual.name === null || pattern.name === actual.name) return true;
+    if (pattern.name === null || actual.name === null || namesAgree(pattern.name, actual.name)) {
+      return true;
+    }
     return isClassTag(actual.tag) && isBundlerPlaceholderName(actual.name);
   }
 
@@ -514,7 +523,11 @@ class Matcher {
 
   private opaqueNameAgrees(pattern: PatternOpaque, actual: RuntimeFiberSnapshot): boolean {
     if (actual.name === null || isBundlerPlaceholderName(actual.name)) return true;
-    return pattern.runtimeNames === null || pattern.runtimeNames.includes(actual.name);
+    const actualName = actual.name;
+    return (
+      pattern.runtimeNames === null ||
+      pattern.runtimeNames.some((runtimeName) => namesAgree(runtimeName, actualName))
+    );
   }
 
   // Searches the library's runtime subtree for the place where it rendered the

--- a/packages/parser/tests/compare.test.ts
+++ b/packages/parser/tests/compare.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vite-plus/test";
+import { comparePatternToRuntime } from "../src/harness/compare.js";
+import type { RuntimeFiberSnapshot } from "../src/harness/snapshot.js";
+import type { PatternFiber } from "../src/harness/static-pattern.js";
+
+const runtimeFiber = (
+  name: string,
+  children: RuntimeFiberSnapshot[] = [],
+  tag: RuntimeFiberSnapshot["tag"] = "FunctionComponent",
+): RuntimeFiberSnapshot => ({ tag, name, key: null, text: null, props: {}, children });
+
+const patternFiber = (
+  name: string,
+  children: PatternFiber[] = [],
+  tag: PatternFiber["tag"] = "FunctionComponent",
+): PatternFiber => ({ kind: "fiber", tag, name, key: null, children });
+
+describe("comparePatternToRuntime", () => {
+  it("accepts a bundler-deconflicted `$N` suffix on the runtime name", () => {
+    const report = comparePatternToRuntime(
+      [patternFiber("Dialog", [patternFiber("Panel", [patternFiber("div", [], "HostComponent")])])],
+      [
+        runtimeFiber("Dialog$1", [
+          runtimeFiber("Panel$12", [runtimeFiber("div", [], "HostComponent")]),
+        ]),
+      ],
+    );
+    expect(report.status).toBe("exact");
+    expect(report.matchedFibers).toBe(3);
+  });
+
+  it("does not equate names that differ beyond a `$N` suffix", () => {
+    const report = comparePatternToRuntime([patternFiber("Dialog")], [runtimeFiber("Dialog$1x")]);
+    expect(report.status).toBe("mismatch");
+  });
+});

--- a/packages/parser/tests/components/namespaced-display-names.tsx
+++ b/packages/parser/tests/components/namespaced-display-names.tsx
@@ -1,0 +1,28 @@
+import { forwardRef, memo, type ReactNode } from "react";
+
+const Field = ({ children }: { children: ReactNode }) => <fieldset>{children}</fieldset>;
+
+Field.Label = ({ text }: { text: string }) => <label>{text}</label>;
+
+Field.Input = forwardRef<HTMLInputElement, { placeholder: string }>(function Input(
+  { placeholder },
+  ref,
+) {
+  return <input ref={ref} placeholder={placeholder} />;
+});
+
+Field.Hint = memo(({ text }: { text: string }) => <small>{text}</small>);
+
+Field.Label.displayName = "Field.Label";
+Field.Input.displayName = "Field.Input";
+Field.Hint.displayName = "Field.Hint";
+
+export default function NamespacedDisplayNames() {
+  return (
+    <Field>
+      <Field.Label text="Name" />
+      <Field.Input placeholder="name" />
+      <Field.Hint text="required" />
+    </Field>
+  );
+}

--- a/packages/parser/tests/fixtures/jsconfig-paths/fixture.json
+++ b/packages/parser/tests/fixtures/jsconfig-paths/fixture.json
@@ -1,0 +1,6 @@
+{
+  "entry": "src/main.jsx",
+  "expectedStatus": "exact",
+  "minCoverage": 1,
+  "notes": "JavaScript project whose @/ alias is declared in jsconfig.json (no tsconfig.json), as Next.js and CRA read it."
+}

--- a/packages/parser/tests/fixtures/jsconfig-paths/jsconfig.json
+++ b/packages/parser/tests/fixtures/jsconfig-paths/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] }
+  }
+}

--- a/packages/parser/tests/fixtures/jsconfig-paths/package.json
+++ b/packages/parser/tests/fixtures/jsconfig-paths/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-jsconfig-paths",
+  "private": true,
+  "type": "module"
+}

--- a/packages/parser/tests/fixtures/jsconfig-paths/src/app.jsx
+++ b/packages/parser/tests/fixtures/jsconfig-paths/src/app.jsx
@@ -1,0 +1,7 @@
+import { Greeting } from "@/components/greeting";
+
+export const App = () => (
+  <main>
+    <Greeting name="jsconfig" />
+  </main>
+);

--- a/packages/parser/tests/fixtures/jsconfig-paths/src/components/greeting.jsx
+++ b/packages/parser/tests/fixtures/jsconfig-paths/src/components/greeting.jsx
@@ -1,0 +1,5 @@
+export const Greeting = ({ name }) => (
+  <section>
+    <h1>Hello {name}</h1>
+  </section>
+);

--- a/packages/parser/tests/fixtures/jsconfig-paths/src/main.jsx
+++ b/packages/parser/tests/fixtures/jsconfig-paths/src/main.jsx
@@ -1,0 +1,9 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "@/app";
+
+createRoot(document.getElementById("root")).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/packages/parser/tests/framework-profile.test.ts
+++ b/packages/parser/tests/framework-profile.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vite-plus/test";
+import { flattenTransparentFibers } from "../src/frameworks/framework-profile.js";
+import { NEXT_PAGES_PROFILE, REACT_ROUTER_PROFILE } from "../src/frameworks/profiles.js";
+import type { RuntimeFiberSnapshot, RuntimeSnapshot } from "../src/harness/snapshot.js";
+
+const fiber = (
+  tag: RuntimeFiberSnapshot["tag"],
+  name: string,
+  children: RuntimeFiberSnapshot[] = [],
+  props: RuntimeFiberSnapshot["props"] = {},
+): RuntimeFiberSnapshot => ({ tag, name, key: null, text: null, props, children });
+
+const snapshotOf = (children: RuntimeFiberSnapshot[]): RuntimeSnapshot => ({
+  reactVersion: "19.0.0",
+  rendererName: "react-dom",
+  buildType: "development",
+  roots: [fiber("HostRoot", "HostRoot", children)],
+  capturedAt: "1970-01-01T00:00:00.000Z",
+});
+
+const describeTree = (fibers: RuntimeFiberSnapshot[]): string[] =>
+  fibers.flatMap((inner) => [
+    `${inner.name}[${inner.tag}]`,
+    ...describeTree(inner.children).map((line) => `  ${line}`),
+  ]);
+
+describe("framework profiles", () => {
+  it("splices out a framework context provider but keeps an application component of the same name", () => {
+    const snapshot = snapshotOf([
+      fiber("FunctionComponent", "BrowserRouter", [
+        fiber("FunctionComponent", "Router", [
+          fiber("ContextProvider", "Navigation", [
+            fiber("ContextProvider", "Location", [
+              fiber("FunctionComponent", "App", [
+                fiber("FunctionComponent", "Navigation", [fiber("HostComponent", "nav")]),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]),
+    ]);
+    const flattened = flattenTransparentFibers(snapshot, REACT_ROUTER_PROFILE);
+    expect(describeTree(flattened.roots[0]?.children ?? [])).toEqual([
+      "BrowserRouter[FunctionComponent]",
+      "  App[FunctionComponent]",
+      "    Navigation[FunctionComponent]",
+      "      nav[HostComponent]",
+    ]);
+  });
+
+  it("drops the pages router's dummy Head and route announcer but keeps the application's next/head", () => {
+    const snapshot = snapshotOf([
+      fiber("FunctionComponent", "Root", [
+        fiber("FunctionComponent", "Head", [], { callback: "[function]" }),
+        fiber("FunctionComponent", "AppContainer", [
+          fiber("FunctionComponent", "App", [
+            fiber("FunctionComponent", "Head", [fiber("FunctionComponent", "SideEffect")]),
+            fiber("HostComponent", "main"),
+          ]),
+          fiber(
+            "FunctionComponent",
+            "Portal",
+            [fiber("HostPortal", "Portal", [fiber("FunctionComponent", "RouteAnnouncer")])],
+            { type: "next-route-announcer" },
+          ),
+        ]),
+      ]),
+    ]);
+    const flattened = flattenTransparentFibers(snapshot, NEXT_PAGES_PROFILE);
+    expect(describeTree(flattened.roots[0]?.children ?? [])).toEqual([
+      "App[FunctionComponent]",
+      "  Head[FunctionComponent]",
+      "    SideEffect[FunctionComponent]",
+      "  main[HostComponent]",
+    ]);
+  });
+});

--- a/packages/parser/tests/helpers/fixture-runner.ts
+++ b/packages/parser/tests/helpers/fixture-runner.ts
@@ -139,9 +139,7 @@ export const runFixture = async (fixture: FixtureCase): Promise<FixtureRunResult
     },
     {
       rootDirectory: fixture.directory,
-      tsconfigPath: existsSync(join(fixture.directory, "tsconfig.json"))
-        ? join(fixture.directory, "tsconfig.json")
-        : undefined,
+      tsconfigPath: join(fixture.directory, "tsconfig.json"),
       externalPackageAllowList: fixture.manifest.externalPackages,
       observations: fixture.manifest.observations,
     },


### PR DESCRIPTION
## Summary

Adds the ten `misc-apps` corpus entries (lobe-chat, CopilotKit, react-three-next, openchakra, craft.js, pdfme, SocialEcho, react-starter-kit, nextjs-starter, Foxel) and the generic fixes their divergences justified. Results: 1 exact (react-three-next), 6 partial, 2 unresolved (lobe-chat, nextjs-starter), 1 static-only (craft.js cannot serve on Node 22, see manifest `notes`).

Generic changes, each with a focused test:

- **Resolver**: `getPathAliasConfigFile` falls back `tsconfig.json → jsconfig.json` for `baseUrl`/`paths` (react-three-next is a JS project with `@/*` in jsconfig). Fixture `tests/fixtures/jsconfig-paths`; `fixture-runner` now always passes `tsconfigPath` so fixtures without a tsconfig exercise the fallback.
- **Evaluator** (`assignMember`): a replacement value produced by `assignProperty` (e.g. a `component-reference` re-created with a new `displayName`) is now written back through non-computed member chains, not only bare identifiers:
  ```ts
  Field.Input.displayName = "Field.Input"; // previously left `Field.Input` pointing at the old reference
  ```
  Case `tests/components/namespaced-display-names.tsx` (CopilotKit's `CopilotChat.Input` etc. went from mismatch/0% to 100% coverage, 91% strict).
- **Framework profiles**: `FrameworkProfile.transparentRuntimeProviders` separates context providers from wrapper components, so an app component named `Navigation`/`Location`/`Router` is no longer flattened just because React Router has a provider of that name. Next pages drops its injected dummy `Head` and route-announcer portal (`isInjectedRuntimeFiber`) while a real `next/head` usage remains. Tests in `tests/framework-profile.test.ts`.
- **Comparer**: `namesAgree` accepts a Rollup/Rolldown deconfliction suffix (`Dialog` vs `Dialog$1`) on runtime names only; `Dialog$1x` still mismatches. Tests in `tests/compare.test.ts`.

Manifest allowlists were extended per entry (`its-fine`, `next-intl`/`use-intl`, `@headlessui/react`, `lucide-react`, `@radix-ui/*`) and nextjs-starter's route corrected to `/en`. No budgets were raised; residual uncertainty is reported in the results as branches/unknowns.


Link to Devin session: https://app.devin.ai/sessions/63b5016ae19f454c9c6109d20a746abe
Open in Devin Desktop: https://app.devin.ai/desktop/session/63b5016ae19f454c9c6109d20a746abe?variant=devin
Requested by: @aidenybai