### PR TITLE
feat(parser): enumerate exhaustive reachable states and match runtime by membership

### DIFF
--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -155,20 +155,25 @@ framework internals; application mismatches are never hidden this way.
   entries, Redux/Kea store state, Lingui catalogs, router location and the identity of exported
   values (`module-exports.ts`). A saved capture replays with `--static-only`, and the static render
   takes the observations as inputs so dynamic data the page actually had is not guessed.
-- `compareStaticToRuntime` reads the materialized fiber tree back into a pattern (`static-pattern.ts`:
-  marker fibers become branch/repeat/opaque/wildcard nodes, everything else is a concrete fiber)
-  and matches it against the runtime tree: hierarchy, tags, names, keys, host elements, text.
-  A marker-free tree is a plain fiber-by-fiber diff. Branches try each alternative;
-  repeats absorb any count; `opaque` subtrees match one runtime subtree (by name, or an anonymous /
-  bundler-placeholder name such as esbuild's `_a2`) and slot their passed children back in;
-  `unknown` is a wildcard. The report carries a tally (matched, absorbed,
-  opaque, unknown), coverage, and the first divergence path with source location.
+- `enumerateStaticStates` reads each committed materialized tree back into a pattern
+  (`static-pattern.ts`: marker fibers become branch/repeat/opaque/wildcard nodes, everything else
+  is a concrete fiber) and expands it into the set of concrete reachable states
+  (`state-space.ts`): one per assignment of the branch predicates and repeat cardinalities, and
+  one per distinct committed tree. Branches sharing a predicate are decided together, repeats
+  enumerate bounded counts, and whatever the `StateSpaceBudget` cuts off is recorded in `omitted`
+  rather than dropped (see `docs/exhaustive-states.md`).
+- `compareStaticToRuntime` checks the runtime tree for membership in that set: hierarchy, tags,
+  names, keys, host elements, text. `opaque` subtrees match one runtime subtree (by name, or an
+  anonymous / bundler-placeholder name such as esbuild's `_a2`) and slot their passed children
+  back in; `unknown` is a wildcard. The report carries a tally (matched, absorbed, opaque,
+  unknown), coverage, the matched state's conditions, the states never observed, the omissions,
+  and on a mismatch the first divergence path with the closest enumerated state.
 
-Statuses: `exact` (all static fibers matched, no uncertainty consumed), `partial` (matched, but
-branches, repeats, opaque subtrees or wildcards were needed), `mismatch` (a divergence),
-`unresolved` (the static side did not produce a component tree), `skipped` (no runtime root or
-anchor). The harness chooses the runtime root by explicit index, then anchor search, then the
-largest root.
+Statuses: `exact` (the runtime equals one enumerated state and nothing was omitted), `truncated`
+(the runtime matched but the state space is incomplete), `partial` (matched through opaque
+subtrees or wildcards), `mismatch` (no state matches), `unresolved` (the static side did not
+produce a component tree), `skipped` (no runtime root or anchor). The harness chooses the runtime
+root by explicit index, then anchor search, then the largest root.
 
 ## Corpus
 

--- a/packages/parser/corpus/results.json
+++ b/packages/parser/corpus/results.json
@@ -68,7 +68,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "partial",
         "runtimeFibers": 232,
@@ -79,6 +78,7 @@
         "stepsUsed": 234,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": null,
       "failure": null
@@ -123,7 +123,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 46,
@@ -134,6 +133,7 @@
         "stepsUsed": 46,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-07T23:12:07.223Z",
       "failure": null
@@ -178,7 +178,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 1,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "partial",
         "runtimeFibers": 938,
@@ -189,6 +188,7 @@
         "stepsUsed": 939,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": "body",
       "note": "runtime replayed from 2026-09-07T11:40:39.987Z",
       "failure": null
@@ -249,63 +249,6 @@
           }
         ],
         "branchesResolved": 12,
-        "branchDeviations": [
-          {
-            "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent] > <CopilotKitInspector> [FunctionComponent]",
-            "reason": "if (<boolean: negation of unknown>)",
-            "preferredIndex": 0,
-            "chosenIndex": 1,
-            "divergence": {
-              "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent] > <CopilotKitInspector> [FunctionComponent][0]",
-              "expected": "<end of children>",
-              "actual": "<WebInspectorElement> [ForwardRef]"
-            }
-          },
-          {
-            "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent]",
-            "reason": "&& on branch(true | false)",
-            "preferredIndex": 0,
-            "chosenIndex": 1,
-            "divergence": {
-              "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent][4]",
-              "expected": "<LicenseWarningBanner> [FunctionComponent]",
-              "actual": "<end of children>"
-            }
-          },
-          {
-            "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent]",
-            "reason": "&& on <boolean: === on dynamic values>",
-            "preferredIndex": 0,
-            "chosenIndex": 1,
-            "divergence": {
-              "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent][4]",
-              "expected": "<LicenseWarningBanner> [FunctionComponent]",
-              "actual": "<end of children>"
-            }
-          },
-          {
-            "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent]",
-            "reason": "&& on <boolean: === on dynamic values>",
-            "preferredIndex": 0,
-            "chosenIndex": 1,
-            "divergence": {
-              "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent][4]",
-              "expected": "<LicenseWarningBanner> [FunctionComponent]",
-              "actual": "<end of children>"
-            }
-          },
-          {
-            "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent]",
-            "reason": "&& on <boolean: === on dynamic values>",
-            "preferredIndex": 0,
-            "chosenIndex": 1,
-            "divergence": {
-              "path": "root > <body> [HostSingleton] > <Home> [FunctionComponent] > <CopilotKitProvider> [FunctionComponent][4]",
-              "expected": "<LicenseWarningBanner> [FunctionComponent]",
-              "actual": "<end of children>"
-            }
-          }
-        ],
         "repeatIterations": 0,
         "status": "partial",
         "runtimeFibers": 179,
@@ -316,6 +259,7 @@
         "stepsUsed": 735,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": "body",
       "note": "runtime replayed from 2026-09-08T08:02:55.873Z",
       "failure": null
@@ -340,6 +284,7 @@
         "diagnostics": []
       },
       "report": null,
+      "stateSpace": null,
       "anchor": null,
       "note": "static only",
       "failure": null
@@ -397,7 +342,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 203,
@@ -408,6 +352,7 @@
         "stepsUsed": 203,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-07T00:50:55.867Z",
       "failure": null
@@ -457,7 +402,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 693,
@@ -468,6 +412,7 @@
         "stepsUsed": 693,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": null,
       "failure": null
@@ -505,6 +450,7 @@
         ]
       },
       "report": null,
+      "stateSpace": null,
       "anchor": null,
       "note": "static only",
       "failure": null
@@ -571,7 +517,6 @@
           }
         ],
         "branchesResolved": 1,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "partial",
         "runtimeFibers": 14,
@@ -582,6 +527,7 @@
         "stepsUsed": 7,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-08T07:24:29.116Z",
       "failure": null
@@ -626,7 +572,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 1,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "partial",
         "runtimeFibers": 378,
@@ -637,6 +582,7 @@
         "stepsUsed": 379,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-08T03:45:17.260Z",
       "failure": null
@@ -655,7 +601,7 @@
         "fibers": 1439,
         "commits": 27,
         "pageErrors": [
-          "Hydration failed because the server rendered text didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:\n\n- A server/client branch `if (typeof window !== 'undefined')`.\n- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n- Date formatting in a user's locale which doesn't match the server.\n- External changing data without sending a snapshot of it along with the HTML.\n- Invalid HTML tag nesting.\n\nIt can also happen if the client has a browser extension installed which messes with the HTML before React loaded.\n\nhttps://react.dev/link/hydration-mismatch\n\n  ...\n    <Home>\n      <main className=\"container ...\">\n        <WizardProvider>\n          <InvoiceMain>\n            <FormProvider control={{...}} subscribe={function subscribe} trigger={function trigger} ...>\n              <form onSubmit={function}>\n                <div className=\"grid grid-...\">\n                  <InvoiceForm>\n                    <div className=\"@container...\">\n                      <div className=\"mx-auto ma...\">\n                        <div className=\"mb-4 flex ...\">\n                          <AutosaveIndicator>\n                          <span\n+                           className=\"text-sm font-medium text-muted-foreground\"\n-                           className=\"flex items-center gap-1.5 text-xs text-muted-foreground\"\n                          >\n+                           New Invoice\n-                           Saved · just now\n                        ...\n                  ...\n                ...\n      ...\n    ...\n"
+          "Hydration failed because the server rendered text didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:\n\n- A server/client branch `if (typeof window !== 'undefined')`.\n- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.\n- Date formatting in a user's locale which doesn't match the server.\n- External changing data without sending a snapshot of it along with the HTML.\n- Invalid HTML tag nesting.\n\nIt can also happen if the client has a browser extension installed which messes with the HTML before React loaded.\n\nhttps://react.dev/link/hydration-mismatch\n\n  ...\n    <Home>\n      <main className=\"container ...\">\n        <WizardProvider>\n          <InvoiceMain>\n            <FormProvider control={{...}} subscribe={function subscribe} trigger={function trigger} ...>\n              <form onSubmit={function}>\n                <div className=\"grid grid-...\">\n                  <InvoiceForm>\n                    <div className=\"@container...\">\n                      <div className=\"mx-auto ma...\">\n                        <div className=\"mb-4 flex ...\">\n                          <AutosaveIndicator>\n                          <span\n+                           className=\"text-sm font-medium text-muted-foreground\"\n-                           className=\"flex items-center gap-1.5 text-xs text-muted-foreground\"\n                          >\n+                           New Invoice\n-                           Saved \u00b7 just now\n                        ...\n                  ...\n                ...\n      ...\n    ...\n"
         ],
         "title": "Free Invoice Generator | Invoify"
       },
@@ -683,7 +629,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 1144,
@@ -694,6 +639,7 @@
         "stepsUsed": 1144,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": "body",
       "note": null,
       "failure": null
@@ -743,7 +689,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 225,
@@ -754,6 +699,7 @@
         "stepsUsed": 225,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-07T23:03:03.725Z",
       "failure": null
@@ -823,7 +769,6 @@
         "slotsUnmatched": 0,
         "opaqueRenamed": 0,
         "unmatchedSlots": [],
-        "branchDeviations": [],
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
@@ -836,6 +781,7 @@
         "stepsUsed": 0,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "React failed to render the materialized tree; runtime replayed from 2026-09-08T07:20:29.476Z",
       "failure": null
@@ -880,7 +826,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 162,
@@ -891,6 +836,7 @@
         "stepsUsed": 162,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": "body",
       "note": null,
       "failure": null
@@ -935,7 +881,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 83,
@@ -946,6 +891,7 @@
         "stepsUsed": 83,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": "body",
       "note": "runtime replayed from 2026-09-06T04:55:26.311Z",
       "failure": null
@@ -988,7 +934,6 @@
         "slotsUnmatched": 0,
         "opaqueRenamed": 0,
         "unmatchedSlots": [],
-        "branchDeviations": [],
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
@@ -1001,6 +946,7 @@
         "stepsUsed": 0,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "static render did not resolve to a component tree; runtime replayed from 2026-09-08T07:50:14.781Z",
       "failure": null
@@ -1082,7 +1028,6 @@
           }
         ],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "partial",
         "runtimeFibers": 1961,
@@ -1093,6 +1038,7 @@
         "stepsUsed": 2,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-08T07:23:05.031Z",
       "failure": null
@@ -1161,41 +1107,6 @@
           }
         ],
         "branchesResolved": 3,
-        "branchDeviations": [
-          {
-            "path": "root > <StrictMode> [Mode] > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Navigation> [FunctionComponent] > <div> [HostComponent] > <nav> [HostComponent] > <HelpModal> [FunctionComponent] > <$e> [ForwardRef] > <j> [FunctionComponent] > <ContextProvider> [ContextProvider]",
-            "reason": "&& on branch(true | <boolean>)",
-            "preferredIndex": 0,
-            "chosenIndex": 1,
-            "divergence": {
-              "path": "root > <StrictMode> [Mode] > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Navigation> [FunctionComponent] > <div> [HostComponent] > <nav> [HostComponent] > <HelpModal> [FunctionComponent] > <$e> [ForwardRef] > <j> [FunctionComponent] > <ContextProvider> [ContextProvider][1]",
-              "expected": "<l> [ForwardRef]",
-              "actual": "<end of children>"
-            }
-          },
-          {
-            "path": "root > <StrictMode> [Mode] > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Suspense> [SuspenseComponent] > <Offscreen> [OffscreenComponent] > <Routes> [FunctionComponent] > <RenderedRoute> [FunctionComponent] > <Route> [ContextProvider] > <TemplatesApp> [FunctionComponent] > <div> [HostComponent] > <div> [HostComponent] > <section> [HostComponent] > <div> [HostComponent]",
-            "reason": "callback for an item that may not occur",
-            "preferredIndex": 0,
-            "chosenIndex": 1,
-            "divergence": {
-              "path": "root > <StrictMode> [Mode] > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Suspense> [SuspenseComponent] > <Offscreen> [OffscreenComponent] > <Routes> [FunctionComponent] > <RenderedRoute> [FunctionComponent] > <Route> [ContextProvider] > <TemplatesApp> [FunctionComponent] > <div> [HostComponent] > <div> [HostComponent] > <section> [HostComponent] > <div> [HostComponent] > <Fragment> [Fragment][0]",
-              "expected": "<end of children>",
-              "actual": "<Fragment> key=\"invoice\" [Fragment]"
-            }
-          },
-          {
-            "path": "root > <StrictMode> [Mode] > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Suspense> [SuspenseComponent] > <Offscreen> [OffscreenComponent] > <Routes> [FunctionComponent] > <RenderedRoute> [FunctionComponent] > <Route> [ContextProvider] > <TemplatesApp> [FunctionComponent] > <div> [HostComponent] > <div> [HostComponent] > <section> [HostComponent] > <div> [HostComponent]",
-            "reason": "&& on branch(true | <boolean>)",
-            "preferredIndex": 0,
-            "chosenIndex": 1,
-            "divergence": {
-              "path": "root > <StrictMode> [Mode] > <BrowserRouter> [FunctionComponent] > <App> [FunctionComponent] > <div> [HostComponent] > <Suspense> [SuspenseComponent] > <Offscreen> [OffscreenComponent] > <Routes> [FunctionComponent] > <RenderedRoute> [FunctionComponent] > <Route> [ContextProvider] > <TemplatesApp> [FunctionComponent] > <div> [HostComponent] > <div> [HostComponent] > <section> [HostComponent] > <div> [HostComponent][1]",
-              "expected": "<div> [HostComponent]",
-              "actual": "<end of children>"
-            }
-          }
-        ],
         "repeatIterations": 32,
         "status": "partial",
         "runtimeFibers": 1456,
@@ -1206,6 +1117,7 @@
         "stepsUsed": 220,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-08T07:35:03.692Z",
       "failure": null
@@ -1258,7 +1170,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 191,
@@ -1269,6 +1180,7 @@
         "stepsUsed": 191,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-07T05:44:44.473Z",
       "failure": null
@@ -1313,7 +1225,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 450,
@@ -1324,6 +1235,7 @@
         "stepsUsed": 450,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": "body",
       "note": "runtime replayed from 2026-09-06T14:42:06.387Z",
       "failure": null
@@ -1380,7 +1292,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "partial",
         "runtimeFibers": 5580,
@@ -1391,6 +1302,7 @@
         "stepsUsed": 29,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-06T14:42:18.572Z",
       "failure": null
@@ -1415,6 +1327,7 @@
         "diagnostics": []
       },
       "report": null,
+      "stateSpace": null,
       "anchor": null,
       "note": "static only",
       "failure": null
@@ -1459,7 +1372,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 50,
@@ -1470,6 +1382,7 @@
         "stepsUsed": 50,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-06T04:55:32.863Z",
       "failure": null
@@ -1535,7 +1448,6 @@
           }
         ],
         "branchesResolved": 1,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "partial",
         "runtimeFibers": 40,
@@ -1546,6 +1458,7 @@
         "stepsUsed": 19,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-08T07:23:55.274Z",
       "failure": null
@@ -1599,7 +1512,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 54,
@@ -1610,6 +1522,7 @@
         "stepsUsed": 54,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": "body",
       "note": "runtime replayed from 2026-09-08T07:22:45.011Z",
       "failure": null
@@ -1654,7 +1567,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 6,
@@ -1665,6 +1577,7 @@
         "stepsUsed": 6,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-07T12:12:03.185Z",
       "failure": null
@@ -1721,7 +1634,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 566,
@@ -1732,6 +1644,7 @@
         "stepsUsed": 566,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-06T23:25:35.602Z",
       "failure": null
@@ -1761,6 +1674,7 @@
         ]
       },
       "report": null,
+      "stateSpace": null,
       "anchor": null,
       "note": "static only",
       "failure": null
@@ -1808,19 +1722,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 2,
-        "branchDeviations": [
-          {
-            "path": "root > <BrowserRouter> [FunctionComponent] > <AppContainer> [FunctionComponent] > <div> [HostComponent]",
-            "reason": "conditional on branch(true | unknown)",
-            "preferredIndex": 0,
-            "chosenIndex": 1,
-            "divergence": {
-              "path": "root > <BrowserRouter> [FunctionComponent] > <AppContainer> [FunctionComponent] > <div> [HostComponent][0]",
-              "expected": "<CommonLoading> [FunctionComponent]",
-              "actual": "<ErrorComponent> [FunctionComponent]"
-            }
-          }
-        ],
         "repeatIterations": 0,
         "status": "partial",
         "runtimeFibers": 5,
@@ -1831,6 +1732,7 @@
         "stepsUsed": 8,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-08T07:23:34.754Z",
       "failure": null
@@ -1875,7 +1777,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 44,
@@ -1886,6 +1787,7 @@
         "stepsUsed": 44,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": "body",
       "note": "runtime replayed from 2026-09-06T04:55:41.386Z",
       "failure": null
@@ -1930,7 +1832,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 217,
@@ -1941,6 +1842,7 @@
         "stepsUsed": 217,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-07T12:08:20.819Z",
       "failure": null
@@ -1985,7 +1887,6 @@
         "wildcardAbsorbedFibers": 0,
         "wildcards": [],
         "branchesResolved": 0,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "exact",
         "runtimeFibers": 48,
@@ -1996,6 +1897,7 @@
         "stepsUsed": 48,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": "runtime replayed from 2026-09-07T13:00:25.894Z",
       "failure": null
@@ -2332,7 +2234,6 @@
           }
         ],
         "branchesResolved": 2,
-        "branchDeviations": [],
         "repeatIterations": 0,
         "status": "partial",
         "runtimeFibers": 3748,
@@ -2343,6 +2244,7 @@
         "stepsUsed": 111,
         "budgetExhausted": false
       },
+      "stateSpace": null,
       "anchor": null,
       "note": null,
       "failure": null

--- a/packages/parser/docs/exhaustive-states.md
+++ b/packages/parser/docs/exhaustive-states.md
@@ -1,0 +1,137 @@
+# Exhaustive reachable states
+
+The static render used to answer "what does this tree look like?" with one tree
+whose uncertain spots were inline maybe-nodes (`$Branch` rendering a preferred
+alternative, `$Repeat` absorbing any count). That is one state with hedges, not
+the set of states the source can reach. The harness now enumerates that set and
+checks the runtime capture for membership in it.
+
+## Representation (`src/harness/state-space.ts`)
+
+```ts
+interface StaticState {
+  tree: PatternNode[]; // concrete: no branch or repeat nodes remain
+  conditions: StateCondition[]; // the decisions that select this tree
+}
+
+interface StaticStateSpace {
+  states: StaticState[];
+  budget: StateSpaceBudget; // { maxStates, maxRepeat }
+  omitted: OmittedStateSpace | null; // non-null whenever `states` is incomplete
+  commits: PatternNode[][]; // distinct committed patterns, in commit order
+}
+```
+
+A condition is one of:
+
+- `branch` — predicate variable, reason, source location, chosen alternative
+  index out of how many;
+- `state-update` — the same, for a branch whose predicate is a `useState` /
+  `useReducer` cell (`state(<cell>)`);
+- `repeat` — repeat variable, source location, concrete cardinality;
+- `transition` — which committed tree (of how many) this state is. Effect and
+  timer driven re-renders commit new trees; each distinct committed tree is a
+  state of its own, reachable within the settle window.
+
+Environment assumptions (`window.innerWidth`, env vars, host values) surface as
+`branch` conditions whose reason names the host value; the interpreter has no
+way to pick a side, so both are states.
+
+`tree` is a `PatternNode[]` rather than a `RuntimeSnapshot` because a concrete
+state can still contain `opaque` subtrees (an external component whose render
+is not modeled) and wildcards; a `RuntimeSnapshot` cannot express "one subtree
+of unknown shape here". After enumeration a state's tree contains no decision
+nodes, so matching it is a plain structural diff with those two kinds of hole.
+
+## How states are produced
+
+The interpreter runs once and the materializer renders once. Every branch
+alternative is rendered by React under a `$Branch`/`$Alternative` marker and
+every repeat body under a `$Repeat` marker, so the single committed tree is the
+product of all alternatives. `enumerateStateSpace` then projects that tree onto
+each assignment of the decision variables; this is the "materialize once per
+assignment" of the design done as a selection over one materialization instead
+of one React render per assignment (256 renders of the same tree would only
+reproduce subtrees React already rendered). The one place the materializer
+does not render an alternative is when it sits more than
+`MAX_ALTERNATIVE_DEPTH` branches off the preferred path or past the element
+budget; it emits a truncated `$Unknown` there, which enumeration reports as a
+`subtree` omission.
+
+## Correlation
+
+A branch's variable is the identity of its predicate, not its position:
+
+- `truthy(<id>)` where `<id>` is the identity of the uncertain value being
+  tested (`src/evaluate/predicates.ts`). `flag ? A : B` evaluated in three
+  components off one `useFlag()` result is one variable → 2 states, not 8.
+- `!truthy(<id>)` is read back as the same variable with its alternatives
+  swapped, so `!flag ? B : A` decides together with `flag ? A : B`.
+- `state(<cell>)` for a branch on a state cell.
+- `path(<n>)` for a fork of statement paths (`if` bodies, early returns,
+  loop exits): every binding joined at that fork shares the variable, as the
+  operands of one SSA phi would; `branch#N` / `repeat#N` for markers without a
+  predicate.
+
+Repeated variables are scoped per iteration (`variable@repeat#3[1]`) so a
+branch inside a `.map` callback is decided once per rendered item.
+
+Correlation is by value identity within one interpretation. Two calls of the
+same opaque hook produce two independent unknowns — the interpreter cannot know
+they return the same value — so they multiply.
+
+## Budget and omissions
+
+`StateSpaceBudget` defaults to `{ maxStates: 256, maxRepeat: 2 }`.
+
+- Repeats enumerate `min .. min + maxRepeat` cardinalities, clipped to the
+  interpreter's `NumberRange` when it knows one (a mapped literal array is
+  exact and produces one count and no omission). Counts above the bound are an
+  `OmittedRepeatStates { countsAbove, max }`.
+- When `states` reaches `maxStates`, the state that would have been emitted
+  next is recorded as `OmittedState { conditions }` and every alternative the
+  enumerator can no longer expand is an `OmittedBranchStates` /
+  `OmittedRepeatStates` carrying the conditions already chosen when it was
+  reached.
+- Subtrees the materializer did not render are `OmittedSubtree`.
+
+`omitted` is `null` only when every reachable state is in `states`. Nothing is
+dropped without an entry here.
+
+## Matching and status
+
+`matchStateSpace` tries each committed pattern, latest first, with the
+assignment-aware matcher (`compare.ts`): a branch variable already decided on
+this attempt is reused, otherwise its alternatives are tried; repeats try
+concrete counts. The decisions of a successful attempt become conditions and
+are looked up in `states`.
+
+- `exact` — the runtime equals one enumerated state and `omitted` is `null`.
+- `truncated` — the runtime matched (an enumerated state, or an assignment
+  outside `states`, reported with `index: null`) but the space is incomplete.
+  Both the fixture suite and the corpus treat this as membership, never as
+  exactness.
+- `partial` — matched, but through an opaque subtree or wildcard.
+- `mismatch` — no committed pattern matches under any assignment. The report
+  carries the furthest divergence and `closestState`: the enumerated state that
+  agrees with the failing attempt on the most decisions.
+
+The report (`format-report.ts`) prints the number of states, the matched
+state's conditions, the states never observed by this capture, and every
+omission. `corpus/results.json` records `stateSpace: { states, matchedState,
+closestState, omitted }` per entry, validated by the wrapper schema in
+`src/corpus/summary.ts`.
+
+## Where enumeration is necessarily bounded
+
+- Repeat cardinality: unbounded lists get `min .. min + maxRepeat`; the rest is
+  an omission.
+- Independent branches multiply; `maxStates` cuts the product and the cut is
+  recorded per alternative.
+- Alternatives nested more than `MAX_ALTERNATIVE_DEPTH` off the preferred path,
+  and anything past the materializer's element budget, are not rendered.
+- Opaque externals: their subtree is a hole, not a set of states.
+- Commits are those observed within the settle window; a timer that fires later
+  is a state this run cannot see.
+- Two unknowns the interpreter cannot prove equal are independent even when the
+  program would always agree on them.

--- a/packages/parser/scripts/corpus.ts
+++ b/packages/parser/scripts/corpus.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { parseArgs } from "node:util";
 import { readCorpusManifest, type CorpusResult } from "../src/corpus/manifest.js";
@@ -12,6 +12,7 @@ import {
   formatCorpusMarkdown,
   formatCorpusTable,
   mergeCorpusResults,
+  readCorpusResults,
   type CorpusResultsFile,
 } from "../src/corpus/summary.js";
 import { BrowserCapturer } from "../src/harness/capture-browser.js";
@@ -77,11 +78,8 @@ if (unknown.length > 0) {
   process.exit(1);
 }
 
-const readResults = (): CorpusResult[] => {
-  if (!existsSync(resultsPath)) return [];
-  const parsed: CorpusResultsFile = JSON.parse(readFileSync(resultsPath, "utf8"));
-  return parsed.results;
-};
+const readResults = (): CorpusResult[] =>
+  existsSync(resultsPath) ? readCorpusResults(resultsPath).results : [];
 
 const writeResults = (results: CorpusResult[]): void => {
   mkdirSync(path.dirname(resultsPath), { recursive: true });
@@ -136,7 +134,7 @@ try {
       log: (message) => console.log(`[${entry.id}] ${message}`),
     });
     fresh.push(result);
-    if (result.report) console.log(formatComparisonReport(result.report));
+    if (result.report) console.log(formatComparisonReport(result.report, result.stateSpace));
     writeResults(mergeCorpusResults(readResults(), fresh));
   }
 } finally {

--- a/packages/parser/src/corpus/manifest.ts
+++ b/packages/parser/src/corpus/manifest.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { z } from "zod";
 import { parseWithSchema } from "../errors.js";
 import type { ComparisonOptions, ComparisonReport } from "../harness/compare.js";
+import type { StateSpaceSummary } from "../harness/state-space.js";
 import type { JsonValue, StaticRenderStats } from "../types.js";
 import type { FrameworkKind } from "../frameworks/framework-profile.js";
 
@@ -108,6 +109,8 @@ export interface CorpusResult {
   runtime: CorpusRuntimeSummary | null;
   static: CorpusStaticSummary | null;
   report: ComparisonReport | null;
+  /** Null on results recorded before the runtime was matched against an enumerated state space. */
+  stateSpace: StateSpaceSummary | null;
   anchor: string | null;
   note: string | null;
   failure: string | null;

--- a/packages/parser/src/corpus/run-entry.ts
+++ b/packages/parser/src/corpus/run-entry.ts
@@ -7,7 +7,11 @@ import { renderFramework } from "../frameworks/render-framework.js";
 import { flattenTransparentFibers } from "../frameworks/framework-profile.js";
 import { getFrameworkProfile } from "../frameworks/profiles.js";
 import { BrowserCapturer, type BrowserCaptureResult } from "../harness/capture-browser.js";
-import { compareStaticToRuntime } from "../harness/compare-render.js";
+import {
+  compareStaticToRuntime,
+  enumerateStaticStates,
+  summarizeStateSpace,
+} from "../harness/compare-render.js";
 import { rankWildcards } from "../harness/format-report.js";
 import { countSnapshotFibers, formatRuntimeSnapshot, readSnapshot } from "../harness/snapshot.js";
 import { formatPattern, getRenderPattern } from "../harness/static-pattern.js";
@@ -230,21 +234,22 @@ const compareEntry = (
   result: CorpusResult,
 ): void => {
   const profile = getFrameworkProfile(entry.framework);
+  const stateSpace = enumerateStaticStates(staticResult, {
+    anchor: entry.static.anchor ?? profile.defaultAnchor ?? undefined,
+    transparentStaticFibers: profile.transparentStaticFibers,
+  });
   const comparison = compareStaticToRuntime(
-    staticResult,
+    stateSpace,
     flattenTransparentFibers(capture.snapshot, profile),
-    {
-      ...entry.compare,
-      anchor: entry.static.anchor ?? profile.defaultAnchor ?? undefined,
-      transparentStaticFibers: profile.transparentStaticFibers,
-    },
+    entry.compare,
   );
   result.runtime = summarizeRuntime(capture);
   result.report = {
     ...comparison.report,
     wildcards: rankWildcards(comparison.report.wildcards, MAX_RECORDED_WILDCARDS),
   };
-  result.anchor = comparison.anchor;
+  result.stateSpace = summarizeStateSpace(comparison);
+  result.anchor = stateSpace.anchor;
   result.note = comparison.note;
 };
 
@@ -292,6 +297,7 @@ export const runCorpusEntry = async (
     runtime: null,
     static: null,
     report: null,
+    stateSpace: null,
     anchor: null,
     note: null,
     failure: null,

--- a/packages/parser/src/corpus/summary.ts
+++ b/packages/parser/src/corpus/summary.ts
@@ -1,4 +1,15 @@
-import type { CorpusResult } from "./manifest.js";
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+import { parseWithSchema } from "../errors.js";
+import type { ComparisonDivergence, ComparisonReport } from "../harness/compare.js";
+import type { StateCondition, StateOmission, StateSpaceSummary } from "../harness/state-space.js";
+import type { StaticRenderStats } from "../types.js";
+import type {
+  CorpusResult,
+  CorpusRuntimeSummary,
+  CorpusStaticSummary,
+  DiagnosticCount,
+} from "./manifest.js";
 
 // Results are persisted per entry so partial corpus runs (one repository at a
 // time, static-only passes, browser passes days apart) accumulate into one
@@ -7,6 +18,151 @@ import type { CorpusResult } from "./manifest.js";
 export interface CorpusResultsFile {
   results: CorpusResult[];
 }
+
+const divergenceSchema: z.ZodType<ComparisonDivergence> = z.object({
+  path: z.string(),
+  expected: z.string(),
+  actual: z.string(),
+});
+
+const reportSchema: z.ZodType<ComparisonReport> = z.object({
+  status: z.enum(["exact", "truncated", "partial", "mismatch", "unresolved", "skipped"]),
+  matchedFibers: z.number(),
+  matchedText: z.number(),
+  opaqueSubtrees: z.number(),
+  opaqueSkippedFibers: z.number(),
+  slotsMatched: z.number(),
+  slotsUnmatched: z.number(),
+  opaqueRenamed: z.number(),
+  unmatchedSlots: z.array(
+    z.object({
+      path: z.string(),
+      reason: z.string(),
+      head: z.string(),
+      skippedFibers: z.number(),
+      divergence: divergenceSchema.nullable(),
+    }),
+  ),
+  wildcardAbsorbedFibers: z.number(),
+  wildcards: z.array(
+    z.object({
+      path: z.string(),
+      reason: z.string(),
+      absorbedFibers: z.number(),
+      heads: z.array(z.string()),
+    }),
+  ),
+  branchesResolved: z.number(),
+  repeatIterations: z.number(),
+  runtimeFibers: z.number(),
+  staticFibers: z.number(),
+  coverage: z.number(),
+  strictCoverage: z.number(),
+  divergence: divergenceSchema.nullable(),
+  stepsUsed: z.number(),
+  budgetExhausted: z.boolean(),
+});
+
+const stateConditionSchema: z.ZodType<StateCondition> = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.enum(["branch", "state-update"]),
+    variable: z.string(),
+    reason: z.string(),
+    location: z.string().nullable(),
+    alternativeIndex: z.number(),
+    alternativeCount: z.number(),
+  }),
+  z.object({
+    kind: z.literal("repeat"),
+    variable: z.string(),
+    location: z.string().nullable(),
+    count: z.number(),
+  }),
+  z.object({ kind: z.literal("transition"), commit: z.number(), commitCount: z.number() }),
+]);
+
+const stateOmissionSchema: z.ZodType<StateOmission> = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("branch"),
+    variable: z.string(),
+    reason: z.string(),
+    location: z.string().nullable(),
+    alternativeIndex: z.number(),
+    conditions: z.array(stateConditionSchema),
+  }),
+  z.object({
+    kind: z.literal("repeat"),
+    variable: z.string(),
+    location: z.string().nullable(),
+    countsAbove: z.number(),
+    max: z.number().nullable(),
+    conditions: z.array(stateConditionSchema),
+  }),
+  z.object({ kind: z.literal("state"), conditions: z.array(stateConditionSchema) }),
+  z.object({ kind: z.literal("subtree"), reason: z.string() }),
+]);
+
+const stateSpaceSummarySchema: z.ZodType<StateSpaceSummary> = z.object({
+  states: z.number(),
+  matchedState: z
+    .object({ index: z.number().nullable(), conditions: z.array(stateConditionSchema) })
+    .nullable(),
+  closestState: z.object({ index: z.number(), divergence: divergenceSchema }).nullable(),
+  omitted: z.object({ omissions: z.array(stateOmissionSchema) }).nullable(),
+});
+
+const runtimeSummarySchema: z.ZodType<CorpusRuntimeSummary> = z.object({
+  reactVersion: z.string().nullable(),
+  rendererName: z.string().nullable(),
+  buildType: z.enum(["development", "production"]).nullable(),
+  roots: z.number(),
+  fibers: z.number(),
+  commits: z.number(),
+  pageErrors: z.array(z.string()),
+  title: z.string(),
+});
+
+const statsSchema: z.ZodType<StaticRenderStats> = z.object({
+  fiberCount: z.number(),
+  textCount: z.number(),
+  branchCount: z.number(),
+  repeatCount: z.number(),
+  opaqueCount: z.number(),
+  unknownCount: z.number(),
+  modulesLoaded: z.number(),
+});
+
+const diagnosticCountSchema: z.ZodType<DiagnosticCount> = z.object({
+  code: z.string(),
+  count: z.number(),
+});
+
+const staticSummarySchema: z.ZodType<CorpusStaticSummary> = z.object({
+  stats: statsSchema,
+  diagnostics: z.array(diagnosticCountSchema),
+});
+
+const resultSchema: z.ZodType<CorpusResult> = z.object({
+  id: z.string(),
+  revision: z.string(),
+  framework: z.enum(["spa", "next-app", "next-pages", "react-router"]),
+  capturedAt: z.string(),
+  durationMs: z.number(),
+  runtime: runtimeSummarySchema.nullable(),
+  static: staticSummarySchema.nullable(),
+  report: reportSchema.nullable(),
+  stateSpace: stateSpaceSummarySchema.nullable(),
+  anchor: z.string().nullable(),
+  note: z.string().nullable(),
+  failure: z.string().nullable(),
+});
+
+const resultsFileSchema: z.ZodType<CorpusResultsFile> = z.object({
+  results: z.array(resultSchema),
+});
+
+export const readCorpusResults = (resultsPath: string): CorpusResultsFile =>
+  parseWithSchema(resultsFileSchema, JSON.parse(readFileSync(resultsPath, "utf8")), resultsPath);
 
 export const mergeCorpusResults = (
   previous: CorpusResult[],
@@ -24,6 +180,21 @@ const outcome = (result: CorpusResult): string => {
   if (result.report) return result.report.status;
   if (result.static) return result.note ?? "static only";
   return "no result";
+};
+
+const describeStateSpace = (stateSpace: StateSpaceSummary): string => {
+  const parts = [`${stateSpace.states} states${stateSpace.omitted ? " (incomplete)" : ""}`];
+  if (stateSpace.matchedState) {
+    parts.push(
+      stateSpace.matchedState.index === null
+        ? "matched outside the enumerated set"
+        : `matched #${stateSpace.matchedState.index + 1}`,
+    );
+  } else if (stateSpace.closestState) {
+    parts.push(`closest #${stateSpace.closestState.index + 1}`);
+  }
+  if (stateSpace.omitted) parts.push(`${stateSpace.omitted.omissions.length} omitted`);
+  return parts.join(", ");
 };
 
 const describeStatic = (result: CorpusResult): string => {
@@ -51,6 +222,7 @@ const describeComparison = (result: CorpusResult): string => {
     `coverage ${percent(report.coverage)} (strict ${percent(report.strictCoverage)})`,
     `${report.matchedFibers} matched`,
   ];
+  if (result.stateSpace) parts.push(describeStateSpace(result.stateSpace));
   if (report.opaqueSubtrees) {
     parts.push(
       `${report.opaqueSubtrees} opaque (${report.opaqueSkippedFibers} skipped, slots ${report.slotsMatched}/${report.slotsMatched + report.slotsUnmatched})`,

--- a/packages/parser/src/evaluate/builtin-calls.ts
+++ b/packages/parser/src/evaluate/builtin-calls.ts
@@ -831,7 +831,7 @@ const callGlobal = (
       const source =
         first?.kind === "object" ? (getCollectionItems(first) ?? arrayLikeToList(first)) : first;
       if (source?.kind === "list" || source?.kind === "repeat") {
-        if (isCallable(second)) return mapList(interpreter, source, second, context);
+        if (isCallable(second)) return mapList(interpreter, source, second, context, location);
         return source;
       }
       return unknownValue("Array.from of dynamic iterable", location);
@@ -848,7 +848,9 @@ const callGlobal = (
       const source =
         first?.kind === "object" ? (getCollectionItems(first) ?? arrayLikeToList(first)) : first;
       if (source?.kind !== "list") return unknownValue(`${name} of dynamic iterable`, location);
-      const mapped = isCallable(second) ? mapList(interpreter, source, second, context) : source;
+      const mapped = isCallable(second)
+        ? mapList(interpreter, source, second, context, location)
+        : source;
       return mapped.kind === "list"
         ? (binaryFromItems(name.slice(0, -".from".length), mapped.items) ?? mapped)
         : mapped;
@@ -1138,7 +1140,7 @@ const MAX_ARRAY_LIKE_LENGTH = 1_000;
 
 const arrayOfLength = (length: StaticValue, location: SourceLocation | null): StaticValue => {
   if (length.kind === "unknown-primitive" && length.primitiveType === "number")
-    return { kind: "repeat", item: UNDEFINED_VALUE, location };
+    return { kind: "repeat", item: UNDEFINED_VALUE, location, count: length.numberRange };
   if (length.kind === "unknown" || length.kind === "branch")
     return unknownValue("Array() with a dynamic length", location);
   if (length.kind !== "primitive" || typeof length.value !== "number") return listValue([length]);
@@ -1328,6 +1330,7 @@ const mapList = (
   receiver: StaticValue,
   callback: CallableValue,
   context: EvaluationContext,
+  location: SourceLocation | null,
 ): StaticValue => {
   if (receiver.kind === "list") {
     return listValue(
@@ -1342,6 +1345,7 @@ const mapList = (
               context,
             ),
             location: item.location,
+            count: item.count,
           };
         }
         if (item.kind === "optional") {
@@ -1375,6 +1379,7 @@ const mapList = (
         context,
       ),
       location: receiver.location,
+      count: receiver.count,
     };
   }
   return {
@@ -1389,7 +1394,7 @@ const mapList = (
       ],
       context,
     ),
-    location: null,
+    location,
   };
 };
 
@@ -1815,7 +1820,9 @@ export const evaluateBuiltinCall = (
     if (shaped) return shaped;
   }
 
-  if (name === "map" && isCallable(first)) return mapList(interpreter, receiver, first, context);
+  if (name === "map" && isCallable(first)) {
+    return mapList(interpreter, receiver, first, context, location);
+  }
 
   if (name === "forEach" && isCallable(first)) {
     if (receiver.kind === "list") {
@@ -1845,7 +1852,7 @@ export const evaluateBuiltinCall = (
   }
 
   if (name === "flatMap" && isCallable(first)) {
-    const mapped = mapList(interpreter, receiver, first, context);
+    const mapped = mapList(interpreter, receiver, first, context, location);
     if (mapped.kind === "list") {
       return listValue(mapped.items.flatMap((item) => flattenOneLevel(item, location)));
     }

--- a/packages/parser/src/evaluate/heap-journal.ts
+++ b/packages/parser/src/evaluate/heap-journal.ts
@@ -95,7 +95,12 @@ export class HeapJournal {
     this.paths.push(path);
   }
 
-  join(reason: string, location: SourceLocation | null, preferredPath: number): void {
+  join(
+    reason: string,
+    location: SourceLocation | null,
+    preferredPath: number,
+    predicate: string | null,
+  ): void {
     for (const [values, originals] of this.bindings) {
       for (const [name, original] of originals) {
         const pathValues = this.paths.map(
@@ -105,7 +110,7 @@ export class HeapJournal {
           name,
           pathValues.every((value) => value === pathValues[0])
             ? pathValues[0]
-            : branchValue(pathValues, reason, location, preferredPath),
+            : branchValue(pathValues, reason, location, preferredPath, predicate),
         );
       }
     }
@@ -114,7 +119,7 @@ export class HeapJournal {
       if (isUnchanged(pathEntries, original)) continue;
       object.entries =
         getAgreedState(pathEntries) ??
-        joinObjectEntries(original, pathEntries, reason, location, preferredPath);
+        joinObjectEntries(original, pathEntries, reason, location, preferredPath, predicate);
     }
     for (const [list, original] of this.lists) {
       const pathItems = this.paths.map((path) => path.lists.get(list) ?? original);

--- a/packages/parser/src/evaluate/hooks.ts
+++ b/packages/parser/src/evaluate/hooks.ts
@@ -1,4 +1,5 @@
 import type { StaticNativeFunctionValue, StaticValue } from "../types.js";
+import { getStatePredicate } from "./predicates.js";
 import { areValuesEquivalent, branchValue, compareIdentity, unknownValue } from "./values.js";
 
 export interface StateCell {
@@ -140,6 +141,8 @@ const escapedStateValue = (cell: StateCell): StaticValue =>
     [cell.initial, unknownValue(`updated state of ${cell.name}`)],
     "state setter escapes to code that is not evaluated",
     null,
+    0,
+    getStatePredicate(cell),
   );
 
 /**
@@ -154,6 +157,8 @@ const pendingStateValue = (cell: StateCell): StaticValue | null => {
     [cell.next ?? cell.current, ...cell.deferred],
     "state set by a continuation that may run after the commit",
     null,
+    0,
+    getStatePredicate(cell),
   );
 };
 

--- a/packages/parser/src/evaluate/interpreter.ts
+++ b/packages/parser/src/evaluate/interpreter.ts
@@ -233,6 +233,7 @@ import {
   thrownValue,
   unknownValue,
 } from "./values.js";
+import { createPathPredicate, getTruthinessPredicate, recordNegation } from "./predicates.js";
 
 export interface InterpreterOptions {
   maxCallDepth?: number;
@@ -401,6 +402,12 @@ export const outcomeToReturnValue = (
 const isThrowingOutcome = (outcome: StatementOutcome): boolean =>
   outcome.returned !== null && getThrowCertainty(outcome.returned) === "always";
 
+const isPureReturn = (outcome: StatementOutcome): boolean =>
+  outcome.returned !== null && !outcome.mayComplete && outcome.jump === null;
+
+const isPureCompletion = (outcome: StatementOutcome): boolean =>
+  outcome.returned === null && outcome.mayComplete && outcome.jump === null;
+
 /** A path that certainly throws is never what a rendered tree took; prefer the first path that may produce a value. */
 const getPreferredOutcome = (outcomes: StatementOutcome[], preferredOutcome: number): number => {
   const preferred = outcomes[preferredOutcome];
@@ -419,6 +426,7 @@ export const mergeOutcomes = (
   reason: string,
   location: SourceLocation | null,
   preferredBranch = 0,
+  predicate: string | null = null,
 ): StatementOutcome => {
   const returnedValues: StaticValue[] = [];
   let preferredIndex = 0;
@@ -434,7 +442,13 @@ export const mergeOutcomes = (
   return {
     returned:
       returnedValues.length > 0
-        ? branchValue(returnedValues, reason, location, preferredIndex)
+        ? branchValue(
+            returnedValues,
+            reason,
+            location,
+            preferredIndex,
+            returnedValues.length === outcomes.length ? predicate : null,
+          )
         : null,
     mayComplete: outcomes.some((outcome) => outcome.mayComplete),
     jump: mergeJumps(outcomes),
@@ -1301,6 +1315,7 @@ export class Interpreter {
           `conditional on ${describeValue(test)}`,
           location,
           getPreferredTruthiness(test) === false ? 1 : 0,
+          getTruthinessPredicate(test),
         );
       }
       case "LogicalExpression":
@@ -1534,6 +1549,7 @@ export class Interpreter {
           `&& on ${describeValue(left)}`,
           location,
           getPreferredTruthiness(left) === false ? 1 : 0,
+          getTruthinessPredicate(left),
         );
       }
       case "||": {
@@ -1553,6 +1569,7 @@ export class Interpreter {
           `|| on ${describeValue(left)}`,
           location,
           getPreferredTruthiness(left) === false ? 1 : 0,
+          getTruthinessPredicate(left),
         );
       }
       case "??": {
@@ -3109,6 +3126,7 @@ export class Interpreter {
             `if (${describeValue(test)})`,
             location,
             getPreferredTruthiness(test) === false ? 1 : 0,
+            getTruthinessPredicate(test),
           );
         }
         case "SwitchStatement":
@@ -3262,8 +3280,9 @@ export class Interpreter {
       journal.endPath();
       this.heapJournals.pop();
       const preferredPath = isLikelyRun ? 0 : 1;
-      journal.join(reason, location, preferredPath);
-      joinScopes([ranSnapshot, entrySnapshot], reason, location, preferredPath);
+      const predicate = createPathPredicate();
+      journal.join(reason, location, preferredPath, predicate);
+      joinScopes([ranSnapshot, entrySnapshot], reason, location, preferredPath, predicate);
     }
   }
 
@@ -3281,6 +3300,7 @@ export class Interpreter {
     reason: string,
     location: SourceLocation,
     preferredBranch = 0,
+    predicate = createPathPredicate(),
   ): StatementOutcome {
     const isTooDeep = context.forkDepth >= this.maxForkDepth;
     const forkContext: EvaluationContext = {
@@ -3310,18 +3330,35 @@ export class Interpreter {
     });
     this.heapJournals.pop();
     const preferredOutcome = getPreferredOutcome(outcomes, preferredBranch);
-    journal.join(reason, location, preferredOutcome);
-    if (joinedSnapshots.length > 0) joinScopes(joinedSnapshots, reason, location);
+    journal.join(reason, location, preferredOutcome, predicate);
+    if (joinedSnapshots.length > 0) {
+      joinScopes(
+        joinedSnapshots,
+        reason,
+        location,
+        0,
+        joinedSnapshots.length === branches.length ? predicate : null,
+      );
+    }
     if (!outcomes.some((outcome) => outcome.mayComplete)) {
-      return mergeOutcomes(outcomes, reason, location, preferredOutcome);
+      return mergeOutcomes(
+        outcomes,
+        reason,
+        location,
+        preferredOutcome,
+        outcomes.every(isPureReturn) ? predicate : null,
+      );
     }
     if (context.hooks) context.hooks.cursor = completedHookCursor;
     const rest = proceed(context);
+    const isRestPositional =
+      outcomes.slice(0, -1).every(isPureReturn) && isPureCompletion(outcomes[outcomes.length - 1]);
     return mergeOutcomes(
       [...outcomes.map((outcome) => ({ ...outcome, mayComplete: false })), rest],
       reason,
       location,
       preferredOutcome,
+      isRestPositional ? predicate : null,
     );
   }
 
@@ -3606,7 +3643,8 @@ const joinScopes = (
   paths: ScopeSnapshot[][],
   reason: string,
   location: SourceLocation | null,
-  preferredPath = 0,
+  preferredPath: number,
+  predicate: string | null,
 ): void => {
   const [firstPath, ...otherPaths] = paths;
   firstPath.forEach((snapshot, scopeIndex) => {
@@ -3620,7 +3658,10 @@ const joinScopes = (
       const values = [snapshot.bindings, ...siblings].map(
         (bindings) => bindings.get(name) ?? UNDEFINED_VALUE,
       );
-      snapshot.scope.bindings.set(name, branchValue(values, reason, location, preferredPath));
+      snapshot.scope.bindings.set(
+        name,
+        branchValue(values, reason, location, preferredPath, predicate),
+      );
     }
   });
 };
@@ -3644,7 +3685,9 @@ const applyUnaryOperator = (
   switch (operator) {
     case "!": {
       const truthiness = getTruthiness(argument);
-      if (truthiness === null) return unknownPrimitiveValue("boolean", "negation of unknown");
+      if (truthiness === null) {
+        return recordNegation(unknownPrimitiveValue("boolean", "negation of unknown"), argument);
+      }
       return truthiness ? FALSE_VALUE : TRUE_VALUE;
     }
     case "-":

--- a/packages/parser/src/evaluate/predicates.ts
+++ b/packages/parser/src/evaluate/predicates.ts
@@ -1,0 +1,50 @@
+import type { StaticValue } from "../types.js";
+
+// A branch predicate names the decision that picks an alternative. Two
+// branches over the same decision (the same uncertain value tested twice, both
+// sides of one fork, one state cell) share a predicate, so the state space
+// enumerates them together instead of multiplying them.
+
+const subjectIds = new WeakMap<object, number>();
+let nextSubjectId = 0;
+
+const getSubjectId = (subject: object): number => {
+  const existing = subjectIds.get(subject);
+  if (existing !== undefined) return existing;
+  const id = ++nextSubjectId;
+  subjectIds.set(subject, id);
+  return id;
+};
+
+const negations = new WeakMap<StaticValue, StaticValue>();
+
+/** Records that `negated` is `!operand`, so tests of either take opposite sides. */
+export const recordNegation = (negated: StaticValue, operand: StaticValue): StaticValue => {
+  negations.set(negated, operand);
+  return negated;
+};
+
+const NEGATED_PREFIX = "!";
+
+/** The predicate of a branch whose first alternative is taken when `test` is truthy. */
+export const getTruthinessPredicate = (test: StaticValue): string => {
+  let subject = test;
+  let isNegated = false;
+  for (let operand = negations.get(subject); operand; operand = negations.get(subject)) {
+    subject = operand;
+    isNegated = !isNegated;
+  }
+  return `${isNegated ? NEGATED_PREFIX : ""}truthy(${getSubjectId(subject)})`;
+};
+
+/** The predicate of a two-way branch taking the opposite side of `predicate`. */
+export const getNegatedPredicate = (predicate: string): string =>
+  predicate.startsWith(NEGATED_PREFIX)
+    ? predicate.slice(NEGATED_PREFIX.length)
+    : `${NEGATED_PREFIX}${predicate}`;
+
+/** The predicate of a fork whose paths are decided by something the analysis cannot see. */
+export const createPathPredicate = (): string => `path(${++nextSubjectId})`;
+
+/** The predicate deciding which value a state cell holds in a committed tree. */
+export const getStatePredicate = (cell: object): string => `state(${getSubjectId(cell)})`;

--- a/packages/parser/src/evaluate/values.ts
+++ b/packages/parser/src/evaluate/values.ts
@@ -321,6 +321,7 @@ const lookupObjectProperty = (object: StaticObjectValue, key: string): StaticVal
         spread.reason,
         spread.location,
         spread.preferredIndex,
+        spread.predicate,
       );
     }
     return unknownValue(`property "${key}" may come from a spread of ${describeValue(spread)}`);
@@ -476,6 +477,7 @@ export const joinObjectEntries = (
   reason: string,
   location: SourceLocation | null,
   preferredIndex: number,
+  predicate: string | null,
 ): StaticObjectEntry[] => {
   const isExtension = (entries: StaticObjectEntry[]): boolean =>
     entries.length >= original.length && original.every((entry, index) => entries[index] === entry);
@@ -490,7 +492,10 @@ export const joinObjectEntries = (
       );
       return [
         ...original,
-        { kind: "spread", value: branchValue(alternatives, reason, location, preferredIndex) },
+        {
+          kind: "spread",
+          value: branchValue(alternatives, reason, location, preferredIndex, predicate),
+        },
       ];
     }
     for (const entry of entries) if (entry.kind === "property") keys.add(entry.key);
@@ -509,6 +514,7 @@ export const joinObjectEntries = (
         reason,
         location,
         preferredIndex,
+        predicate,
       ),
     })),
   ];
@@ -895,6 +901,7 @@ export const branchValue = (
   reason: string,
   location: SourceLocation | null = null,
   preferredIndex = 0,
+  predicate: string | null = null,
 ): StaticValue => {
   const flattened: StaticValue[] = [];
   let resolvedPreferred = 0;
@@ -918,12 +925,16 @@ export const branchValue = (
     }
   });
   if (flattened.length === 1) return flattened[0];
+  const isPositional =
+    flattened.length === alternatives.length &&
+    alternatives.every((alternative) => alternative.kind !== "branch");
   return {
     kind: "branch",
     alternatives: flattened,
     preferredIndex: resolvedPreferred,
     reason,
     location,
+    predicate: isPositional ? predicate : null,
   };
 };
 
@@ -1032,6 +1043,7 @@ export const mapValue = (
     value.reason,
     value.location,
     value.preferredIndex,
+    value.predicate,
   );
 };
 
@@ -1089,6 +1101,7 @@ export const spreadListItems = (
           value.reason,
           value.location,
           value.preferredIndex,
+          value.predicate,
         ),
       );
     }

--- a/packages/parser/src/harness/commit-recorder.ts
+++ b/packages/parser/src/harness/commit-recorder.ts
@@ -8,6 +8,8 @@ import type { RuntimeSnapshot } from "./snapshot.js";
 
 export interface CommitRecorder {
   snapshot: () => RuntimeSnapshot;
+  /** The tree after each commit, in commit order (only with `recordCommits`). */
+  commits: () => RuntimeSnapshot[];
   /** Library state held by providers in the live roots, as the page's code reads it. */
   observations: () => Promise<RootObservations>;
   commitCount: () => number;
@@ -22,6 +24,8 @@ export interface CommitRecorderOptions {
   reduxStores?: () => ReduxStoreLike[] | Promise<ReduxStoreLike[]>;
   /** Exports of the page's loaded modules, so captured state names them instead of serializing them. */
   moduleExports?: () => ExportIndex | Promise<ExportIndex>;
+  /** Snapshot the roots after every commit, so intermediate committed trees are kept. */
+  recordCommits?: boolean;
 }
 
 const DEFAULT_COMMIT_TIMEOUT_MS = 5_000;
@@ -37,11 +41,15 @@ export const createCommitRecorder = ({
   rootFilter,
   reduxStores,
   moduleExports,
+  recordCommits = false,
 }: CommitRecorderOptions = {}): CommitRecorder => {
   const roots = new Set<FiberRoot>();
+  const committedSnapshots: RuntimeSnapshot[] = [];
   let renderer: ReactRenderer | null = null;
   let commits = 0;
   let commitWaiters: Array<() => void> = [];
+  const liveRoots = (): FiberRoot[] => [...roots].filter((root) => _fiberRoots.has(root));
+  const snapshot = (): RuntimeSnapshot => createRuntimeSnapshot({ roots: liveRoots(), renderer });
   const unsubscribe = instrument({
     name: "bippy-parser-harness",
     onCommitFiberRoot: (rendererId, root) => {
@@ -49,14 +57,15 @@ export const createCommitRecorder = ({
       roots.add(root);
       renderer = getRDTHook().renderers.get(rendererId) ?? renderer;
       commits++;
+      if (recordCommits) committedSnapshots.push(snapshot());
       const waiters = commitWaiters;
       commitWaiters = [];
       for (const resolve of waiters) resolve();
     },
   });
-  const liveRoots = (): FiberRoot[] => [...roots].filter((root) => _fiberRoots.has(root));
   return {
-    snapshot: () => createRuntimeSnapshot({ roots: liveRoots(), renderer }),
+    snapshot,
+    commits: () => [...committedSnapshots],
     observations: async () =>
       readRootObservations(liveRoots(), await reduxStores?.(), await moduleExports?.()),
     commitCount: () => commits,

--- a/packages/parser/src/harness/compare-render.ts
+++ b/packages/parser/src/harness/compare-render.ts
@@ -1,29 +1,49 @@
 import type { StaticRenderResult } from "../types.js";
-import {
-  comparePatternToRuntime,
-  type ComparisonOptions,
-  type ComparisonReport,
-} from "./compare.js";
+import type { ComparisonOptions, ComparisonReport } from "./compare.js";
+import { formatComparisonReport } from "./format-report.js";
 import { findSnapshotFiber, type RuntimeFiberSnapshot, type RuntimeSnapshot } from "./snapshot.js";
 import {
+  DEFAULT_STATE_SPACE_BUDGET,
+  enumerateStateSpace,
+  matchStateSpace,
+  type ClosestState,
+  type MatchedState,
+  type StateSpaceBudget,
+  type StateSpaceSummary,
+  type StaticStateSpace,
+} from "./state-space.js";
+import {
   flattenPatternFibers,
-  getRenderRootChildren,
+  getSnapshotRootChildren,
   type PatternFiber,
   type PatternNode,
 } from "./static-pattern.js";
 
-export interface CompareRenderOptions extends ComparisonOptions {
+export interface StaticStateSpaceOptions {
   anchor?: string;
-  rootIndex?: number;
   /** Static fibers to splice out before matching (framework wrappers synthesized by a route adapter). */
   transparentStaticFibers?: ReadonlySet<string>;
+  budget?: Partial<StateSpaceBudget>;
+}
+
+export interface CompareRenderOptions extends ComparisonOptions {
+  rootIndex?: number;
+}
+
+export interface StaticRenderStateSpace extends StaticStateSpace {
+  /** The final commit's pattern after anchoring and flattening; what the states were expanded from last. */
+  staticPattern: PatternNode[];
+  anchor: string | null;
+  /** Why no state could be enumerated; `states` is empty then. */
+  unresolved: string | null;
 }
 
 export interface CompareRenderResult {
   report: ComparisonReport;
-  staticPattern: PatternNode[];
+  stateSpace: StaticRenderStateSpace;
+  matchedState: MatchedState | null;
+  closestState: ClosestState | null;
   runtimeSubtree: RuntimeFiberSnapshot[];
-  anchor: string | null;
   note: string | null;
 }
 
@@ -65,8 +85,77 @@ const didMaterializedRenderFail = (staticResult: StaticRenderResult): boolean =>
   staticResult.snapshot.roots.every((root) => root.children.length === 0) &&
   staticResult.diagnostics.some((diagnostic) => diagnostic.code === "render-error");
 
-const skipped = (
+const unresolvedStateSpace = (
   staticPattern: PatternNode[],
+  budget: StateSpaceBudget,
+  unresolved: string,
+): StaticRenderStateSpace => ({
+  states: [],
+  budget,
+  omitted: null,
+  commits: [],
+  staticPattern,
+  anchor: null,
+  unresolved,
+});
+
+/**
+ * Enumerates the concrete trees the static render can produce: every commit
+ * React made while the materialized tree settled, expanded over every
+ * assignment of its branch and repeat decisions within the budget.
+ */
+export const enumerateStaticStates = (
+  staticResult: StaticRenderResult,
+  options: StaticStateSpaceOptions = {},
+): StaticRenderStateSpace => {
+  const budget = { ...DEFAULT_STATE_SPACE_BUDGET, ...options.budget };
+  const transparent = options.transparentStaticFibers ?? new Set<string>();
+  const rootPattern = getSnapshotRootChildren(staticResult.snapshot);
+  const staticChildren = flattenPatternFibers(rootPattern, transparent);
+  if (isStaticRootUnresolved(rootPattern)) {
+    return unresolvedStateSpace(
+      staticChildren,
+      budget,
+      "static render did not resolve to a component tree",
+    );
+  }
+  if (didMaterializedRenderFail(staticResult)) {
+    return unresolvedStateSpace(
+      staticChildren,
+      budget,
+      "React failed to render the materialized tree",
+    );
+  }
+  const commits = (staticResult.commits.length > 0 ? staticResult.commits : [staticResult.snapshot])
+    .map((commit) => flattenPatternFibers(getSnapshotRootChildren(commit), transparent))
+    .filter((pattern) => pattern.length > 0);
+  const anchor = options.anchor ?? null;
+  const anchoredCommits =
+    anchor === null
+      ? commits
+      : commits.flatMap((pattern) => {
+          const staticAnchor = findPatternFiber(pattern, (fiber) => fiber.name === anchor);
+          return staticAnchor ? [[staticAnchor]] : [];
+        });
+  if (anchoredCommits.length === 0) {
+    return unresolvedStateSpace(
+      staticChildren,
+      budget,
+      anchor === null
+        ? "static render committed no fibers"
+        : `anchor <${anchor}> not found in static tree`,
+    );
+  }
+  return {
+    ...enumerateStateSpace(anchoredCommits, budget),
+    staticPattern: anchoredCommits[anchoredCommits.length - 1],
+    anchor,
+    unresolved: null,
+  };
+};
+
+const skipped = (
+  stateSpace: StaticRenderStateSpace,
   note: string,
   status: "unresolved" | "skipped",
 ): CompareRenderResult => ({
@@ -80,7 +169,6 @@ const skipped = (
     slotsUnmatched: 0,
     opaqueRenamed: 0,
     unmatchedSlots: [],
-    branchDeviations: [],
     wildcardAbsorbedFibers: 0,
     wildcards: [],
     branchesResolved: 0,
@@ -93,9 +181,10 @@ const skipped = (
     stepsUsed: 0,
     budgetExhausted: false,
   },
-  staticPattern,
+  stateSpace,
+  matchedState: null,
+  closestState: null,
   runtimeSubtree: [],
-  anchor: null,
   note,
 });
 
@@ -112,10 +201,10 @@ const countFibers = (fibers: RuntimeFiberSnapshot[]): number => {
  */
 const chooseRuntimeRoot = (
   runtime: RuntimeSnapshot,
+  anchor: string | null,
   options: CompareRenderOptions,
 ): RuntimeFiberSnapshot | null => {
   if (options.rootIndex !== undefined) return runtime.roots[options.rootIndex] ?? null;
-  const anchor = options.anchor;
   if (anchor) {
     const anchored = runtime.roots.find(
       (root) =>
@@ -136,55 +225,50 @@ const chooseRuntimeRoot = (
   return largest;
 };
 
+/** Checks the runtime tree for membership in the enumerated state space. */
 export const compareStaticToRuntime = (
-  staticResult: StaticRenderResult,
+  stateSpace: StaticRenderStateSpace,
   runtime: RuntimeSnapshot,
   options: CompareRenderOptions = {},
 ): CompareRenderResult => {
-  const rootPattern = getRenderRootChildren(staticResult);
-  const staticChildren = flattenPatternFibers(
-    rootPattern,
-    options.transparentStaticFibers ?? new Set(),
-  );
-  if (isStaticRootUnresolved(rootPattern)) {
-    return skipped(
-      staticChildren,
-      "static render did not resolve to a component tree",
-      "unresolved",
-    );
-  }
-  if (didMaterializedRenderFail(staticResult)) {
-    return skipped(staticChildren, "React failed to render the materialized tree", "unresolved");
-  }
-  const runtimeRoot = chooseRuntimeRoot(runtime, options);
+  if (stateSpace.unresolved !== null)
+    return skipped(stateSpace, stateSpace.unresolved, "unresolved");
+  const runtimeRoot = chooseRuntimeRoot(runtime, stateSpace.anchor, options);
   if (!runtimeRoot)
-    return skipped(staticChildren, "runtime snapshot has no committed roots", "skipped");
+    return skipped(stateSpace, "runtime snapshot has no committed roots", "skipped");
 
-  if (options.anchor) {
-    const anchor = options.anchor;
-    const staticAnchor = findPatternFiber(staticChildren, (fiber) => fiber.name === anchor);
+  let runtimeSubtree = runtimeRoot.children;
+  if (stateSpace.anchor !== null) {
+    const anchor = stateSpace.anchor;
     const runtimeAnchor = findSnapshotFiber(
       runtimeRoot,
       (fiber) => fiber.name === anchor && fiber.tag !== "HostText",
     );
-    if (!staticAnchor)
-      return skipped(staticChildren, `anchor <${anchor}> not found in static tree`, "unresolved");
     if (!runtimeAnchor)
-      return skipped(staticChildren, `anchor <${anchor}> not found in runtime tree`, "skipped");
-    return {
-      report: comparePatternToRuntime([staticAnchor], [runtimeAnchor], options),
-      staticPattern: [staticAnchor],
-      runtimeSubtree: [runtimeAnchor],
-      anchor,
-      note: null,
-    };
+      return skipped(stateSpace, `anchor <${anchor}> not found in runtime tree`, "skipped");
+    runtimeSubtree = [runtimeAnchor];
   }
-
+  const match = matchStateSpace(stateSpace, runtimeSubtree, options);
   return {
-    report: comparePatternToRuntime(staticChildren, runtimeRoot.children, options),
-    staticPattern: staticChildren,
-    runtimeSubtree: runtimeRoot.children,
-    anchor: null,
+    report: match.report,
+    stateSpace,
+    matchedState: match.matched,
+    closestState: match.closest,
+    runtimeSubtree,
     note: null,
   };
 };
+
+export const summarizeStateSpace = (comparison: CompareRenderResult): StateSpaceSummary => ({
+  states: comparison.stateSpace.states.length,
+  matchedState: comparison.matchedState,
+  closestState: comparison.closestState,
+  omitted: comparison.stateSpace.omitted,
+});
+
+export const formatCompareRenderResult = (comparison: CompareRenderResult): string =>
+  formatComparisonReport(
+    comparison.report,
+    summarizeStateSpace(comparison),
+    comparison.stateSpace.states,
+  );

--- a/packages/parser/src/harness/compare.ts
+++ b/packages/parser/src/harness/compare.ts
@@ -1,12 +1,28 @@
 import { countSnapshotFibers, type RuntimeFiberSnapshot } from "./snapshot.js";
 import {
   countPatternFibers,
+  formatRepeatBounds,
+  scopePatternVariables,
+  type PatternBranch,
   type PatternFiber,
   type PatternNode,
   type PatternOpaque,
+  type PatternRepeat,
 } from "./static-pattern.js";
 
-export type ComparisonStatus = "exact" | "partial" | "mismatch" | "unresolved" | "skipped";
+/**
+ * `exact`: the runtime tree is one enumerated state and no state was left out.
+ * `truncated`: it is one enumerated state (or lies in the omitted region), but
+ * the state space was bounded. `partial`: it matches only by letting wildcards
+ * or opaque subtrees stand in for runtime fibers.
+ */
+export type ComparisonStatus =
+  | "exact"
+  | "truncated"
+  | "partial"
+  | "mismatch"
+  | "unresolved"
+  | "skipped";
 
 // esbuild lowers `class X { static … }` to `var _a; _a = class {…}`, so pre-bundled
 // library components can surface as `_a`, `_a2`, … with no identity to compare.
@@ -54,14 +70,10 @@ export interface UnmatchedSlot {
   divergence: ComparisonDivergence | null;
 }
 
-/** A branch matched by an alternative other than the one the evaluator expected. */
-export interface BranchDeviation {
-  path: string;
-  reason: string;
-  preferredIndex: number;
-  chosenIndex: number;
-  /** Where the preferred alternative stopped matching. */
-  divergence: ComparisonDivergence | null;
+/** The alternative (branch) or cardinality (repeat) a decision variable took to match. */
+export interface MatchDecision {
+  node: PatternBranch | PatternRepeat;
+  choice: number;
 }
 
 export interface ComparisonTally {
@@ -79,8 +91,11 @@ export interface ComparisonTally {
   wildcardAbsorbedFibers: number;
   wildcards: WildcardAbsorption[];
   branchesResolved: number;
-  branchDeviations: BranchDeviation[];
   repeatIterations: number;
+}
+
+interface MatchTally extends ComparisonTally {
+  decisions: MatchDecision[];
 }
 
 export interface ComparisonReport extends ComparisonTally {
@@ -101,7 +116,7 @@ const DEFAULT_MAX_STEPS = 200_000;
 // layers; deeper slot searches would start matching unrelated subtrees.
 const MAX_SLOT_SEARCH_DEPTH = 12;
 
-const EMPTY_TALLY: ComparisonTally = {
+const EMPTY_TALLY: MatchTally = {
   matchedFibers: 0,
   matchedText: 0,
   opaqueSubtrees: 0,
@@ -113,11 +128,11 @@ const EMPTY_TALLY: ComparisonTally = {
   wildcardAbsorbedFibers: 0,
   wildcards: [],
   branchesResolved: 0,
-  branchDeviations: [],
   repeatIterations: 0,
+  decisions: [],
 };
 
-const addTally = (left: ComparisonTally, right: Partial<ComparisonTally>): ComparisonTally => ({
+const addTally = (left: MatchTally, right: Partial<MatchTally>): MatchTally => ({
   matchedFibers: left.matchedFibers + (right.matchedFibers ?? 0),
   matchedText: left.matchedText + (right.matchedText ?? 0),
   opaqueSubtrees: left.opaqueSubtrees + (right.opaqueSubtrees ?? 0),
@@ -131,23 +146,23 @@ const addTally = (left: ComparisonTally, right: Partial<ComparisonTally>): Compa
   wildcardAbsorbedFibers: left.wildcardAbsorbedFibers + (right.wildcardAbsorbedFibers ?? 0),
   wildcards: right.wildcards ? [...right.wildcards, ...left.wildcards] : left.wildcards,
   branchesResolved: left.branchesResolved + (right.branchesResolved ?? 0),
-  branchDeviations: right.branchDeviations
-    ? [...right.branchDeviations, ...left.branchDeviations]
-    : left.branchDeviations,
   repeatIterations: left.repeatIterations + (right.repeatIterations ?? 0),
+  decisions: right.decisions ? [...right.decisions, ...left.decisions] : left.decisions,
 });
 
 interface Continuation {
-  (runtimeIndex: number): ComparisonTally | null;
+  (runtimeIndex: number): MatchTally | null;
 }
 
-interface FurthestFailure {
+/** Where matching got furthest before failing, with the decisions in force there. */
+export interface FurthestFailure {
   position: number;
   divergence: ComparisonDivergence;
+  assignment: Map<string, number>;
 }
 
 interface SlotMatch {
-  tally: ComparisonTally;
+  tally: MatchTally;
   consumedFibers: number;
 }
 
@@ -157,7 +172,7 @@ interface Attempt<Result> {
 }
 
 interface RankedAlternative {
-  tally: ComparisonTally;
+  tally: MatchTally;
   index: number;
 }
 
@@ -196,7 +211,7 @@ export const describePatternNode = (node: PatternNode): string => {
     case "branch":
       return `?branch(${node.reason})`;
     case "repeat":
-      return "*repeat";
+      return `*repeat(${formatRepeatBounds(node.count)})`;
     case "opaque":
       return `<${node.name}> (opaque)`;
     case "wildcard":
@@ -250,6 +265,9 @@ class Matcher {
   private steps = 0;
   private readonly furthest: (FurthestFailure | null)[] = [null];
   private positions: RuntimePositions = { start: new Map(), end: new Map() };
+  /** Decisions in force on the path being tried; a variable met again must agree. */
+  private readonly assignment = new Map<string, number>();
+  private readonly scopedRepeatChildren = new Map<PatternRepeat, PatternNode[][]>();
   private readonly compareKeys: boolean;
   private readonly compareTags: boolean;
   private readonly compareText: boolean;
@@ -266,8 +284,8 @@ class Matcher {
     return this.steps;
   }
 
-  get divergence(): ComparisonDivergence | null {
-    return this.furthest[this.furthest.length - 1]?.divergence ?? null;
+  get failure(): FurthestFailure | null {
+    return this.furthest[this.furthest.length - 1];
   }
 
   indexRuntime(roots: RuntimeFiberSnapshot[]): void {
@@ -293,6 +311,7 @@ class Matcher {
         expected: expected ? describePatternNode(expected) : "<end of children>",
         actual: describeRuntimeFiber(actual),
       },
+      assignment: new Map(this.assignment),
     };
   }
 
@@ -311,13 +330,6 @@ class Matcher {
     }
   }
 
-  private recordFurthest(failure: FurthestFailure | null): void {
-    if (!failure) return;
-    const level = this.furthest.length - 1;
-    const current = this.furthest[level];
-    if (!current || failure.position > current.position) this.furthest[level] = failure;
-  }
-
   matchList(
     patterns: PatternNode[],
     index: number,
@@ -325,7 +337,7 @@ class Matcher {
     runtimeIndex: number,
     path: string[],
     continuation: Continuation,
-  ): ComparisonTally | null {
+  ): MatchTally | null {
     if (index === patterns.length) return continuation(runtimeIndex);
     return this.matchNode(patterns[index], runtime, runtimeIndex, path, (nextIndex) =>
       this.matchList(patterns, index + 1, runtime, nextIndex, path, continuation),
@@ -338,7 +350,7 @@ class Matcher {
     runtimeIndex: number,
     path: string[],
     continuation: Continuation,
-  ): ComparisonTally | null {
+  ): MatchTally | null {
     this.tick();
     const actual = runtime[runtimeIndex];
     switch (pattern.kind) {
@@ -347,13 +359,20 @@ class Matcher {
           this.recordFailure(path, runtime, runtimeIndex, pattern);
           return null;
         }
-        const childTally = this.matchChildren(pattern, actual, [
-          ...path,
-          describePatternNode(pattern),
-        ]);
-        if (!childTally) return null;
-        const rest = continuation(runtimeIndex + 1);
-        return rest ? addTally(addTally(rest, childTally), { matchedFibers: 1 }) : null;
+        const childPath = [...path, describePatternNode(pattern)];
+        const tally = this.matchList(
+          pattern.children,
+          0,
+          actual.children,
+          0,
+          childPath,
+          (nextIndex) => {
+            if (nextIndex === actual.children.length) return continuation(runtimeIndex + 1);
+            this.recordFailure(childPath, actual.children, nextIndex, null);
+            return null;
+          },
+        );
+        return tally ? addTally(tally, { matchedFibers: 1 }) : null;
       }
       case "text": {
         if (
@@ -374,7 +393,7 @@ class Matcher {
         }
         const rest = continuation(runtimeIndex + 1);
         if (!rest) return null;
-        const head: Partial<ComparisonTally> = {
+        const head: Partial<MatchTally> = {
           opaqueSubtrees: 1,
           opaqueRenamed: this.opaqueNameAgrees(pattern, actual) ? 0 : 1,
         };
@@ -433,43 +452,39 @@ class Matcher {
         return null;
       }
       case "branch": {
+        const decided = this.assignment.get(pattern.variable);
+        if (decided !== undefined) {
+          const alternative = pattern.alternatives[decided];
+          if (!alternative) {
+            this.recordFailure(path, runtime, runtimeIndex, pattern);
+            return null;
+          }
+          return this.matchList(alternative, 0, runtime, runtimeIndex, path, continuation);
+        }
         const order = pattern.alternatives.map((_, alternativeIndex) => alternativeIndex);
         if (pattern.preferredIndex !== null && pattern.preferredIndex < order.length) {
           order.splice(order.indexOf(pattern.preferredIndex), 1);
           order.unshift(pattern.preferredIndex);
         }
-        let preferredDivergence: ComparisonDivergence | null = null;
-        const resolve = (result: ComparisonTally, chosenIndex: number): ComparisonTally =>
-          addTally(result, {
-            branchesResolved: 1,
-            branchDeviations:
-              pattern.preferredIndex !== null && chosenIndex !== pattern.preferredIndex
-                ? [
-                    {
-                      path: path.join(" > "),
-                      reason: pattern.reason,
-                      preferredIndex: pattern.preferredIndex,
-                      chosenIndex,
-                      divergence: preferredDivergence,
-                    },
-                  ]
-                : [],
-          });
+        const resolve = (result: MatchTally, choice: number): MatchTally =>
+          addTally(result, { branchesResolved: 1, decisions: [{ node: pattern, choice }] });
         // Alternatives are tried in preference order, but one that explains the
         // runtime without leaning on wildcards beats an earlier one that does.
         let best: RankedAlternative | null = null;
         for (const alternativeIndex of order) {
-          const alternative = pattern.alternatives[alternativeIndex];
-          const run = (): ComparisonTally | null =>
-            this.matchList(alternative, 0, runtime, runtimeIndex, path, continuation);
-          let result: ComparisonTally | null;
-          if (alternativeIndex === pattern.preferredIndex) {
-            const attempt = this.attempt(run);
-            this.recordFurthest(attempt.failure);
-            result = attempt.result;
-            if (!result) preferredDivergence = attempt.failure?.divergence ?? null;
-          } else {
-            result = run();
+          this.assignment.set(pattern.variable, alternativeIndex);
+          let result: MatchTally | null;
+          try {
+            result = this.matchList(
+              pattern.alternatives[alternativeIndex],
+              0,
+              runtime,
+              runtimeIndex,
+              path,
+              continuation,
+            );
+          } finally {
+            this.assignment.delete(pattern.variable);
           }
           if (!result) continue;
           if (result.wildcardAbsorbedFibers === 0) return resolve(result, alternativeIndex);
@@ -480,18 +495,48 @@ class Matcher {
         return best ? resolve(best.tally, best.index) : null;
       }
       case "repeat": {
-        const iterate = (start: number): ComparisonTally | null => {
-          const more = this.matchList(pattern.children, 0, runtime, start, path, (nextIndex) => {
-            if (nextIndex === start) return null;
-            const rest = iterate(nextIndex);
-            return rest ? addTally(rest, { repeatIterations: 1 }) : null;
-          });
+        // Longest run first; every iteration gets its own copies of the
+        // decision variables inside, as each item decides for itself.
+        const iterate = (start: number, iteration: number): MatchTally | null => {
+          const canIterate = pattern.count.max === null || iteration < pattern.count.max;
+          const more = canIterate
+            ? this.matchList(
+                this.iterationChildren(pattern, iteration),
+                0,
+                runtime,
+                start,
+                path,
+                (nextIndex) => (nextIndex === start ? null : iterate(nextIndex, iteration + 1)),
+              )
+            : null;
           if (more) return more;
-          return continuation(start);
+          if (iteration < pattern.count.min) {
+            this.recordFailure(path, runtime, start, pattern);
+            return null;
+          }
+          const rest = continuation(start);
+          return rest
+            ? addTally(rest, {
+                repeatIterations: iteration,
+                decisions: [{ node: pattern, choice: iteration }],
+              })
+            : null;
         };
-        return iterate(runtimeIndex);
+        return iterate(runtimeIndex, 0);
       }
     }
+  }
+
+  private iterationChildren(pattern: PatternRepeat, iteration: number): PatternNode[] {
+    let iterations = this.scopedRepeatChildren.get(pattern);
+    if (!iterations) {
+      iterations = [];
+      this.scopedRepeatChildren.set(pattern, iterations);
+    }
+    for (let index = iterations.length; index <= iteration; index++) {
+      iterations.push(scopePatternVariables(pattern.children, `${pattern.variable}[${index}]`));
+    }
+    return iterations[iteration];
   }
 
   private headMatches(pattern: PatternFiber, actual: RuntimeFiberSnapshot): boolean {
@@ -579,38 +624,33 @@ class Matcher {
     });
     return tally ? { tally, consumedFibers } : null;
   }
-
-  private matchChildren(
-    pattern: PatternFiber,
-    actual: RuntimeFiberSnapshot,
-    path: string[],
-  ): ComparisonTally | null {
-    return this.matchList(pattern.children, 0, actual.children, 0, path, (nextIndex) => {
-      if (nextIndex === actual.children.length) return EMPTY_TALLY;
-      this.recordFailure(path, actual.children, nextIndex, null);
-      return null;
-    });
-  }
 }
 
 const classify = (tally: ComparisonTally): ComparisonStatus =>
-  tally.opaqueSubtrees === 0 &&
-  tally.wildcardAbsorbedFibers === 0 &&
-  tally.branchesResolved === 0 &&
-  tally.repeatIterations === 0
-    ? "exact"
-    : "partial";
+  tally.opaqueSubtrees === 0 && tally.wildcardAbsorbedFibers === 0 ? "exact" : "partial";
 
-export const comparePatternToRuntime = (
+export interface PatternMatch {
+  report: ComparisonReport;
+  /** The decisions that selected the matching concrete tree; empty when nothing matched. */
+  decisions: MatchDecision[];
+  failure: FurthestFailure | null;
+}
+
+/**
+ * Finds an assignment of the pattern's decision variables under which the
+ * pattern equals the runtime tree, backtracking through alternatives and
+ * repeat counts. Variables met twice must take the same value both times.
+ */
+export const matchPatternToRuntime = (
   patterns: PatternNode[],
   runtime: RuntimeFiberSnapshot[],
   options: ComparisonOptions = {},
-): ComparisonReport => {
+): PatternMatch => {
   const matcher = new Matcher(options);
   matcher.indexRuntime(runtime);
   const runtimeFibers = runtime.reduce((sum, fiber) => sum + countSnapshotFibers(fiber), 0);
   const staticFibers = patterns.reduce((sum, node) => sum + countPatternFibers(node), 0);
-  let tally: ComparisonTally | null = null;
+  let tally: MatchTally | null = null;
   let budgetExhausted = false;
   try {
     tally = matcher.matchList(patterns, 0, runtime, 0, ["root"], (nextIndex) => {
@@ -622,22 +662,33 @@ export const comparePatternToRuntime = (
     if (!(error instanceof BudgetExceeded)) throw error;
     budgetExhausted = true;
   }
-  const base = tally ?? EMPTY_TALLY;
+  const { decisions, ...base } = tally ?? EMPTY_TALLY;
   const denominator = Math.max(
     1,
     runtimeFibers - base.opaqueSkippedFibers - base.wildcardAbsorbedFibers,
   );
+  const failure = tally ? null : matcher.failure;
   return {
-    ...base,
-    status: tally ? classify(tally) : "mismatch",
-    runtimeFibers,
-    staticFibers,
-    coverage: tally ? (base.matchedFibers + base.matchedText) / denominator : 0,
-    strictCoverage: tally
-      ? (base.matchedFibers + base.matchedText) / Math.max(1, runtimeFibers)
-      : 0,
-    divergence: tally ? null : matcher.divergence,
-    stepsUsed: matcher.stepsUsed,
-    budgetExhausted,
+    report: {
+      ...base,
+      status: tally ? classify(tally) : "mismatch",
+      runtimeFibers,
+      staticFibers,
+      coverage: tally ? (base.matchedFibers + base.matchedText) / denominator : 0,
+      strictCoverage: tally
+        ? (base.matchedFibers + base.matchedText) / Math.max(1, runtimeFibers)
+        : 0,
+      divergence: failure?.divergence ?? null,
+      stepsUsed: matcher.stepsUsed,
+      budgetExhausted,
+    },
+    decisions,
+    failure,
   };
 };
+
+export const comparePatternToRuntime = (
+  patterns: PatternNode[],
+  runtime: RuntimeFiberSnapshot[],
+  options: ComparisonOptions = {},
+): ComparisonReport => matchPatternToRuntime(patterns, runtime, options).report;

--- a/packages/parser/src/harness/format-report.ts
+++ b/packages/parser/src/harness/format-report.ts
@@ -1,10 +1,16 @@
 import type { ComparisonDivergence, ComparisonReport, WildcardAbsorption } from "./compare.js";
+import type {
+  StateCondition,
+  StateOmission,
+  StateSpaceSummary,
+  StaticState,
+} from "./state-space.js";
 
 const percent = (value: number): string => `${(value * 100).toFixed(1)}%`;
 
 const MAX_REPORTED_WILDCARDS = 5;
 const MAX_REPORTED_HEADS = 3;
-const MAX_REPORTED_DEVIATIONS = 5;
+const MAX_REPORTED_STATES = 8;
 const MAX_PATH_SEGMENTS = 6;
 
 const shortenPath = (path: string): string => {
@@ -30,13 +36,83 @@ const formatWildcard = (wildcard: WildcardAbsorption): string => {
   return `  ${wildcard.absorbedFibers} fibers ?unknown(${wildcard.reason}) at ${shortenPath(wildcard.path)}: ${heads}${more}`;
 };
 
-export const formatComparisonReport = (report: ComparisonReport): string => {
+const formatLocation = (location: string | null): string => (location ? ` @${location}` : "");
+
+export const formatStateCondition = (condition: StateCondition): string => {
+  switch (condition.kind) {
+    case "branch":
+    case "state-update":
+      return `${condition.kind}(${condition.reason})${formatLocation(condition.location)} = |${condition.alternativeIndex} of ${condition.alternativeCount}`;
+    case "repeat":
+      return `repeat${formatLocation(condition.location)} = ×${condition.count}`;
+    case "transition":
+      return `commit ${condition.commit + 1} of ${condition.commitCount}`;
+  }
+};
+
+export const formatStateConditions = (conditions: StateCondition[]): string =>
+  conditions.length === 0 ? "(unconditional)" : conditions.map(formatStateCondition).join(", ");
+
+const formatOmissionScope = (conditions: StateCondition[]): string =>
+  conditions.length === 0 ? "" : ` under ${formatStateConditions(conditions)}`;
+
+const formatOmission = (omission: StateOmission): string => {
+  switch (omission.kind) {
+    case "branch":
+      return `branch(${omission.reason})${formatLocation(omission.location)} alternative |${omission.alternativeIndex} not expanded${formatOmissionScope(omission.conditions)} (state budget)`;
+    case "repeat":
+      return `repeat${formatLocation(omission.location)} counts above ×${omission.countsAbove} not enumerated${formatOmissionScope(omission.conditions)} (${omission.max === null ? "unbounded" : `up to ×${omission.max}`}${omission.conditions.length === 0 ? "" : ", state budget"})`;
+    case "state":
+      return `state ${formatStateConditions(omission.conditions)} not recorded (state budget)`;
+    case "subtree":
+      return `subtree not materialized: ${omission.reason}`;
+  }
+};
+
+export const formatStateSpaceSummary = (
+  summary: StateSpaceSummary,
+  states: StaticState[] = [],
+): string[] => {
+  const lines = [`states: ${summary.states}${summary.omitted ? " (incomplete)" : ""}`];
+  if (summary.matchedState) {
+    const { index, conditions } = summary.matchedState;
+    lines.push(
+      `matched state: ${index === null ? "outside the enumerated set" : `#${index + 1}`} ${formatStateConditions(conditions)}`,
+    );
+  }
+  if (summary.closestState) {
+    lines.push(
+      `closest state: #${summary.closestState.index + 1} ${formatStateConditions(states[summary.closestState.index]?.conditions ?? [])}`,
+    );
+    lines.push(`  diverged at ${formatDivergence(summary.closestState.divergence)}`);
+  }
+  const unobserved = states.filter((_, index) => index !== summary.matchedState?.index);
+  if (unobserved.length > 0) {
+    lines.push(`unobserved states (${unobserved.length}):`);
+    for (const state of unobserved.slice(0, MAX_REPORTED_STATES))
+      lines.push(`  ${formatStateConditions(state.conditions)}`);
+    if (unobserved.length > MAX_REPORTED_STATES)
+      lines.push(`  … and ${unobserved.length - MAX_REPORTED_STATES} more`);
+  }
+  if (summary.omitted) {
+    lines.push(`omitted (${summary.omitted.omissions.length}):`);
+    for (const omission of summary.omitted.omissions) lines.push(`  ${formatOmission(omission)}`);
+  }
+  return lines;
+};
+
+export const formatComparisonReport = (
+  report: ComparisonReport,
+  stateSpace: StateSpaceSummary | null = null,
+  states: StaticState[] = [],
+): string => {
   const lines = [
     `status: ${report.status}`,
     `coverage: ${percent(report.coverage)} (${report.matchedFibers} fibers + ${report.matchedText} text of ${report.runtimeFibers} runtime nodes; ${report.staticFibers} static)`,
     `uncertainty: branches=${report.branchesResolved} repeats=${report.repeatIterations} opaque=${report.opaqueSubtrees} (${report.opaqueSkippedFibers} skipped, ${report.opaqueRenamed} renamed, slots ${report.slotsMatched} matched/${report.slotsUnmatched} unmatched) wildcard=${report.wildcardAbsorbedFibers}`,
     `steps: ${report.stepsUsed}${report.budgetExhausted ? " (budget exhausted)" : ""}`,
   ];
+  if (stateSpace) lines.push(...formatStateSpaceSummary(stateSpace, states));
   if (report.divergence) lines.push(`divergence at ${formatDivergence(report.divergence)}`);
   if (report.wildcards.length > 0) {
     lines.push("largest wildcards:");
@@ -50,18 +126,6 @@ export const formatComparisonReport = (report: ComparisonReport): string => {
         `  ${slot.skippedFibers} fibers under ${slot.head} at ${shortenPath(slot.path)} (${slot.reason})`,
       );
       if (slot.divergence) lines.push(`    furthest: ${formatDivergence(slot.divergence)}`);
-    }
-  }
-  if (report.branchDeviations.length > 0) {
-    lines.push(
-      `branches resolved against the preferred alternative (${report.branchDeviations.length}):`,
-    );
-    for (const deviation of report.branchDeviations.slice(0, MAX_REPORTED_DEVIATIONS)) {
-      lines.push(
-        `  ?branch(${deviation.reason}) took |${deviation.chosenIndex} over |${deviation.preferredIndex} at ${shortenPath(deviation.path)}`,
-      );
-      if (deviation.divergence)
-        lines.push(`    preferred failed at ${formatDivergence(deviation.divergence)}`);
     }
   }
   return lines.join("\n");

--- a/packages/parser/src/harness/index.ts
+++ b/packages/parser/src/harness/index.ts
@@ -16,4 +16,9 @@ export {
 export * from "./static-pattern.js";
 export * from "./compare.js";
 export * from "./compare-render.js";
-export { formatComparisonReport } from "./format-report.js";
+export * from "./state-space.js";
+export {
+  formatComparisonReport,
+  formatStateCondition,
+  formatStateConditions,
+} from "./format-report.js";

--- a/packages/parser/src/harness/state-space.ts
+++ b/packages/parser/src/harness/state-space.ts
@@ -1,0 +1,500 @@
+import {
+  matchPatternToRuntime,
+  type ComparisonDivergence,
+  type ComparisonOptions,
+  type ComparisonReport,
+  type ComparisonStatus,
+  type MatchDecision,
+  type PatternMatch,
+} from "./compare.js";
+import type { RuntimeFiberSnapshot } from "./snapshot.js";
+import {
+  scopePatternVariables,
+  type PatternBranch,
+  type PatternNode,
+  type PatternRepeat,
+} from "./static-pattern.js";
+
+// A static render describes a set of concrete fiber trees, one per assignment
+// of its decision variables (branches, repeat counts) per committed render.
+// The set is enumerated here, bounded by a budget, and every state left out is
+// recorded so the enumeration is never mistaken for complete.
+
+/** A branch predicate took one alternative; `state-update` when the predicate is a state cell's value. */
+export interface BranchCondition {
+  kind: "branch" | "state-update";
+  variable: string;
+  reason: string;
+  location: string | null;
+  alternativeIndex: number;
+  alternativeCount: number;
+}
+
+export interface RepeatCondition {
+  kind: "repeat";
+  variable: string;
+  location: string | null;
+  count: number;
+}
+
+/** The tree is the one React committed at `commit` (0-based) while effects, state updates and timers settled. */
+export interface TransitionCondition {
+  kind: "transition";
+  commit: number;
+  commitCount: number;
+}
+
+export type StateCondition = BranchCondition | RepeatCondition | TransitionCondition;
+
+export interface StaticState {
+  /** A concrete pattern: no branches or repeats remain, only fibers, text, opaque subtrees and wildcards. */
+  tree: PatternNode[];
+  conditions: StateCondition[];
+}
+
+export interface StateSpaceBudget {
+  maxStates: number;
+  /** Cardinalities enumerated above a repeat's minimum; larger counts are omitted. */
+  maxRepeat: number;
+}
+
+/** An alternative never expanded, under the decisions in `conditions`, because the state budget ran out first. */
+export interface OmittedBranchStates {
+  kind: "branch";
+  variable: string;
+  reason: string;
+  location: string | null;
+  alternativeIndex: number;
+  conditions: StateCondition[];
+}
+
+/**
+ * Repeat counts above `countsAbove` (up to `max`, unbounded when null) were not
+ * enumerated: everywhere when `conditions` is empty (the repeat bound), else
+ * under those decisions (the state budget).
+ */
+export interface OmittedRepeatStates {
+  kind: "repeat";
+  variable: string;
+  location: string | null;
+  countsAbove: number;
+  max: number | null;
+  conditions: StateCondition[];
+}
+
+/** A fully decided state dropped because the state budget was already full. */
+export interface OmittedState {
+  kind: "state";
+  conditions: StateCondition[];
+}
+
+/** A subtree the materializer did not render, so whatever states it holds are missing. */
+export interface OmittedSubtree {
+  kind: "subtree";
+  reason: string;
+}
+
+export type StateOmission =
+  | OmittedBranchStates
+  | OmittedRepeatStates
+  | OmittedState
+  | OmittedSubtree;
+
+export interface OmittedStateSpace {
+  omissions: StateOmission[];
+}
+
+export interface StaticStateSpace {
+  states: StaticState[];
+  budget: StateSpaceBudget;
+  /** Non-null whenever some reachable state is not in `states`. */
+  omitted: OmittedStateSpace | null;
+  /** The distinct committed patterns the states were expanded from, in commit order. */
+  commits: PatternNode[][];
+}
+
+export const DEFAULT_STATE_SPACE_BUDGET: StateSpaceBudget = { maxStates: 256, maxRepeat: 2 };
+
+const STATE_PREDICATE_PREFIX = "state(";
+
+type ConditionMap = ReadonlyMap<string, StateCondition>;
+
+interface Emit {
+  (nodes: PatternNode[], conditions: ConditionMap): void;
+}
+
+const branchCondition = (node: PatternBranch, alternativeIndex: number): BranchCondition => ({
+  kind: node.variable.startsWith(STATE_PREDICATE_PREFIX) ? "state-update" : "branch",
+  variable: node.variable,
+  reason: node.reason,
+  location: node.location,
+  alternativeIndex,
+  alternativeCount: node.alternatives.length,
+});
+
+const repeatCondition = (node: PatternRepeat, count: number): RepeatCondition => ({
+  kind: "repeat",
+  variable: node.variable,
+  location: node.location,
+  count,
+});
+
+/** A single commit needs no transition to select it. */
+const transitionCondition = (commit: number, commitCount: number): TransitionCondition | null =>
+  commitCount > 1 ? { kind: "transition", commit, commitCount } : null;
+
+const iterationScope = (node: PatternRepeat, iteration: number): string =>
+  `${node.variable}[${iteration}]`;
+
+class StateEnumerator {
+  readonly states: StaticState[] = [];
+  private readonly omissions = new Map<string, StateOmission>();
+  private isExhausted = false;
+
+  constructor(private readonly budget: StateSpaceBudget) {}
+
+  get omitted(): OmittedStateSpace | null {
+    return this.omissions.size === 0 ? null : { omissions: [...this.omissions.values()] };
+  }
+
+  enumerate(pattern: PatternNode[], transition: TransitionCondition | null): void {
+    this.isExhausted = this.states.length >= this.budget.maxStates;
+    this.expandList(pattern, 0, [], new Map(), (tree, conditions) => {
+      const stateConditions = transition
+        ? [transition, ...conditions.values()]
+        : [...conditions.values()];
+      if (this.states.length >= this.budget.maxStates) {
+        this.isExhausted = true;
+        this.omit(`state|${describeConditions(stateConditions)}`, {
+          kind: "state",
+          conditions: stateConditions,
+        });
+        return;
+      }
+      this.states.push({ tree, conditions: stateConditions });
+    });
+  }
+
+  private omit(key: string, omission: StateOmission): void {
+    const existing = this.omissions.get(key);
+    if (existing?.kind === "repeat" && omission.kind === "repeat") {
+      omission = { ...omission, countsAbove: Math.min(existing.countsAbove, omission.countsAbove) };
+    }
+    this.omissions.set(key, omission);
+  }
+
+  private omitUnderBudget(
+    conditions: ConditionMap,
+    omission: OmittedBranchStates | OmittedRepeatStates,
+  ): void {
+    const under = [...conditions.values()];
+    const subject =
+      omission.kind === "branch"
+        ? `${omission.variable}|${omission.alternativeIndex}`
+        : omission.variable;
+    this.omit(`${subject}|${describeConditions(under)}`, { ...omission, conditions: under });
+  }
+
+  private expandList(
+    nodes: PatternNode[],
+    index: number,
+    prefix: PatternNode[],
+    conditions: ConditionMap,
+    emit: Emit,
+  ): void {
+    if (this.isExhausted) return;
+    if (index === nodes.length) {
+      emit(prefix, conditions);
+      return;
+    }
+    this.expandNode(nodes[index], conditions, (expanded, next) =>
+      this.expandList(nodes, index + 1, [...prefix, ...expanded], next, emit),
+    );
+  }
+
+  private expandNode(node: PatternNode, conditions: ConditionMap, emit: Emit): void {
+    switch (node.kind) {
+      case "text":
+        emit([node], conditions);
+        return;
+      case "wildcard":
+        if (node.isTruncated) this.omit(node.reason, { kind: "subtree", reason: node.reason });
+        emit([node], conditions);
+        return;
+      case "fiber":
+        this.expandList(node.children, 0, [], conditions, (children, next) =>
+          emit([{ ...node, children }], next),
+        );
+        return;
+      case "opaque":
+        this.expandList(node.passedChildren, 0, [], conditions, (passedChildren, next) =>
+          emit([{ ...node, passedChildren }], next),
+        );
+        return;
+      case "branch":
+        this.expandBranch(node, conditions, emit);
+        return;
+      case "repeat":
+        this.expandRepeat(node, conditions, emit);
+        return;
+    }
+  }
+
+  private expandBranch(node: PatternBranch, conditions: ConditionMap, emit: Emit): void {
+    const decided = conditions.get(node.variable);
+    if (decided && decided.kind !== "repeat" && decided.kind !== "transition") {
+      this.expandList(node.alternatives[decided.alternativeIndex] ?? [], 0, [], conditions, emit);
+      return;
+    }
+    node.alternatives.forEach((alternative, alternativeIndex) => {
+      if (this.isExhausted) {
+        this.omitUnderBudget(conditions, {
+          kind: "branch",
+          variable: node.variable,
+          reason: node.reason,
+          location: node.location,
+          alternativeIndex,
+          conditions: [],
+        });
+        return;
+      }
+      const next = new Map(conditions).set(node.variable, branchCondition(node, alternativeIndex));
+      this.expandList(alternative, 0, [], next, emit);
+    });
+  }
+
+  private expandRepeat(node: PatternRepeat, conditions: ConditionMap, emit: Emit): void {
+    const { min, max } = node.count;
+    const enumeratedMax =
+      max === null ? min + this.budget.maxRepeat : Math.min(max, min + this.budget.maxRepeat);
+    const omittedCounts = (countsAbove: number): OmittedRepeatStates => ({
+      kind: "repeat",
+      variable: node.variable,
+      location: node.location,
+      countsAbove,
+      max,
+      conditions: [],
+    });
+    if (max === null || max > enumeratedMax) {
+      this.omit(node.variable, omittedCounts(enumeratedMax));
+    }
+    for (let count = min; count <= enumeratedMax; count++) {
+      if (this.isExhausted) {
+        this.omitUnderBudget(conditions, omittedCounts(count - 1));
+        return;
+      }
+      const next = new Map(conditions).set(node.variable, repeatCondition(node, count));
+      this.expandIterations(node, count, 0, [], next, emit);
+    }
+  }
+
+  private expandIterations(
+    node: PatternRepeat,
+    count: number,
+    iteration: number,
+    prefix: PatternNode[],
+    conditions: ConditionMap,
+    emit: Emit,
+  ): void {
+    if (this.isExhausted) return;
+    if (iteration === count) {
+      emit(prefix, conditions);
+      return;
+    }
+    this.expandList(
+      scopePatternVariables(node.children, iterationScope(node, iteration)),
+      0,
+      [],
+      conditions,
+      (nodes, next) =>
+        this.expandIterations(node, count, iteration + 1, [...prefix, ...nodes], next, emit),
+    );
+  }
+}
+
+const dedupeCommits = (commits: PatternNode[][]): PatternNode[][] => {
+  const seen = new Set<string>();
+  return commits.filter((pattern) => {
+    const key = JSON.stringify(pattern);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
+/**
+ * Expands every committed pattern into the concrete trees it stands for.
+ * Independent decisions multiply; a variable met again inside one tree takes
+ * the value already chosen for it; decisions inside a repeat are made per
+ * iteration. Enumeration stops at `budget.maxStates` and repeat counts stop at
+ * `budget.maxRepeat` above the known minimum, and both are reported in `omitted`.
+ */
+export const enumerateStateSpace = (
+  commitPatterns: PatternNode[][],
+  budget: StateSpaceBudget = DEFAULT_STATE_SPACE_BUDGET,
+): StaticStateSpace => {
+  const commits = dedupeCommits(commitPatterns);
+  const enumerator = new StateEnumerator(budget);
+  commits.forEach((pattern, commit) => {
+    enumerator.enumerate(pattern, transitionCondition(commit, commits.length));
+  });
+  return { states: enumerator.states, budget, omitted: enumerator.omitted, commits };
+};
+
+export interface MatchedState {
+  /** Index into `states`; null when the runtime tree lies in the omitted part of the state space. */
+  index: number | null;
+  conditions: StateCondition[];
+}
+
+export interface ClosestState {
+  index: number;
+  divergence: ComparisonDivergence;
+}
+
+export interface StateSpaceMatch {
+  status: ComparisonStatus;
+  report: ComparisonReport;
+  matched: MatchedState | null;
+  /** On a mismatch, the enumerated state that agrees with the furthest-reaching attempt on the most decisions. */
+  closest: ClosestState | null;
+}
+
+/** What a comparison learned about the state space, small enough to persist alongside the report. */
+export interface StateSpaceSummary {
+  states: number;
+  matchedState: MatchedState | null;
+  closestState: ClosestState | null;
+  omitted: OmittedStateSpace | null;
+}
+
+const toCondition = (decision: MatchDecision): StateCondition =>
+  decision.node.kind === "branch"
+    ? branchCondition(decision.node, decision.choice)
+    : repeatCondition(decision.node, decision.choice);
+
+const conditionValue = (condition: StateCondition): number => {
+  switch (condition.kind) {
+    case "branch":
+    case "state-update":
+      return condition.alternativeIndex;
+    case "repeat":
+      return condition.count;
+    case "transition":
+      return condition.commit;
+  }
+};
+
+const conditionKey = (condition: StateCondition): string =>
+  condition.kind === "transition" ? "transition" : condition.variable;
+
+const describeConditions = (conditions: StateCondition[]): string =>
+  conditions
+    .map((condition) => `${conditionKey(condition)}=${conditionValue(condition)}`)
+    .join(",");
+
+const haveSameConditions = (left: StateCondition[], right: StateCondition[]): boolean => {
+  if (left.length !== right.length) return false;
+  const values = new Map(
+    left.map((condition) => [conditionKey(condition), conditionValue(condition)]),
+  );
+  return right.every(
+    (condition) => values.get(conditionKey(condition)) === conditionValue(condition),
+  );
+};
+
+const findState = (states: StaticState[], conditions: StateCondition[]): number | null => {
+  const index = states.findIndex((state) => haveSameConditions(state.conditions, conditions));
+  return index === -1 ? null : index;
+};
+
+const stateCommit = (state: StaticState): number =>
+  state.conditions.find((condition) => condition.kind === "transition")?.commit ?? 0;
+
+const findClosestState = (
+  states: StaticState[],
+  assignment: ReadonlyMap<string, number>,
+  commit: number,
+): number | null => {
+  let closest: number | null = null;
+  let closestAgreement = -1;
+  states.forEach((state, index) => {
+    if (stateCommit(state) !== commit) return;
+    const agreement = state.conditions.filter(
+      (condition) =>
+        condition.kind !== "transition" &&
+        assignment.get(condition.variable) === conditionValue(condition),
+    ).length;
+    if (agreement > closestAgreement) {
+      closest = index;
+      closestAgreement = agreement;
+    }
+  });
+  return closest;
+};
+
+const classifyMatch = (
+  report: ComparisonReport,
+  stateSpace: StaticStateSpace,
+): ComparisonStatus => {
+  if (report.status !== "exact") return report.status;
+  return stateSpace.omitted ? "truncated" : "exact";
+};
+
+interface CommitAttempt {
+  commit: number;
+  match: PatternMatch;
+}
+
+/**
+ * Decides whether the runtime tree is one of the enumerated states. The
+ * latest commit is tried first, as a settled runtime most often shows it.
+ * A runtime tree that matches under decisions no enumerated state carries lies
+ * in the omitted part of the space and is reported as such, never as exact.
+ */
+export const matchStateSpace = (
+  stateSpace: StaticStateSpace,
+  runtime: RuntimeFiberSnapshot[],
+  options: ComparisonOptions = {},
+): StateSpaceMatch => {
+  let furthest: CommitAttempt | null = null;
+  for (let commit = stateSpace.commits.length - 1; commit >= 0; commit--) {
+    const match = matchPatternToRuntime(stateSpace.commits[commit], runtime, options);
+    if (match.report.status !== "mismatch") {
+      const transition = transitionCondition(commit, stateSpace.commits.length);
+      const conditions: StateCondition[] = [
+        ...(transition ? [transition] : []),
+        ...match.decisions.map(toCondition),
+      ];
+      const index = findState(stateSpace.states, conditions);
+      const classified = classifyMatch(match.report, stateSpace);
+      const status = index === null && classified === "exact" ? "truncated" : classified;
+      return {
+        status,
+        report: { ...match.report, status },
+        matched: { index, conditions },
+        closest: null,
+      };
+    }
+    const position = match.failure?.position ?? -1;
+    if (!furthest || position > (furthest.match.failure?.position ?? -1)) {
+      furthest = { commit, match };
+    }
+  }
+  if (!furthest) {
+    throw new Error("a state space needs at least one committed pattern to match against");
+  }
+  const { failure } = furthest.match;
+  const closestIndex = failure
+    ? findClosestState(stateSpace.states, failure.assignment, furthest.commit)
+    : null;
+  return {
+    status: "mismatch",
+    report: furthest.match.report,
+    matched: null,
+    closest:
+      closestIndex !== null && failure
+        ? { index: closestIndex, divergence: failure.divergence }
+        : null,
+  };
+};

--- a/packages/parser/src/harness/static-pattern.ts
+++ b/packages/parser/src/harness/static-pattern.ts
@@ -1,9 +1,16 @@
 import { MARKER_NAMES } from "../materialize/markers.js";
 import type { StaticRenderResult } from "../types.js";
-import type { RuntimeFiberSnapshot, SnapshotPropValue, SnapshotWorkTag } from "./snapshot.js";
+import type {
+  RuntimeFiberSnapshot,
+  RuntimeSnapshot,
+  SnapshotPropValue,
+  SnapshotWorkTag,
+} from "./snapshot.js";
 
 // A pattern is the materialized fiber tree as the matcher consumes it:
 // concrete nodes, text, alternatives, repeats, opaque subtrees and wildcards.
+// Every branch and repeat is a decision variable; branches that share a
+// predicate share the variable and are therefore always decided together.
 
 export interface PatternFiber {
   kind: "fiber";
@@ -20,6 +27,7 @@ export interface PatternText {
 
 export interface PatternBranch {
   kind: "branch";
+  variable: string;
   reason: string;
   /** Where the source branched (`file:line:column`); null for branches the materializer introduces. */
   location: string | null;
@@ -27,8 +35,17 @@ export interface PatternBranch {
   alternatives: PatternNode[][];
 }
 
+export interface RepeatBounds {
+  min: number;
+  /** null when the interpreter does not know how many items there are. */
+  max: number | null;
+}
+
 export interface PatternRepeat {
   kind: "repeat";
+  variable: string;
+  location: string | null;
+  count: RepeatBounds;
   children: PatternNode[];
 }
 
@@ -46,6 +63,8 @@ export interface PatternOpaque {
 export interface PatternWildcard {
   kind: "wildcard";
   reason: string;
+  /** The materializer did not render this subtree, so its states are missing from the enumeration. */
+  isTruncated: boolean;
 }
 
 export type PatternNode =
@@ -76,71 +95,115 @@ const readNumber = (props: Record<string, SnapshotPropValue>, key: string): numb
   return typeof value === "number" ? value : null;
 };
 
-const toPatternNode = (fiber: RuntimeFiberSnapshot): PatternNode[] => {
-  if (fiber.tag === "HostText") return [{ kind: "text", text: fiber.text }];
-  switch (fiber.name) {
-    case MARKER_NAMES.branch:
-      return [
-        {
-          kind: "branch",
-          reason: readString(fiber.props, "reason") ?? "",
-          location: readString(fiber.props, "location"),
-          preferredIndex: readNumber(fiber.props, "preferredIndex"),
-          alternatives: fiber.children.map((alternative) =>
-            snapshotToPattern(alternative.children),
-          ),
-        },
-      ];
-    case MARKER_NAMES.repeat:
-      return [{ kind: "repeat", children: snapshotToPattern(fiber.children) }];
-    case MARKER_NAMES.opaque:
-      return [
-        {
-          kind: "opaque",
-          name: readString(fiber.props, "displayName") ?? "",
-          runtimeNames: getOpaqueRuntimeNames(
-            readString(fiber.props, "displayName"),
-            readString(fiber.props, "importedName"),
-          ),
-          key: fiber.key,
-          reason: readString(fiber.props, "reason") ?? "",
-          passedChildren: snapshotToPattern(fiber.children),
-        },
-      ];
-    case MARKER_NAMES.unknown:
-      return [{ kind: "wildcard", reason: readString(fiber.props, "reason") ?? "" }];
-    case MARKER_NAMES.text:
-      return [{ kind: "text", text: null }];
-    case MARKER_NAMES.suspenseBoundary:
-      return snapshotToPattern(fiber.children);
-    case MARKER_NAMES.suspended:
-      return [];
-    default:
-      return [
-        {
-          kind: "fiber",
-          tag: fiber.tag,
-          name: fiber.name,
-          key: fiber.key,
-          children: snapshotToPattern(fiber.children),
-        },
-      ];
+const NEGATED_PREDICATE_PREFIX = "!";
+
+/** `!flag ? A : B` decides the same variable as `flag ? B : A`; both are read as the latter. */
+const normalizeNegatedBranch = (branch: PatternBranch): PatternBranch => {
+  if (!branch.variable.startsWith(NEGATED_PREDICATE_PREFIX) || branch.alternatives.length !== 2) {
+    return branch;
   }
+  return {
+    ...branch,
+    variable: branch.variable.slice(NEGATED_PREDICATE_PREFIX.length),
+    preferredIndex: branch.preferredIndex === null ? null : 1 - branch.preferredIndex,
+    alternatives: [branch.alternatives[1], branch.alternatives[0]],
+  };
 };
+
+class PatternReader {
+  private anonymousDecisions = 0;
+
+  read(fibers: RuntimeFiberSnapshot[]): PatternNode[] {
+    return fibers.flatMap((fiber) => this.toPatternNode(fiber));
+  }
+
+  private toPatternNode(fiber: RuntimeFiberSnapshot): PatternNode[] {
+    if (fiber.tag === "HostText") return [{ kind: "text", text: fiber.text }];
+    switch (fiber.name) {
+      case MARKER_NAMES.branch:
+        return [
+          normalizeNegatedBranch({
+            kind: "branch",
+            variable: readString(fiber.props, "predicate") ?? `branch#${++this.anonymousDecisions}`,
+            reason: readString(fiber.props, "reason") ?? "",
+            location: readString(fiber.props, "location"),
+            preferredIndex: readNumber(fiber.props, "preferredIndex"),
+            alternatives: fiber.children.map((alternative) => this.read(alternative.children)),
+          }),
+        ];
+      case MARKER_NAMES.repeat:
+        return [
+          {
+            kind: "repeat",
+            variable: `repeat#${++this.anonymousDecisions}`,
+            location: readString(fiber.props, "location"),
+            count: {
+              min: readNumber(fiber.props, "countMin") ?? 0,
+              max: readNumber(fiber.props, "countMax"),
+            },
+            children: this.read(fiber.children),
+          },
+        ];
+      case MARKER_NAMES.opaque:
+        return [
+          {
+            kind: "opaque",
+            name: readString(fiber.props, "displayName") ?? "",
+            runtimeNames: getOpaqueRuntimeNames(
+              readString(fiber.props, "displayName"),
+              readString(fiber.props, "importedName"),
+            ),
+            key: fiber.key,
+            reason: readString(fiber.props, "reason") ?? "",
+            passedChildren: this.read(fiber.children),
+          },
+        ];
+      case MARKER_NAMES.unknown:
+        return [
+          {
+            kind: "wildcard",
+            reason: readString(fiber.props, "reason") ?? "",
+            isTruncated: fiber.props.isTruncated === true,
+          },
+        ];
+      case MARKER_NAMES.text:
+        return [{ kind: "text", text: null }];
+      case MARKER_NAMES.suspenseBoundary:
+        return this.read(fiber.children);
+      case MARKER_NAMES.suspended:
+        return [];
+      default:
+        return [
+          {
+            kind: "fiber",
+            tag: fiber.tag,
+            name: fiber.name,
+            key: fiber.key,
+            children: this.read(fiber.children),
+          },
+        ];
+    }
+  }
+}
 
 /**
  * Reads the materialized fiber tree back into a pattern: marker components
  * become branches, repeats, opaque subtrees and wildcards; everything else is
  * a concrete fiber. A tree without markers is a fully concrete pattern.
+ * Decision variables are numbered in document order, so equal trees read to
+ * equal patterns.
  */
 export const snapshotToPattern = (fibers: RuntimeFiberSnapshot[]): PatternNode[] =>
-  fibers.flatMap(toPatternNode);
+  new PatternReader().read(fibers);
 
 export const getRenderPattern = (result: StaticRenderResult): PatternNode[] =>
   snapshotToPattern(result.snapshot.roots);
 
+export const getSnapshotRootChildren = (snapshot: RuntimeSnapshot): PatternNode[] =>
+  snapshotToPattern(snapshot.roots.flatMap((root) => root.children));
+
 export const getRenderRootChildren = (result: StaticRenderResult): PatternNode[] =>
-  snapshotToPattern(result.snapshot.roots.flatMap((root) => root.children));
+  getSnapshotRootChildren(result.snapshot);
 
 const flattenPatternNode = (node: PatternNode, transparent: ReadonlySet<string>): PatternNode[] => {
   switch (node.kind) {
@@ -179,6 +242,34 @@ export const flattenPatternFibers = (
   return result;
 };
 
+/** Renames every decision variable inside `nodes` into `scope`, so one repeat iteration decides independently of the next. */
+export const scopePatternVariables = (nodes: PatternNode[], scope: string): PatternNode[] =>
+  nodes.map((node) => {
+    switch (node.kind) {
+      case "fiber":
+        return { ...node, children: scopePatternVariables(node.children, scope) };
+      case "opaque":
+        return { ...node, passedChildren: scopePatternVariables(node.passedChildren, scope) };
+      case "branch":
+        return {
+          ...node,
+          variable: `${node.variable}@${scope}`,
+          alternatives: node.alternatives.map((alternative) =>
+            scopePatternVariables(alternative, scope),
+          ),
+        };
+      case "repeat":
+        return {
+          ...node,
+          variable: `${node.variable}@${scope}`,
+          children: scopePatternVariables(node.children, scope),
+        };
+      case "text":
+      case "wildcard":
+        return node;
+    }
+  });
+
 export const countPatternFibers = (node: PatternNode): number => {
   switch (node.kind) {
     case "fiber":
@@ -200,6 +291,9 @@ export const countPatternFibers = (node: PatternNode): number => {
       return 0;
   }
 };
+
+export const formatRepeatBounds = (count: RepeatBounds): string =>
+  count.max === null ? `${count.min}..` : `${count.min}..${count.max}`;
 
 const formatPatternNode = (node: PatternNode, depth: number): string[] => {
   const indent = "  ".repeat(depth);
@@ -223,7 +317,7 @@ const formatPatternNode = (node: PatternNode, depth: number): string[] => {
       ];
     case "repeat":
       return [
-        `${indent}*repeat`,
+        `${indent}*repeat(${formatRepeatBounds(node.count)})${node.location === null ? "" : ` @ ${node.location}`}`,
         ...node.children.flatMap((child) => formatPatternNode(child, depth + 1)),
       ];
     case "opaque": {

--- a/packages/parser/src/libraries/react-hook-form.ts
+++ b/packages/parser/src/libraries/react-hook-form.ts
@@ -54,7 +54,8 @@ const NAMED_CONTEXT_VERSIONS = ">=7.58.0";
 const createHookFormContext = (version: string | null): ContextDefinition => ({
   name: "HookFormContext",
   displayName:
-    version === null || semver.satisfies(version, NAMED_CONTEXT_VERSIONS, { includePrerelease: true })
+    version === null ||
+    semver.satisfies(version, NAMED_CONTEXT_VERSIONS, { includePrerelease: true })
       ? "HookFormContext"
       : null,
   defaultValue: NULL_VALUE,
@@ -1560,87 +1561,90 @@ const createUseFormContext = (context: ContextDefinition): StaticValue =>
 
 const createUseWatch = (context: ContextDefinition): StaticValue =>
   nativeFunction("useWatch", ([props], tools) => {
-  const control = resolveControl(props, tools, context);
-  if (!control) return missingControl("useWatch", props);
-  const name = propertyOf(props, "name");
-  const disabled = propertyOf(props, "disabled");
-  const isExact = isTruthy(propertyOf(props, "exact"));
-  const compute = propertyOf(props, "compute");
-  const instance = useInstance(tools, watchInstances, () => ({
-    defaultValue: propertyOf(props, "defaultValue"),
-    computedValue: null,
-  }));
-  const applyCompute = (value: StaticValue, computeTools: StubRenderTools): StaticValue =>
-    isCallable(compute) ? computeTools.call(compute, [value]) : value;
-  const [value, updateValue] = useStateValue(
-    tools,
-    applyCompute(getWatch(control, name, instance.defaultValue, false), tools),
-  );
-  useEffectHook(
-    tools,
-    "useLayoutEffect",
-    [control.control, disabled, name, primitiveValue(isExact)],
-    () =>
-      subscribeState(control, {
-        name,
-        isExact,
-        proxy: new Map([["values", true]]),
-        isRoot: false,
-        notify: (payload, notifyTools) => {
-          if (isTruthy(disabled)) return;
-          const formValues = generateWatchOutput(
-            name,
-            control.names,
-            payload.values ?? readStore(control, "formValues"),
-            false,
-            instance.defaultValue,
-          );
-          if (!isCallable(compute)) {
-            notifyTools.call(updateValue, [formValues]);
-            return;
-          }
-          const computed = notifyTools.call(compute, [formValues]);
-          if (!instance.computedValue || compareDeeply(computed, instance.computedValue) !== true) {
-            notifyTools.call(updateValue, [computed]);
-            instance.computedValue = computed;
-          }
-        },
-      }),
-  );
-  return value;
+    const control = resolveControl(props, tools, context);
+    if (!control) return missingControl("useWatch", props);
+    const name = propertyOf(props, "name");
+    const disabled = propertyOf(props, "disabled");
+    const isExact = isTruthy(propertyOf(props, "exact"));
+    const compute = propertyOf(props, "compute");
+    const instance = useInstance(tools, watchInstances, () => ({
+      defaultValue: propertyOf(props, "defaultValue"),
+      computedValue: null,
+    }));
+    const applyCompute = (value: StaticValue, computeTools: StubRenderTools): StaticValue =>
+      isCallable(compute) ? computeTools.call(compute, [value]) : value;
+    const [value, updateValue] = useStateValue(
+      tools,
+      applyCompute(getWatch(control, name, instance.defaultValue, false), tools),
+    );
+    useEffectHook(
+      tools,
+      "useLayoutEffect",
+      [control.control, disabled, name, primitiveValue(isExact)],
+      () =>
+        subscribeState(control, {
+          name,
+          isExact,
+          proxy: new Map([["values", true]]),
+          isRoot: false,
+          notify: (payload, notifyTools) => {
+            if (isTruthy(disabled)) return;
+            const formValues = generateWatchOutput(
+              name,
+              control.names,
+              payload.values ?? readStore(control, "formValues"),
+              false,
+              instance.defaultValue,
+            );
+            if (!isCallable(compute)) {
+              notifyTools.call(updateValue, [formValues]);
+              return;
+            }
+            const computed = notifyTools.call(compute, [formValues]);
+            if (
+              !instance.computedValue ||
+              compareDeeply(computed, instance.computedValue) !== true
+            ) {
+              notifyTools.call(updateValue, [computed]);
+              instance.computedValue = computed;
+            }
+          },
+        }),
+    );
+    return value;
   });
 
 const createUseFormState = (context: ContextDefinition): StaticValue =>
   nativeFunction("useFormState", ([props], tools) => {
-  const control = resolveControl(props, tools, context);
-  if (!control) return missingControl("useFormState", props);
-  const name = propertyOf(props, "name");
-  const disabled = propertyOf(props, "disabled");
-  const isExact = isTruthy(propertyOf(props, "exact"));
-  const [formState, updateFormState] = useStateValue(tools, readStore(control, "formState"));
-  const localProxy = useInstance<ProxyFormState>(
-    tools,
-    localProxies,
-    () => new Map(LOCAL_PROXY_KEYS.map((key) => [key, false])),
-  );
-  useEffectHook(tools, "useLayoutEffect", [name, disabled, primitiveValue(isExact)], () =>
-    subscribeState(control, {
-      name,
-      isExact,
-      proxy: localProxy,
-      isRoot: false,
-      notify: (payload, notifyTools) => {
-        if (isTruthy(disabled)) return;
-        notifyTools.call(updateFormState, [
-          withProperties(readStore(control, "formState"), payload),
-        ]);
-      },
-    }),
-  );
-  useEffectHook(tools, "useEffect", [control.control], (effectTools) => {
-    if (localProxy.get("isValid")) setValid(control, true, effectTools);
-  });
-  return getProxyFormState(formState, control, localProxy, false);
+    const control = resolveControl(props, tools, context);
+    if (!control) return missingControl("useFormState", props);
+    const name = propertyOf(props, "name");
+    const disabled = propertyOf(props, "disabled");
+    const isExact = isTruthy(propertyOf(props, "exact"));
+    const [formState, updateFormState] = useStateValue(tools, readStore(control, "formState"));
+    const localProxy = useInstance<ProxyFormState>(
+      tools,
+      localProxies,
+      () => new Map(LOCAL_PROXY_KEYS.map((key) => [key, false])),
+    );
+    useEffectHook(tools, "useLayoutEffect", [name, disabled, primitiveValue(isExact)], () =>
+      subscribeState(control, {
+        name,
+        isExact,
+        proxy: localProxy,
+        isRoot: false,
+        notify: (payload, notifyTools) => {
+          if (isTruthy(disabled)) return;
+          notifyTools.call(updateFormState, [
+            withProperties(readStore(control, "formState"), payload),
+          ]);
+        },
+      }),
+    );
+    useEffectHook(tools, "useEffect", [control.control], (effectTools) => {
+      if (localProxy.get("isValid")) setValid(control, true, effectTools);
+    });
+    return getProxyFormState(formState, control, localProxy, false);
   });
 
 const createUseController = (
@@ -1649,147 +1653,153 @@ const createUseController = (
   useFormState: StaticValue,
 ): StaticValue =>
   nativeFunction("useController", ([props], tools) => {
-  const control = resolveControl(props, tools, context);
-  if (!control) return missingControl("useController", props);
-  const nameValue = propertyOf(props, "name");
-  const name = knownString(nameValue);
-  const disabled = propertyOf(props, "disabled");
-  const shouldUnregister = propertyOf(props, "shouldUnregister");
-  const isArrayField = name !== null && control.names.array.has(getNodeParentName(name));
-  const defaultValue =
-    name === null
-      ? unknownValue(`default of field ${describeValue(nameValue)}`)
-      : readPath(
-          readStore(control, "formValues"),
-          name,
-          readPath(readStore(control, "defaultValues"), name, propertyOf(props, "defaultValue")),
-        );
-  const value = tools.call(useWatch, [
-    objectFromRecord({
-      control: control.control,
-      name: nameValue,
-      defaultValue,
-      exact: TRUE_VALUE,
-    }),
-  ]);
-  const formState = tools.call(useFormState, [
-    objectFromRecord({
-      control: control.control,
-      name: nameValue,
-      exact: TRUE_VALUE,
-    }),
-  ]);
-  const isDisabledBoolean = disabled.kind === "primitive" && typeof disabled.value === "boolean";
-  const rules = spreadCopy(propertyOf(props, "rules"));
-  register(
-    control,
-    nameValue,
-    withProperties(rules, {
-      value,
-      ...(isDisabledBoolean ? { disabled } : {}),
-    }),
-    tools,
-  );
-  const readFieldState = (key: string, fieldTools: StubRenderTools): StaticValue =>
-    name === null
-      ? unknownValue(`${key} of field ${describeValue(nameValue)}`)
-      : readPath(readProperty(formState, key, fieldTools), name);
-  const fieldStateEntry = (key: string, source: string, isBoolean: boolean): StaticObjectEntry => ({
-    kind: "property",
-    key,
-    value: unknownValue(`fieldState.${key}`),
-    accessor: {
-      get: nativeFunction(key, (_args, fieldTools) => {
-        const read = readFieldState(source, fieldTools);
-        return isBoolean ? booleanValue(getTruthiness(read), `whether ${key} for "${name}"`) : read;
+    const control = resolveControl(props, tools, context);
+    if (!control) return missingControl("useController", props);
+    const nameValue = propertyOf(props, "name");
+    const name = knownString(nameValue);
+    const disabled = propertyOf(props, "disabled");
+    const shouldUnregister = propertyOf(props, "shouldUnregister");
+    const isArrayField = name !== null && control.names.array.has(getNodeParentName(name));
+    const defaultValue =
+      name === null
+        ? unknownValue(`default of field ${describeValue(nameValue)}`)
+        : readPath(
+            readStore(control, "formValues"),
+            name,
+            readPath(readStore(control, "defaultValues"), name, propertyOf(props, "defaultValue")),
+          );
+    const value = tools.call(useWatch, [
+      objectFromRecord({
+        control: control.control,
+        name: nameValue,
+        defaultValue,
+        exact: TRUE_VALUE,
       }),
-      set: null,
-    },
-  });
-  const fieldState = objectValue([
-    fieldStateEntry("invalid", "errors", true),
-    fieldStateEntry("isDirty", "dirtyFields", true),
-    fieldStateEntry("isTouched", "touchedFields", true),
-    fieldStateEntry("isValidating", "validatingFields", true),
-    fieldStateEntry("error", "errors", false),
-  ]);
-  const formDisabled = readProperty(formState, "disabled", tools);
-  const onChange = handleChange(control);
-  const field = objectFromRecord({
-    name: nameValue,
-    value,
-    ...(isDisabledBoolean || isTruthy(formDisabled)
-      ? { disabled: orValue(formDisabled, disabled) }
-      : {}),
-    onChange: nativeFunction("onChange", ([event], changeTools) =>
-      changeTools.call(onChange, [
-        objectFromRecord({
-          target: objectFromRecord({
-            value: eventValue(event),
-            name: nameValue,
-          }),
-          type: primitiveValue("change"),
+    ]);
+    const formState = tools.call(useFormState, [
+      objectFromRecord({
+        control: control.control,
+        name: nameValue,
+        exact: TRUE_VALUE,
+      }),
+    ]);
+    const isDisabledBoolean = disabled.kind === "primitive" && typeof disabled.value === "boolean";
+    const rules = spreadCopy(propertyOf(props, "rules"));
+    register(
+      control,
+      nameValue,
+      withProperties(rules, {
+        value,
+        ...(isDisabledBoolean ? { disabled } : {}),
+      }),
+      tools,
+    );
+    const readFieldState = (key: string, fieldTools: StubRenderTools): StaticValue =>
+      name === null
+        ? unknownValue(`${key} of field ${describeValue(nameValue)}`)
+        : readPath(readProperty(formState, key, fieldTools), name);
+    const fieldStateEntry = (
+      key: string,
+      source: string,
+      isBoolean: boolean,
+    ): StaticObjectEntry => ({
+      kind: "property",
+      key,
+      value: unknownValue(`fieldState.${key}`),
+      accessor: {
+        get: nativeFunction(key, (_args, fieldTools) => {
+          const read = readFieldState(source, fieldTools);
+          return isBoolean
+            ? booleanValue(getTruthiness(read), `whether ${key} for "${name}"`)
+            : read;
         }),
-      ]),
-    ),
-    onBlur: nativeFunction("onBlur", (_args, blurTools) =>
-      blurTools.call(onChange, [
-        objectFromRecord({
-          target: objectFromRecord({
-            value:
-              name === null ? UNDEFINED_VALUE : readPath(readStore(control, "formValues"), name),
-            name: nameValue,
+        set: null,
+      },
+    });
+    const fieldState = objectValue([
+      fieldStateEntry("invalid", "errors", true),
+      fieldStateEntry("isDirty", "dirtyFields", true),
+      fieldStateEntry("isTouched", "touchedFields", true),
+      fieldStateEntry("isValidating", "validatingFields", true),
+      fieldStateEntry("error", "errors", false),
+    ]);
+    const formDisabled = readProperty(formState, "disabled", tools);
+    const onChange = handleChange(control);
+    const field = objectFromRecord({
+      name: nameValue,
+      value,
+      ...(isDisabledBoolean || isTruthy(formDisabled)
+        ? { disabled: orValue(formDisabled, disabled) }
+        : {}),
+      onChange: nativeFunction("onChange", ([event], changeTools) =>
+        changeTools.call(onChange, [
+          objectFromRecord({
+            target: objectFromRecord({
+              value: eventValue(event),
+              name: nameValue,
+            }),
+            type: primitiveValue("change"),
           }),
-          type: primitiveValue("blur"),
-        }),
-      ]),
-    ),
-    ref: nativeFunction("ref", () => UNDEFINED_VALUE),
-  });
-  useEffectHook(
-    tools,
-    "useEffect",
-    [nameValue, control.control, primitiveValue(isArrayField), shouldUnregister],
-    (effectTools) => {
-      const shouldUnregisterField =
-        isTruthy(getObjectProperty(control.options, "shouldUnregister")) ||
-        isTruthy(shouldUnregister);
-      register(
-        control,
-        nameValue,
-        withProperties(rules, isDisabledBoolean ? { disabled } : {}),
-        effectTools,
-      );
-      if (shouldUnregisterField && name !== null) {
-        const optionDefault = cloneValue(
-          readPath(getObjectProperty(control.options, "defaultValues"), name),
-        );
-        writeStore(
+        ]),
+      ),
+      onBlur: nativeFunction("onBlur", (_args, blurTools) =>
+        blurTools.call(onChange, [
+          objectFromRecord({
+            target: objectFromRecord({
+              value:
+                name === null ? UNDEFINED_VALUE : readPath(readStore(control, "formValues"), name),
+              name: nameValue,
+            }),
+            type: primitiveValue("blur"),
+          }),
+        ]),
+      ),
+      ref: nativeFunction("ref", () => UNDEFINED_VALUE),
+    });
+    useEffectHook(
+      tools,
+      "useEffect",
+      [nameValue, control.control, primitiveValue(isArrayField), shouldUnregister],
+      (effectTools) => {
+        const shouldUnregisterField =
+          isTruthy(getObjectProperty(control.options, "shouldUnregister")) ||
+          isTruthy(shouldUnregister);
+        register(
           control,
-          "defaultValues",
-          writePath(readStore(control, "defaultValues"), toPath(name), optionDefault),
+          nameValue,
+          withProperties(rules, isDisabledBoolean ? { disabled } : {}),
           effectTools,
         );
-        if (isUndefined(readPath(readStore(control, "formValues"), name))) {
+        if (shouldUnregisterField && name !== null) {
+          const optionDefault = cloneValue(
+            readPath(getObjectProperty(control.options, "defaultValues"), name),
+          );
           writeStore(
             control,
-            "formValues",
-            writePath(readStore(control, "formValues"), toPath(name), optionDefault),
+            "defaultValues",
+            writePath(readStore(control, "defaultValues"), toPath(name), optionDefault),
             effectTools,
           );
+          if (isUndefined(readPath(readStore(control, "formValues"), name))) {
+            writeStore(
+              control,
+              "formValues",
+              writePath(readStore(control, "formValues"), toPath(name), optionDefault),
+              effectTools,
+            );
+          }
         }
-      }
-      if (!isArrayField) register(control, nameValue, UNDEFINED_VALUE, effectTools);
-      return nativeFunction("cleanup", (_args, cleanupTools) => {
-        if (shouldUnregisterField) unregister(control, nameValue, UNDEFINED_VALUE, cleanupTools);
-        return UNDEFINED_VALUE;
-      });
-    },
-  );
-  useEffectHook(tools, "useEffect", [disabled, nameValue, control.control], () => {
-    if (name !== null) setDisabledField(control, name, disabled);
-  });
-  return objectFromRecord({ field, formState, fieldState });
+        if (!isArrayField) register(control, nameValue, UNDEFINED_VALUE, effectTools);
+        return nativeFunction("cleanup", (_args, cleanupTools) => {
+          if (shouldUnregisterField) unregister(control, nameValue, UNDEFINED_VALUE, cleanupTools);
+          return UNDEFINED_VALUE;
+        });
+      },
+    );
+    useEffectHook(tools, "useEffect", [disabled, nameValue, control.control], () => {
+      if (name !== null) setDisabledField(control, name, disabled);
+    });
+    return objectFromRecord({ field, formState, fieldState });
   });
 
 const eventValue = (event: StaticValue | undefined): StaticValue => {
@@ -1834,187 +1844,187 @@ const generateId = (): StaticValue =>
 
 const createUseFieldArray = (context: ContextDefinition): StaticValue =>
   nativeFunction("useFieldArray", ([props], tools) => {
-  const control = resolveControl(props, tools, context);
-  if (!control) return missingControl("useFieldArray", props);
-  const nameValue = propertyOf(props, "name");
-  const name = knownString(nameValue);
-  if (name === null) return unknownValue(`useFieldArray on ${describeValue(nameValue)}`);
-  const keyName = knownString(propertyOf(props, "keyName")) ?? "id";
-  const shouldUnregister = propertyOf(props, "shouldUnregister");
-  const [fields, setFields] = useStateValue(tools, getFieldArray(control, name));
-  const instance = useInstance(tools, fieldArrayInstances, () => ({
-    ids: (fields.kind === "list" ? fields.items : []).map(generateId),
-  }));
-  control.names.array.add(name);
-  const rules = propertyOf(props, "rules");
-  useInstance(tools, ruleRegistrations, () => {
-    if (isTruthy(rules)) register(control, nameValue, rules, tools);
-    return true;
-  });
-  useEffectHook(tools, "useLayoutEffect", [control.control, nameValue], () => {
-    const subscription: ArraySubscription = {
-      notify: (payload, notifyTools) => {
-        const fieldArrayName = payload.name;
-        if (fieldArrayName !== undefined && getTruthiness(fieldArrayName) !== false) {
-          const signal = knownString(fieldArrayName);
-          if (signal !== null && signal !== name) return;
-        }
-        const fieldValues = readPath(payload.values ?? UNDEFINED_VALUE, name);
-        if (fieldValues.kind === "list") {
-          notifyTools.call(setFields, [fieldValues]);
-          instance.ids = fieldValues.items.map(generateId);
-        } else if (fieldValues.kind !== "primitive") {
-          notifyTools.call(setFields, [unknownValue(`field array "${name}" after an update`)]);
-        }
-      },
-    };
-    control.arraySubscriptions.add(subscription);
-    return nativeFunction("unsubscribe", () => {
-      control.arraySubscriptions.delete(subscription);
-      return UNDEFINED_VALUE;
+    const control = resolveControl(props, tools, context);
+    if (!control) return missingControl("useFieldArray", props);
+    const nameValue = propertyOf(props, "name");
+    const name = knownString(nameValue);
+    if (name === null) return unknownValue(`useFieldArray on ${describeValue(nameValue)}`);
+    const keyName = knownString(propertyOf(props, "keyName")) ?? "id";
+    const shouldUnregister = propertyOf(props, "shouldUnregister");
+    const [fields, setFields] = useStateValue(tools, getFieldArray(control, name));
+    const instance = useInstance(tools, fieldArrayInstances, () => ({
+      ids: (fields.kind === "list" ? fields.items : []).map(generateId),
+    }));
+    control.names.array.add(name);
+    const rules = propertyOf(props, "rules");
+    useInstance(tools, ruleRegistrations, () => {
+      if (isTruthy(rules)) register(control, nameValue, rules, tools);
+      return true;
     });
-  });
-  const updateValues = (updated: StaticValue[], updateTools: StubRenderTools): void => {
-    writeStore(
-      control,
-      "formValues",
-      writePath(readStore(control, "formValues"), toPath(name), listValue(updated)),
-      updateTools,
-    );
-    updateTools.call(setFields, [listValue(updated)]);
-    notifyState(
-      control,
-      {
-        name: nameValue,
-        isDirty: getDirty(control),
-        dirtyFields: isProxied(control, "dirtyFields")
-          ? unknownValue("dirty fields after a field array change")
-          : readFormState(control, "dirtyFields"),
-        errors: readFormState(control, "errors"),
-        isValid: readFormState(control, "isValid"),
-      },
-      updateTools,
-    );
-    notifyState(
-      control,
-      { name: nameValue, values: cloneValue(readStore(control, "formValues")) },
-      updateTools,
-    );
-    setValid(control, false, updateTools);
-  };
-  const currentItems = (): StaticValue[] | null => {
-    const current = getFieldArray(control, name);
-    return current.kind === "list" ? current.items : null;
-  };
-  const arrayMethod = (
-    methodName: string,
-    apply: (items: StaticValue[], args: StaticValue[]) => StaticValue[] | null,
-  ): StaticValue =>
-    nativeFunction(methodName, (args, methodTools) => {
-      const items = currentItems();
-      const updated = items ? apply(items, args) : null;
-      if (updated === null) {
-        writeStore(
-          control,
-          "formValues",
-          writePath(
-            readStore(control, "formValues"),
-            toPath(name),
-            unknownValue(`field array "${name}" after ${methodName}`),
-          ),
-          methodTools,
-        );
-        methodTools.call(setFields, [unknownValue(`field array "${name}" after ${methodName}`)]);
+    useEffectHook(tools, "useLayoutEffect", [control.control, nameValue], () => {
+      const subscription: ArraySubscription = {
+        notify: (payload, notifyTools) => {
+          const fieldArrayName = payload.name;
+          if (fieldArrayName !== undefined && getTruthiness(fieldArrayName) !== false) {
+            const signal = knownString(fieldArrayName);
+            if (signal !== null && signal !== name) return;
+          }
+          const fieldValues = readPath(payload.values ?? UNDEFINED_VALUE, name);
+          if (fieldValues.kind === "list") {
+            notifyTools.call(setFields, [fieldValues]);
+            instance.ids = fieldValues.items.map(generateId);
+          } else if (fieldValues.kind !== "primitive") {
+            notifyTools.call(setFields, [unknownValue(`field array "${name}" after an update`)]);
+          }
+        },
+      };
+      control.arraySubscriptions.add(subscription);
+      return nativeFunction("unsubscribe", () => {
+        control.arraySubscriptions.delete(subscription);
         return UNDEFINED_VALUE;
-      }
-      instance.ids = updated.map(generateId);
-      updateValues(updated, methodTools);
-      return UNDEFINED_VALUE;
+      });
     });
-  const toItems = (value: StaticValue | undefined): StaticValue[] | null => {
-    if (value === undefined) return [];
-    if (value.kind === "list")
-      return value.items.some(isIndefinite) ? null : value.items.map(cloneValue);
-    return [cloneValue(value)];
-  };
-  const knownIndex = (value: StaticValue | undefined): number | null =>
-    value?.kind === "primitive" && typeof value.value === "number" ? value.value : null;
-  useEffectHook(
-    tools,
-    "useEffect",
-    [nameValue, control.control, primitiveValue(keyName), shouldUnregister],
-    (effectTools) => {
-      if (getTruthiness(readPath(readStore(control, "formValues"), name)) === false) {
-        writeStore(
-          control,
-          "formValues",
-          writePath(readStore(control, "formValues"), toPath(name), listValue([])),
-          effectTools,
-        );
-      }
-    },
-  );
-  return objectFromRecord({
-    swap: arrayMethod("swap", (items, [from, to]) => {
-      const fromIndex = knownIndex(from);
-      const toIndex = knownIndex(to);
-      if (fromIndex === null || toIndex === null) return null;
-      const updated = [...items];
-      [updated[fromIndex], updated[toIndex]] = [
-        updated[toIndex] ?? UNDEFINED_VALUE,
-        updated[fromIndex] ?? UNDEFINED_VALUE,
-      ];
-      return updated;
-    }),
-    move: arrayMethod("move", (items, [from, to]) => {
-      const fromIndex = knownIndex(from);
-      const toIndex = knownIndex(to);
-      if (fromIndex === null || toIndex === null) return null;
-      const updated = [...items];
-      const [moved] = updated.splice(fromIndex, 1);
-      updated.splice(toIndex, 0, moved ?? UNDEFINED_VALUE);
-      return updated;
-    }),
-    prepend: arrayMethod("prepend", (items, [value]) => {
-      const added = toItems(value);
-      return added && [...added, ...items];
-    }),
-    append: arrayMethod("append", (items, [value]) => {
-      const added = toItems(value);
-      return added && [...items, ...added];
-    }),
-    remove: arrayMethod("remove", (items, [index]) => {
-      if (index === undefined || isUndefined(index)) return [];
-      const indexes = index.kind === "list" ? index.items.map(knownIndex) : [knownIndex(index)];
-      return indexes.includes(null)
-        ? null
-        : items.filter((_item, position) => !indexes.includes(position));
-    }),
-    insert: arrayMethod("insert", (items, [index, value]) => {
-      const position = knownIndex(index);
-      const added = toItems(value);
-      if (position === null || added === null) return null;
-      return [...items.slice(0, position), ...added, ...items.slice(position)];
-    }),
-    update: arrayMethod("update", (items, [index, value]) => {
-      const position = knownIndex(index);
-      if (position === null) return null;
-      const updated = [...items];
-      updated[position] = cloneValue(value ?? UNDEFINED_VALUE);
-      return updated;
-    }),
-    replace: arrayMethod("replace", (_items, [value]) => toItems(value)),
-    fields:
-      fields.kind === "list"
-        ? listValue(
-            fields.items.map((field, index) =>
-              withProperties(spreadCopy(field), {
-                [keyName]: instance.ids[index] ?? generateId(),
-              }),
+    const updateValues = (updated: StaticValue[], updateTools: StubRenderTools): void => {
+      writeStore(
+        control,
+        "formValues",
+        writePath(readStore(control, "formValues"), toPath(name), listValue(updated)),
+        updateTools,
+      );
+      updateTools.call(setFields, [listValue(updated)]);
+      notifyState(
+        control,
+        {
+          name: nameValue,
+          isDirty: getDirty(control),
+          dirtyFields: isProxied(control, "dirtyFields")
+            ? unknownValue("dirty fields after a field array change")
+            : readFormState(control, "dirtyFields"),
+          errors: readFormState(control, "errors"),
+          isValid: readFormState(control, "isValid"),
+        },
+        updateTools,
+      );
+      notifyState(
+        control,
+        { name: nameValue, values: cloneValue(readStore(control, "formValues")) },
+        updateTools,
+      );
+      setValid(control, false, updateTools);
+    };
+    const currentItems = (): StaticValue[] | null => {
+      const current = getFieldArray(control, name);
+      return current.kind === "list" ? current.items : null;
+    };
+    const arrayMethod = (
+      methodName: string,
+      apply: (items: StaticValue[], args: StaticValue[]) => StaticValue[] | null,
+    ): StaticValue =>
+      nativeFunction(methodName, (args, methodTools) => {
+        const items = currentItems();
+        const updated = items ? apply(items, args) : null;
+        if (updated === null) {
+          writeStore(
+            control,
+            "formValues",
+            writePath(
+              readStore(control, "formValues"),
+              toPath(name),
+              unknownValue(`field array "${name}" after ${methodName}`),
             ),
-          )
-        : fields,
-  });
+            methodTools,
+          );
+          methodTools.call(setFields, [unknownValue(`field array "${name}" after ${methodName}`)]);
+          return UNDEFINED_VALUE;
+        }
+        instance.ids = updated.map(generateId);
+        updateValues(updated, methodTools);
+        return UNDEFINED_VALUE;
+      });
+    const toItems = (value: StaticValue | undefined): StaticValue[] | null => {
+      if (value === undefined) return [];
+      if (value.kind === "list")
+        return value.items.some(isIndefinite) ? null : value.items.map(cloneValue);
+      return [cloneValue(value)];
+    };
+    const knownIndex = (value: StaticValue | undefined): number | null =>
+      value?.kind === "primitive" && typeof value.value === "number" ? value.value : null;
+    useEffectHook(
+      tools,
+      "useEffect",
+      [nameValue, control.control, primitiveValue(keyName), shouldUnregister],
+      (effectTools) => {
+        if (getTruthiness(readPath(readStore(control, "formValues"), name)) === false) {
+          writeStore(
+            control,
+            "formValues",
+            writePath(readStore(control, "formValues"), toPath(name), listValue([])),
+            effectTools,
+          );
+        }
+      },
+    );
+    return objectFromRecord({
+      swap: arrayMethod("swap", (items, [from, to]) => {
+        const fromIndex = knownIndex(from);
+        const toIndex = knownIndex(to);
+        if (fromIndex === null || toIndex === null) return null;
+        const updated = [...items];
+        [updated[fromIndex], updated[toIndex]] = [
+          updated[toIndex] ?? UNDEFINED_VALUE,
+          updated[fromIndex] ?? UNDEFINED_VALUE,
+        ];
+        return updated;
+      }),
+      move: arrayMethod("move", (items, [from, to]) => {
+        const fromIndex = knownIndex(from);
+        const toIndex = knownIndex(to);
+        if (fromIndex === null || toIndex === null) return null;
+        const updated = [...items];
+        const [moved] = updated.splice(fromIndex, 1);
+        updated.splice(toIndex, 0, moved ?? UNDEFINED_VALUE);
+        return updated;
+      }),
+      prepend: arrayMethod("prepend", (items, [value]) => {
+        const added = toItems(value);
+        return added && [...added, ...items];
+      }),
+      append: arrayMethod("append", (items, [value]) => {
+        const added = toItems(value);
+        return added && [...items, ...added];
+      }),
+      remove: arrayMethod("remove", (items, [index]) => {
+        if (index === undefined || isUndefined(index)) return [];
+        const indexes = index.kind === "list" ? index.items.map(knownIndex) : [knownIndex(index)];
+        return indexes.includes(null)
+          ? null
+          : items.filter((_item, position) => !indexes.includes(position));
+      }),
+      insert: arrayMethod("insert", (items, [index, value]) => {
+        const position = knownIndex(index);
+        const added = toItems(value);
+        if (position === null || added === null) return null;
+        return [...items.slice(0, position), ...added, ...items.slice(position)];
+      }),
+      update: arrayMethod("update", (items, [index, value]) => {
+        const position = knownIndex(index);
+        if (position === null) return null;
+        const updated = [...items];
+        updated[position] = cloneValue(value ?? UNDEFINED_VALUE);
+        return updated;
+      }),
+      replace: arrayMethod("replace", (_items, [value]) => toItems(value)),
+      fields:
+        fields.kind === "list"
+          ? listValue(
+              fields.items.map((field, index) =>
+                withProperties(spreadCopy(field), {
+                  [keyName]: instance.ids[index] ?? generateId(),
+                }),
+              ),
+            )
+          : fields,
+    });
   });
 
 const get = nativeFunction("get", ([object, path, defaultValue]) => {

--- a/packages/parser/src/materialize/markers.ts
+++ b/packages/parser/src/materialize/markers.ts
@@ -31,6 +31,14 @@ export interface BranchMarkerProps extends MarkerChildrenProps {
   reason: string;
   location: string | null;
   preferredIndex: number | null;
+  /** Identity of the decision; branches sharing one are selected together. */
+  predicate: string | null;
+}
+
+export interface RepeatMarkerProps extends MarkerChildrenProps {
+  location: string | null;
+  countMin: number;
+  countMax: number | null;
 }
 
 export interface OpaqueMarkerProps extends MarkerChildrenProps {
@@ -42,6 +50,8 @@ export interface OpaqueMarkerProps extends MarkerChildrenProps {
 
 export interface UnknownMarkerProps {
   reason: string;
+  /** The subtree was not materialized, so the states below it are not enumerated. */
+  isTruncated: boolean;
 }
 
 export const TEXT_PLACEHOLDER = "\u2026";
@@ -61,7 +71,7 @@ export const AlternativeMarker = named(
 
 export const RepeatMarker = named(
   MARKER_NAMES.repeat,
-  ({ children }: MarkerChildrenProps): ReactNode => children,
+  ({ children }: RepeatMarkerProps): ReactNode => children,
 );
 
 export const OpaqueMarker = named(

--- a/packages/parser/src/materialize/materializer.ts
+++ b/packages/parser/src/materialize/materializer.ts
@@ -513,6 +513,9 @@ export class Materializer {
         return value.items.map((item) => this.toNode(item, context, false));
       case "repeat":
         return this.runtime.react.createElement(RepeatMarker, {
+          location: value.location && formatSourceLocation(value.location),
+          countMin: value.count?.min ?? 0,
+          countMax: value.count?.max ?? null,
           children: [this.toNode(value.item, context, false)],
         });
       case "branch":
@@ -524,6 +527,7 @@ export class Materializer {
           value.preferredIndex,
           isTopLevel,
           value.location,
+          value.predicate,
         );
       case "optional":
         return this.branchNode(
@@ -555,6 +559,7 @@ export class Materializer {
     if (context.alternativeDepth >= MAX_ALTERNATIVE_DEPTH) {
       return this.unknownNode(
         `alternative nested ${MAX_ALTERNATIVE_DEPTH} branches away from the preferred path`,
+        true,
       );
     }
     return this.toNode(
@@ -570,20 +575,22 @@ export class Materializer {
     preferredIndex: number | null,
     isTopLevel: boolean,
     location: SourceLocation | null = null,
+    predicate: string | null = null,
   ): ReactNode {
     const { createElement } = this.runtime.react;
     return createElement(BranchMarker, {
       reason,
       location: location && formatSourceLocation(location),
       preferredIndex,
+      predicate,
       children: alternatives.map((node, index) =>
         createElement(AlternativeMarker, { key: index, children: isTopLevel ? node : [node] }),
       ),
     });
   }
 
-  private unknownNode(reason: string): ReactNode {
-    return this.runtime.react.createElement(UnknownMarker, { reason });
+  private unknownNode(reason: string, isTruncated = false): ReactNode {
+    return this.runtime.react.createElement(UnknownMarker, { reason, isTruncated });
   }
 
   /** An element whose component is not known may suspend (a `use()` or lazy inside it). */
@@ -677,7 +684,7 @@ export class Materializer {
           "warning",
         );
       }
-      return this.unknownNode("element budget exhausted");
+      return this.unknownNode("element budget exhausted", true);
     }
     const reactKey = this.keyToString(key, location);
     const children = getObjectProperty(props, "children");

--- a/packages/parser/src/materialize/mount.ts
+++ b/packages/parser/src/materialize/mount.ts
@@ -11,6 +11,8 @@ const noop = (): void => {};
 
 export interface MountResult {
   snapshot: RuntimeSnapshot;
+  /** Every tree React committed while settling, in order; the last one is `snapshot`. */
+  commits: RuntimeSnapshot[];
   /** Errors React surfaced while rendering: uncaught ones unmount the tree, caught ones reached a boundary. */
   uncaughtErrors: unknown[];
   caughtErrors: unknown[];
@@ -32,6 +34,7 @@ export const mountNode = async (
   document.body.appendChild(container);
   const recorder = createCommitRecorder({
     rootFilter: (root) => getRootContainer(root) === container,
+    recordCommits: true,
   });
   const uncaughtErrors: unknown[] = [];
   const caughtErrors: unknown[] = [];
@@ -59,7 +62,12 @@ export const mountNode = async (
     } catch (error) {
       uncaughtErrors.push(error);
     }
-    return { snapshot: recorder.snapshot(), uncaughtErrors, caughtErrors };
+    return {
+      snapshot: recorder.snapshot(),
+      commits: recorder.commits(),
+      uncaughtErrors,
+      caughtErrors,
+    };
   } finally {
     await runtime.act(async () => root.unmount());
     console.error = consoleError;

--- a/packages/parser/src/render/static-renderer.ts
+++ b/packages/parser/src/render/static-renderer.ts
@@ -188,6 +188,7 @@ export class StaticRenderer {
     }
     return {
       snapshot: mounted.snapshot,
+      commits: mounted.commits,
       diagnostics: [...interpreter.diagnostics],
       stats: computeRenderStats(mounted.snapshot, this.graph.loadedModuleCount),
     };

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -603,6 +603,8 @@ export interface StaticRepeatValue {
   kind: "repeat";
   item: StaticValue;
   location: SourceLocation | null;
+  /** Inclusive bounds of the item count when the interpreter knows them. */
+  count?: NumberRange;
 }
 
 export interface StaticBranchValue {
@@ -611,6 +613,11 @@ export interface StaticBranchValue {
   preferredIndex: number;
   reason: string;
   location: SourceLocation | null;
+  /**
+   * Identity of the decision that selects an alternative. Branches sharing a
+   * predicate take the same alternative index in any one reachable state.
+   */
+  predicate: string | null;
 }
 
 export interface StaticFunctionValue {
@@ -846,6 +853,8 @@ export interface StaticRenderStats {
 export interface StaticRenderResult {
   /** The fiber tree React committed for the materialized element, as bippy observed it. */
   snapshot: RuntimeSnapshot;
+  /** Every tree committed while effects, state updates and timers settled, in commit order. */
+  commits: RuntimeSnapshot[];
   diagnostics: Diagnostic[];
   stats: StaticRenderStats;
 }

--- a/packages/parser/tests/fixtures.test.ts
+++ b/packages/parser/tests/fixtures.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, it } from "vite-plus/test";
 import type { CapturedMutation, CapturedQuery } from "../src/index.js";
+import type { ComparisonStatus } from "../src/harness/index.js";
 import { describeFixtureRun, listFixtures, runFixture } from "./helpers/fixture-runner.js";
 
-const STATUS_RANK = { exact: 3, partial: 2, mismatch: 0, unresolved: 0, skipped: 0 };
+const STATUS_RANK: Record<ComparisonStatus, number> = {
+  exact: 4,
+  truncated: 3,
+  partial: 2,
+  mismatch: 0,
+  unresolved: 0,
+  skipped: 0,
+};
+
+/** The runtime tree was one enumerated state, with every decision that selects it known. */
+const isMember = (status: ComparisonStatus): boolean =>
+  status === "exact" || status === "truncated";
 
 const withoutTimestamps = (query: CapturedQuery | undefined): CapturedQuery | undefined =>
   query && { ...query, dataUpdatedAt: 0, errorUpdatedAt: 0 };
@@ -25,12 +37,23 @@ describe("synthetic fixtures: static fiber tree vs react-dom", () => {
         detail,
       ).toEqual([]);
       if (!run.comparison) return;
-      const { report } = run.comparison;
+      const { report, stateSpace, matchedState } = run.comparison;
       expect(report.status, detail).not.toBe("mismatch");
       expect(STATUS_RANK[report.status], detail).toBeGreaterThanOrEqual(
         STATUS_RANK[fixture.manifest.expectedStatus],
       );
       expect(report.coverage, detail).toBeGreaterThanOrEqual(fixture.manifest.minCoverage);
+      if (isMember(report.status)) {
+        expect(matchedState, detail).not.toBeNull();
+        expect(stateSpace.states.length, detail).toBeGreaterThan(0);
+      }
+      if (report.status === "exact") expect(stateSpace.omitted, detail).toBeNull();
+      if (fixture.manifest.expectedStates !== undefined) {
+        expect(stateSpace.states.length, detail).toBe(fixture.manifest.expectedStates);
+      }
+      if (fixture.manifest.expectOmitted !== undefined) {
+        expect(stateSpace.omitted !== null, detail).toBe(fixture.manifest.expectOmitted);
+      }
       const replayed = fixture.manifest.observations;
       for (const observed of replayed?.queries ?? []) {
         const captured = run.observed.queries.find(

--- a/packages/parser/tests/fixtures/states-budget-exhausted/fixture.json
+++ b/packages/parser/tests/fixtures/states-budget-exhausted/fixture.json
@@ -1,0 +1,9 @@
+{
+  "entry": "src/main.tsx",
+  "expectedStatus": "truncated",
+  "minCoverage": 1,
+  "stateSpaceBudget": { "maxStates": 4 },
+  "expectedStates": 4,
+  "expectOmitted": true,
+  "notes": "Four independent flags reach sixteen states but the budget allows four. The remaining alternatives are reported as omitted, and a runtime match against the bounded space is truncated, never exact."
+}

--- a/packages/parser/tests/fixtures/states-budget-exhausted/node_modules/flag-kit/index.d.ts
+++ b/packages/parser/tests/fixtures/states-budget-exhausted/node_modules/flag-kit/index.d.ts
@@ -1,0 +1,1 @@
+export declare const useFlag: (name: string) => boolean;

--- a/packages/parser/tests/fixtures/states-budget-exhausted/node_modules/flag-kit/index.js
+++ b/packages/parser/tests/fixtures/states-budget-exhausted/node_modules/flag-kit/index.js
@@ -1,0 +1,2 @@
+const FLAGS = { compact: true, dark: false, beta: true, legacy: false };
+export const useFlag = (name) => FLAGS[name] ?? false;

--- a/packages/parser/tests/fixtures/states-budget-exhausted/node_modules/flag-kit/package.json
+++ b/packages/parser/tests/fixtures/states-budget-exhausted/node_modules/flag-kit/package.json
@@ -1,0 +1,1 @@
+{ "name": "flag-kit", "version": "0.0.0", "type": "module", "main": "./index.js", "types": "./index.d.ts" }

--- a/packages/parser/tests/fixtures/states-budget-exhausted/package.json
+++ b/packages/parser/tests/fixtures/states-budget-exhausted/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-states-budget-exhausted",
+  "private": true,
+  "type": "module"
+}

--- a/packages/parser/tests/fixtures/states-budget-exhausted/src/app.tsx
+++ b/packages/parser/tests/fixtures/states-budget-exhausted/src/app.tsx
@@ -1,0 +1,16 @@
+import { useFlag } from "flag-kit";
+
+export const App = () => {
+  const isCompact = useFlag("compact");
+  const isDark = useFlag("dark");
+  const isBeta = useFlag("beta");
+  const isLegacy = useFlag("legacy");
+  return (
+    <main>
+      {isCompact ? <small>compact</small> : <p>spacious</p>}
+      {isDark ? <header className="dark" /> : <header className="light" />}
+      {isBeta ? <mark>beta</mark> : <span>stable</span>}
+      {isLegacy ? <del>legacy</del> : <ins>modern</ins>}
+    </main>
+  );
+};

--- a/packages/parser/tests/fixtures/states-budget-exhausted/src/main.tsx
+++ b/packages/parser/tests/fixtures/states-budget-exhausted/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/packages/parser/tests/fixtures/states-budget-exhausted/tsconfig.json
+++ b/packages/parser/tests/fixtures/states-budget-exhausted/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] },
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "strict": true
+  }
+}

--- a/packages/parser/tests/fixtures/states-correlated-predicate/fixture.json
+++ b/packages/parser/tests/fixtures/states-correlated-predicate/fixture.json
@@ -1,0 +1,8 @@
+{
+  "entry": "src/main.tsx",
+  "expectedStatus": "exact",
+  "minCoverage": 1,
+  "expectedStates": 2,
+  "expectOmitted": false,
+  "notes": "One flag decides three conditionals (one through props, one negated). The decisions are correlated, so the space has two states rather than eight."
+}

--- a/packages/parser/tests/fixtures/states-correlated-predicate/node_modules/flag-kit/index.d.ts
+++ b/packages/parser/tests/fixtures/states-correlated-predicate/node_modules/flag-kit/index.d.ts
@@ -1,0 +1,1 @@
+export declare const useFlag: (name: string) => boolean;

--- a/packages/parser/tests/fixtures/states-correlated-predicate/node_modules/flag-kit/index.js
+++ b/packages/parser/tests/fixtures/states-correlated-predicate/node_modules/flag-kit/index.js
@@ -1,0 +1,2 @@
+const FLAGS = { compact: true, dark: false, beta: true, legacy: false };
+export const useFlag = (name) => FLAGS[name] ?? false;

--- a/packages/parser/tests/fixtures/states-correlated-predicate/node_modules/flag-kit/package.json
+++ b/packages/parser/tests/fixtures/states-correlated-predicate/node_modules/flag-kit/package.json
@@ -1,0 +1,1 @@
+{ "name": "flag-kit", "version": "0.0.0", "type": "module", "main": "./index.js", "types": "./index.d.ts" }

--- a/packages/parser/tests/fixtures/states-correlated-predicate/package.json
+++ b/packages/parser/tests/fixtures/states-correlated-predicate/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-states-correlated-predicate",
+  "private": true,
+  "type": "module"
+}

--- a/packages/parser/tests/fixtures/states-correlated-predicate/src/app.tsx
+++ b/packages/parser/tests/fixtures/states-correlated-predicate/src/app.tsx
@@ -1,0 +1,16 @@
+import { useFlag } from "flag-kit";
+
+const Toolbar = ({ isCompact }: { isCompact: boolean }) => (
+  <nav>{isCompact ? <button type="button" /> : <menu />}</nav>
+);
+
+export const App = () => {
+  const isCompact = useFlag("compact");
+  return (
+    <main>
+      <Toolbar isCompact={isCompact} />
+      {isCompact ? <small>compact</small> : <p>spacious</p>}
+      {!isCompact ? <aside>details</aside> : <span>summary</span>}
+    </main>
+  );
+};

--- a/packages/parser/tests/fixtures/states-correlated-predicate/src/main.tsx
+++ b/packages/parser/tests/fixtures/states-correlated-predicate/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/packages/parser/tests/fixtures/states-correlated-predicate/tsconfig.json
+++ b/packages/parser/tests/fixtures/states-correlated-predicate/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] },
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "strict": true
+  }
+}

--- a/packages/parser/tests/fixtures/states-effect-update/fixture.json
+++ b/packages/parser/tests/fixtures/states-effect-update/fixture.json
@@ -1,0 +1,8 @@
+{
+  "entry": "src/main.tsx",
+  "expectedStatus": "exact",
+  "minCoverage": 1,
+  "expectedStates": 2,
+  "expectOmitted": false,
+  "notes": "A mount effect flips a state cell, so two trees are committed within the settle window. Each commit is its own state; the runtime snapshot must equal the last one."
+}

--- a/packages/parser/tests/fixtures/states-effect-update/package.json
+++ b/packages/parser/tests/fixtures/states-effect-update/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-states-effect-update",
+  "private": true,
+  "type": "module"
+}

--- a/packages/parser/tests/fixtures/states-effect-update/src/app.tsx
+++ b/packages/parser/tests/fixtures/states-effect-update/src/app.tsx
@@ -1,0 +1,9 @@
+import { useEffect, useState } from "react";
+
+export const App = () => {
+  const [isReady, setIsReady] = useState(false);
+  useEffect(() => {
+    setIsReady(true);
+  }, []);
+  return <main>{isReady ? <output>ready</output> : <progress />}</main>;
+};

--- a/packages/parser/tests/fixtures/states-effect-update/src/main.tsx
+++ b/packages/parser/tests/fixtures/states-effect-update/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/packages/parser/tests/fixtures/states-effect-update/tsconfig.json
+++ b/packages/parser/tests/fixtures/states-effect-update/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] },
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "strict": true
+  }
+}

--- a/packages/parser/tests/fixtures/states-host-unknown/fixture.json
+++ b/packages/parser/tests/fixtures/states-host-unknown/fixture.json
@@ -1,0 +1,8 @@
+{
+  "entry": "src/main.tsx",
+  "expectedStatus": "exact",
+  "minCoverage": 1,
+  "expectedStates": 2,
+  "expectOmitted": false,
+  "notes": "The viewport width is a host value the analysis cannot know, so the layout conditional is enumerated as two states and the runtime selects one."
+}

--- a/packages/parser/tests/fixtures/states-host-unknown/package.json
+++ b/packages/parser/tests/fixtures/states-host-unknown/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-states-host-unknown",
+  "private": true,
+  "type": "module"
+}

--- a/packages/parser/tests/fixtures/states-host-unknown/src/app.tsx
+++ b/packages/parser/tests/fixtures/states-host-unknown/src/app.tsx
@@ -1,0 +1,6 @@
+const WIDE_VIEWPORT = 600;
+
+export const App = () => {
+  const isWide = window.innerWidth > WIDE_VIEWPORT;
+  return <main>{isWide ? <table /> : <dl />}</main>;
+};

--- a/packages/parser/tests/fixtures/states-host-unknown/src/main.tsx
+++ b/packages/parser/tests/fixtures/states-host-unknown/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/packages/parser/tests/fixtures/states-host-unknown/tsconfig.json
+++ b/packages/parser/tests/fixtures/states-host-unknown/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] },
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "strict": true
+  }
+}

--- a/packages/parser/tests/fixtures/states-nested-independent/fixture.json
+++ b/packages/parser/tests/fixtures/states-nested-independent/fixture.json
@@ -1,0 +1,8 @@
+{
+  "entry": "src/main.tsx",
+  "expectedStatus": "exact",
+  "minCoverage": 1,
+  "expectedStates": 4,
+  "expectOmitted": false,
+  "notes": "Two flags decided independently (one inside a child component) multiply: every combination is a reachable state, so the space has four members."
+}

--- a/packages/parser/tests/fixtures/states-nested-independent/node_modules/flag-kit/index.d.ts
+++ b/packages/parser/tests/fixtures/states-nested-independent/node_modules/flag-kit/index.d.ts
@@ -1,0 +1,1 @@
+export declare const useFlag: (name: string) => boolean;

--- a/packages/parser/tests/fixtures/states-nested-independent/node_modules/flag-kit/index.js
+++ b/packages/parser/tests/fixtures/states-nested-independent/node_modules/flag-kit/index.js
@@ -1,0 +1,2 @@
+const FLAGS = { compact: true, dark: false, beta: true, legacy: false };
+export const useFlag = (name) => FLAGS[name] ?? false;

--- a/packages/parser/tests/fixtures/states-nested-independent/node_modules/flag-kit/package.json
+++ b/packages/parser/tests/fixtures/states-nested-independent/node_modules/flag-kit/package.json
@@ -1,0 +1,1 @@
+{ "name": "flag-kit", "version": "0.0.0", "type": "module", "main": "./index.js", "types": "./index.d.ts" }

--- a/packages/parser/tests/fixtures/states-nested-independent/package.json
+++ b/packages/parser/tests/fixtures/states-nested-independent/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-states-nested-independent",
+  "private": true,
+  "type": "module"
+}

--- a/packages/parser/tests/fixtures/states-nested-independent/src/app.tsx
+++ b/packages/parser/tests/fixtures/states-nested-independent/src/app.tsx
@@ -1,0 +1,15 @@
+import { useFlag } from "flag-kit";
+
+const Header = ({ isDark }: { isDark: boolean }) =>
+  isDark ? <header className="dark" /> : <header className="light" />;
+
+export const App = () => {
+  const isCompact = useFlag("compact");
+  const isDark = useFlag("dark");
+  return (
+    <main>
+      <Header isDark={isDark} />
+      {isCompact ? <small>compact</small> : <p>spacious</p>}
+    </main>
+  );
+};

--- a/packages/parser/tests/fixtures/states-nested-independent/src/main.tsx
+++ b/packages/parser/tests/fixtures/states-nested-independent/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/packages/parser/tests/fixtures/states-nested-independent/tsconfig.json
+++ b/packages/parser/tests/fixtures/states-nested-independent/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] },
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "strict": true
+  }
+}

--- a/packages/parser/tests/fixtures/states-repeat-cardinality/fixture.json
+++ b/packages/parser/tests/fixtures/states-repeat-cardinality/fixture.json
@@ -1,0 +1,8 @@
+{
+  "entry": "src/main.tsx",
+  "expectedStatus": "truncated",
+  "minCoverage": 1,
+  "expectedStates": 3,
+  "expectOmitted": true,
+  "notes": "A list from an opaque package has unknown length. Cardinalities 0, 1 and 2 are enumerated as states; larger counts are reported as an omission, so a runtime match is truncated rather than exact."
+}

--- a/packages/parser/tests/fixtures/states-repeat-cardinality/node_modules/feed-kit/index.d.ts
+++ b/packages/parser/tests/fixtures/states-repeat-cardinality/node_modules/feed-kit/index.d.ts
@@ -1,0 +1,5 @@
+export interface FeedItem {
+  id: string;
+  title: string;
+}
+export declare const useFeed: () => FeedItem[];

--- a/packages/parser/tests/fixtures/states-repeat-cardinality/node_modules/feed-kit/index.js
+++ b/packages/parser/tests/fixtures/states-repeat-cardinality/node_modules/feed-kit/index.js
@@ -1,0 +1,5 @@
+const ITEMS = [
+  { id: "a", title: "first" },
+  { id: "b", title: "second" },
+];
+export const useFeed = () => ITEMS;

--- a/packages/parser/tests/fixtures/states-repeat-cardinality/node_modules/feed-kit/package.json
+++ b/packages/parser/tests/fixtures/states-repeat-cardinality/node_modules/feed-kit/package.json
@@ -1,0 +1,1 @@
+{ "name": "feed-kit", "version": "0.0.0", "type": "module", "main": "./index.js", "types": "./index.d.ts" }

--- a/packages/parser/tests/fixtures/states-repeat-cardinality/package.json
+++ b/packages/parser/tests/fixtures/states-repeat-cardinality/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-states-repeat-cardinality",
+  "private": true,
+  "type": "module"
+}

--- a/packages/parser/tests/fixtures/states-repeat-cardinality/src/app.tsx
+++ b/packages/parser/tests/fixtures/states-repeat-cardinality/src/app.tsx
@@ -1,0 +1,14 @@
+import { useFeed } from "feed-kit";
+
+const Entry = ({ title }: { title: string }) => <li>{title}</li>;
+
+export const App = () => {
+  const items = useFeed();
+  return (
+    <ul>
+      {items.map((item) => (
+        <Entry key={item.id} title={item.title} />
+      ))}
+    </ul>
+  );
+};

--- a/packages/parser/tests/fixtures/states-repeat-cardinality/src/main.tsx
+++ b/packages/parser/tests/fixtures/states-repeat-cardinality/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/packages/parser/tests/fixtures/states-repeat-cardinality/tsconfig.json
+++ b/packages/parser/tests/fixtures/states-repeat-cardinality/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] },
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "strict": true
+  }
+}

--- a/packages/parser/tests/fixtures/states-two-way/fixture.json
+++ b/packages/parser/tests/fixtures/states-two-way/fixture.json
@@ -1,0 +1,8 @@
+{
+  "entry": "src/main.tsx",
+  "expectedStatus": "exact",
+  "minCoverage": 1,
+  "expectedStates": 2,
+  "expectOmitted": false,
+  "notes": "A flag from an opaque package selects one of two subtrees; both are enumerated as states and the runtime must equal exactly one of them."
+}

--- a/packages/parser/tests/fixtures/states-two-way/node_modules/flag-kit/index.d.ts
+++ b/packages/parser/tests/fixtures/states-two-way/node_modules/flag-kit/index.d.ts
@@ -1,0 +1,1 @@
+export declare const useFlag: (name: string) => boolean;

--- a/packages/parser/tests/fixtures/states-two-way/node_modules/flag-kit/index.js
+++ b/packages/parser/tests/fixtures/states-two-way/node_modules/flag-kit/index.js
@@ -1,0 +1,2 @@
+const FLAGS = { compact: true, dark: false, beta: true, legacy: false };
+export const useFlag = (name) => FLAGS[name] ?? false;

--- a/packages/parser/tests/fixtures/states-two-way/node_modules/flag-kit/package.json
+++ b/packages/parser/tests/fixtures/states-two-way/node_modules/flag-kit/package.json
@@ -1,0 +1,1 @@
+{ "name": "flag-kit", "version": "0.0.0", "type": "module", "main": "./index.js", "types": "./index.d.ts" }

--- a/packages/parser/tests/fixtures/states-two-way/package.json
+++ b/packages/parser/tests/fixtures/states-two-way/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-states-two-way",
+  "private": true,
+  "type": "module"
+}

--- a/packages/parser/tests/fixtures/states-two-way/src/app.tsx
+++ b/packages/parser/tests/fixtures/states-two-way/src/app.tsx
@@ -1,0 +1,9 @@
+import { useFlag } from "flag-kit";
+
+const Compact = () => <small>compact</small>;
+const Spacious = () => <p>spacious</p>;
+
+export const App = () => {
+  const isCompact = useFlag("compact");
+  return <main>{isCompact ? <Compact /> : <Spacious />}</main>;
+};

--- a/packages/parser/tests/fixtures/states-two-way/src/main.tsx
+++ b/packages/parser/tests/fixtures/states-two-way/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/packages/parser/tests/fixtures/states-two-way/tsconfig.json
+++ b/packages/parser/tests/fixtures/states-two-way/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] },
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "strict": true
+  }
+}

--- a/packages/parser/tests/helpers/component-runner.ts
+++ b/packages/parser/tests/helpers/component-runner.ts
@@ -8,7 +8,8 @@ import { createStaticRenderer, type StaticRenderResult } from "../../src/index.j
 import {
   compareStaticToRuntime,
   createCommitRecorder,
-  formatComparisonReport,
+  enumerateStaticStates,
+  formatCompareRenderResult,
   formatPattern,
   formatRuntimeSnapshot,
   getRenderPattern,
@@ -109,7 +110,7 @@ export const runComponentFixture = async (
   });
   const staticResult = await renderer.renderComponent(fixture.filePath);
   const runtime = await runFromProjectRoot(() => mountComponent(loaded.default));
-  const comparison = compareStaticToRuntime(staticResult, runtime);
+  const comparison = compareStaticToRuntime(enumerateStaticStates(staticResult), runtime);
   return { staticResult, runtime, comparison, minCoverage: loaded.minCoverage ?? 1 };
 };
 
@@ -118,7 +119,7 @@ export const describeComponentRun = (fixture: ComponentFixture, run: ComponentRu
     `fixture: ${fixture.name}`,
     `static:\n${formatPattern(getRenderPattern(run.staticResult))}`,
     `runtime:\n${run.runtime.roots.map((root) => formatRuntimeSnapshot(root)).join("\n")}`,
-    `comparison:\n${formatComparisonReport(run.comparison.report)}`,
+    `comparison:\n${formatCompareRenderResult(run.comparison)}`,
     ...(run.staticResult.diagnostics.length > 0
       ? [
           `diagnostics:\n${run.staticResult.diagnostics

--- a/packages/parser/tests/helpers/fixture-runner.ts
+++ b/packages/parser/tests/helpers/fixture-runner.ts
@@ -10,7 +10,8 @@ import {
 import {
   compareStaticToRuntime,
   createCommitRecorder,
-  formatComparisonReport,
+  enumerateStaticStates,
+  formatCompareRenderResult,
   formatPattern,
   formatRuntimeSnapshot,
   getRenderPattern,
@@ -20,6 +21,7 @@ import {
   type ComparisonStatus,
   type RuntimeFiberSnapshot,
   type RuntimeSnapshot,
+  type StateSpaceBudget,
 } from "../../src/harness/index.js";
 import { NODE_TIMER_UNDERRUN_MS } from "../../src/evaluate/timers.js";
 import { installReduxStoreHook } from "../../src/harness/redux-store.js";
@@ -36,6 +38,12 @@ export interface FixtureManifest {
   /** Runtime state replayed into the static render, as a live capture would record it. */
   observations?: RuntimeObservations;
   skipRuntime?: boolean;
+  /** Bounds on the enumerated state space; defaults are generous enough for every fixture but the budget one. */
+  stateSpaceBudget?: Partial<StateSpaceBudget>;
+  /** How many concrete states the static render must enumerate. */
+  expectedStates?: number;
+  /** Whether the enumeration must (true) or must not (false) report omitted states. */
+  expectOmitted?: boolean;
   notes?: string;
 }
 
@@ -156,14 +164,12 @@ export const runFixture = async (fixture: FixtureCase): Promise<FixtureRunResult
     };
   }
   const { snapshot: runtime, observed } = await mountFixture(fixture);
-  const comparison = compareStaticToRuntime(
-    staticResult,
-    flattenTransparentFibers(runtime, profile),
-    {
-      anchor: fixture.manifest.anchor ?? profile.defaultAnchor ?? undefined,
-      transparentStaticFibers: profile.transparentStaticFibers,
-    },
-  );
+  const stateSpace = enumerateStaticStates(staticResult, {
+    anchor: fixture.manifest.anchor ?? profile.defaultAnchor ?? undefined,
+    transparentStaticFibers: profile.transparentStaticFibers,
+    budget: fixture.manifest.stateSpaceBudget,
+  });
+  const comparison = compareStaticToRuntime(stateSpace, flattenTransparentFibers(runtime, profile));
   return { staticResult, runtime, observed, comparison };
 };
 
@@ -178,7 +184,7 @@ export const describeFixtureRun = (fixture: FixtureCase, run: FixtureRunResult):
     );
   }
   if (run.comparison) {
-    sections.push(`comparison:\n${formatComparisonReport(run.comparison.report)}`);
+    sections.push(`comparison:\n${formatCompareRenderResult(run.comparison)}`);
     if (run.comparison.note) sections.push(`note: ${run.comparison.note}`);
   }
   if (run.staticResult.diagnostics.length > 0) {

--- a/packages/parser/tests/state-membership.test.ts
+++ b/packages/parser/tests/state-membership.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vite-plus/test";
+import { compareStaticToRuntime, formatCompareRenderResult } from "../src/harness/index.js";
+import type { RuntimeFiberSnapshot, RuntimeSnapshot } from "../src/harness/snapshot.js";
+import { listFixtures, runFixture } from "./helpers/fixture-runner.js";
+
+const renameHostFibers = (
+  fibers: RuntimeFiberSnapshot[],
+  from: string,
+  to: string,
+): RuntimeFiberSnapshot[] =>
+  fibers.map((fiber) => ({
+    ...fiber,
+    name: fiber.tag === "HostComponent" && fiber.name === from ? to : fiber.name,
+    children: renameHostFibers(fiber.children, from, to),
+  }));
+
+describe("runtime outside the enumerated states", () => {
+  it("reports a mismatch with the closest state", async () => {
+    const fixture = listFixtures().find((candidate) => candidate.name === "states-two-way");
+    if (!fixture) throw new Error("states-two-way fixture is missing");
+    const run = await runFixture(fixture);
+    if (!run.comparison || !run.runtime) throw new Error("states-two-way did not compare");
+    expect(run.comparison.report.status).toBe("exact");
+
+    const unreachable: RuntimeSnapshot = {
+      ...run.runtime,
+      roots: run.runtime.roots.map((root) => ({
+        ...root,
+        children: renameHostFibers(root.children, "small", "em"),
+      })),
+    };
+    const comparison = compareStaticToRuntime(run.comparison.stateSpace, unreachable);
+    const detail = formatCompareRenderResult(comparison);
+    expect(comparison.report.status, detail).toBe("mismatch");
+    expect(comparison.matchedState, detail).toBeNull();
+    expect(comparison.closestState?.divergence, detail).toMatchObject({
+      expected: expect.stringContaining("small"),
+      actual: expect.stringContaining("em"),
+    });
+    expect(comparison.stateSpace.states.length, detail).toBe(2);
+  });
+});

--- a/packages/parser/tests/state-space.test.ts
+++ b/packages/parser/tests/state-space.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { RuntimeFiberSnapshot } from "../src/harness/snapshot.js";
+import {
+  enumerateStateSpace,
+  matchStateSpace,
+  type StateCondition,
+} from "../src/harness/state-space.js";
+import type {
+  PatternBranch,
+  PatternFiber,
+  PatternNode,
+  PatternRepeat,
+} from "../src/harness/static-pattern.js";
+
+const host = (name: string, children: RuntimeFiberSnapshot[] = []): RuntimeFiberSnapshot => ({
+  tag: "HostComponent",
+  name,
+  key: null,
+  text: null,
+  props: {},
+  children,
+});
+
+const fiber = (name: string, children: PatternNode[] = []): PatternFiber => ({
+  kind: "fiber",
+  tag: "HostComponent",
+  name,
+  key: null,
+  children,
+});
+
+const branch = (variable: string, ...alternatives: PatternNode[][]): PatternBranch => ({
+  kind: "branch",
+  variable,
+  reason: variable,
+  location: null,
+  preferredIndex: 0,
+  alternatives,
+});
+
+const repeat = (
+  variable: string,
+  children: PatternNode[],
+  count: PatternRepeat["count"] = { min: 0, max: null },
+): PatternRepeat => ({ kind: "repeat", variable, location: null, count, children });
+
+const describeConditions = (conditions: StateCondition[]): string =>
+  conditions
+    .map((condition) => {
+      switch (condition.kind) {
+        case "branch":
+        case "state-update":
+          return `${condition.variable}=${condition.alternativeIndex}`;
+        case "repeat":
+          return `${condition.variable}×${condition.count}`;
+        case "transition":
+          return `commit${condition.commit}`;
+      }
+    })
+    .join(" ");
+
+describe("enumerateStateSpace", () => {
+  it("multiplies independent decisions and shares correlated ones", () => {
+    const independent = enumerateStateSpace([
+      [fiber("main", [branch("a", [fiber("x")], [fiber("y")]), branch("b", [fiber("p")], [])])],
+    ]);
+    expect(independent.states.map((state) => describeConditions(state.conditions))).toEqual([
+      "a=0 b=0",
+      "a=0 b=1",
+      "a=1 b=0",
+      "a=1 b=1",
+    ]);
+    expect(independent.omitted).toBeNull();
+
+    const correlated = enumerateStateSpace([
+      [
+        fiber("main", [
+          fiber("nav", [branch("a", [fiber("x")], [fiber("y")])]),
+          branch("a", [fiber("p")], [fiber("q")]),
+        ]),
+      ],
+    ]);
+    expect(correlated.states.map((state) => describeConditions(state.conditions))).toEqual([
+      "a=0",
+      "a=1",
+    ]);
+    expect(correlated.states[1].tree).toEqual([
+      fiber("main", [fiber("nav", [fiber("y")]), fiber("q")]),
+    ]);
+  });
+
+  it("enumerates repeat cardinalities up to the bound and records the rest as omitted", () => {
+    const unbounded = enumerateStateSpace([[fiber("ul", [repeat("r", [fiber("li")])])]]);
+    expect(unbounded.states.map((state) => describeConditions(state.conditions))).toEqual([
+      "r×0",
+      "r×1",
+      "r×2",
+    ]);
+    expect(unbounded.states[2].tree).toEqual([fiber("ul", [fiber("li"), fiber("li")])]);
+    expect(unbounded.omitted).toEqual({
+      omissions: [
+        {
+          kind: "repeat",
+          variable: "r",
+          location: null,
+          countsAbove: 2,
+          max: null,
+          conditions: [],
+        },
+      ],
+    });
+
+    const known = enumerateStateSpace([
+      [fiber("ul", [repeat("r", [fiber("li")], { min: 1, max: 2 })])],
+    ]);
+    expect(known.states.map((state) => describeConditions(state.conditions))).toEqual([
+      "r×1",
+      "r×2",
+    ]);
+    expect(known.omitted).toBeNull();
+  });
+
+  it("decides a branch inside a repeat once per iteration", () => {
+    const space = enumerateStateSpace([
+      [fiber("ul", [repeat("r", [branch("a", [fiber("li")], [fiber("dd")])], { min: 2, max: 2 })])],
+    ]);
+    expect(space.states.map((state) => describeConditions(state.conditions))).toEqual([
+      "r×2 a@r[0]=0 a@r[1]=0",
+      "r×2 a@r[0]=0 a@r[1]=1",
+      "r×2 a@r[0]=1 a@r[1]=0",
+      "r×2 a@r[0]=1 a@r[1]=1",
+    ]);
+  });
+
+  it("stops at the state budget and reports every alternative it could not expand", () => {
+    const space = enumerateStateSpace(
+      [[fiber("main", [branch("a", [fiber("x")], [fiber("y")]), branch("b", [fiber("p")], [])])]],
+      { maxStates: 3, maxRepeat: 2 },
+    );
+    expect(space.states).toHaveLength(3);
+    expect(space.omitted?.omissions.map((omission) => omission.kind)).toEqual(["state"]);
+    const [omission] = space.omitted?.omissions ?? [];
+    if (omission?.kind !== "state") throw new Error("expected the dropped state to be recorded");
+    expect(describeConditions(omission.conditions)).toBe("a=1 b=1");
+
+    const cutEarly = enumerateStateSpace(
+      [
+        [
+          fiber("main", [
+            branch("a", [fiber("x")], [fiber("y")]),
+            branch("b", [fiber("p")], [fiber("q")]),
+            branch("c", [fiber("s")], [fiber("t")]),
+          ]),
+        ],
+      ],
+      { maxStates: 2, maxRepeat: 2 },
+    );
+    expect(cutEarly.states.map((state) => describeConditions(state.conditions))).toEqual([
+      "a=0 b=0 c=0",
+      "a=0 b=0 c=1",
+    ]);
+    expect(
+      cutEarly.omitted?.omissions.map((omission) =>
+        omission.kind === "branch"
+          ? `${omission.variable}|${omission.alternativeIndex} under ${describeConditions(omission.conditions)}`
+          : `${omission.kind} ${omission.kind === "state" ? describeConditions(omission.conditions) : ""}`,
+      ),
+    ).toEqual(["state a=0 b=1 c=0", "c|1 under a=0 b=1", "a|1 under "]);
+  });
+
+  it("makes each distinct committed tree a state", () => {
+    const space = enumerateStateSpace([
+      [fiber("main", [fiber("progress")])],
+      [fiber("main", [fiber("progress")])],
+      [fiber("main", [fiber("output")])],
+    ]);
+    expect(space.states.map((state) => describeConditions(state.conditions))).toEqual([
+      "commit0",
+      "commit1",
+    ]);
+  });
+});
+
+describe("matchStateSpace", () => {
+  const space = enumerateStateSpace([
+    [
+      fiber("main", [
+        branch("a", [fiber("x")], [fiber("y")]),
+        branch("b", [fiber("p")], [fiber("q")]),
+      ]),
+    ],
+  ]);
+
+  it("reports the enumerated state the runtime equals", () => {
+    const match = matchStateSpace(space, [host("main", [host("y"), host("p")])]);
+    expect(match.status).toBe("exact");
+    expect(match.matched).toEqual({
+      index: 2,
+      conditions: space.states[2].conditions,
+    });
+    expect(match.closest).toBeNull();
+  });
+
+  it("reports a mismatch with the closest state when no state equals the runtime", () => {
+    const match = matchStateSpace(space, [host("main", [host("y"), host("z")])]);
+    expect(match.status).toBe("mismatch");
+    expect(match.matched).toBeNull();
+    expect(match.closest?.index).toBe(2);
+    expect(match.closest?.divergence.actual).toContain("z");
+  });
+
+  it("never reports exact when the space is truncated", () => {
+    const truncated = enumerateStateSpace([[fiber("ul", [repeat("r", [fiber("li")])])]]);
+    const within = matchStateSpace(truncated, [host("ul", [host("li")])]);
+    expect(within.status).toBe("truncated");
+    expect(within.matched?.index).toBe(1);
+
+    const beyond = matchStateSpace(truncated, [
+      host("ul", [host("li"), host("li"), host("li"), host("li")]),
+    ]);
+    expect(beyond.status).toBe("truncated");
+    expect(beyond.matched?.index).toBeNull();
+    expect(describeConditions(beyond.matched?.conditions ?? [])).toBe("r×4");
+  });
+
+  it("matches the runtime against the commit that produced it", () => {
+    const commits = enumerateStateSpace([
+      [fiber("main", [fiber("progress")])],
+      [fiber("main", [fiber("output")])],
+    ]);
+    const settled = matchStateSpace(commits, [host("main", [host("output")])]);
+    expect(settled.matched?.index).toBe(1);
+    const early = matchStateSpace(commits, [host("main", [host("progress")])]);
+    expect(early.matched?.index).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

The static render used to emit one tree with inline maybe-nodes (`$Branch` rendering `preferredIndex`, `$Repeat` absorbing any count) and the matcher tried alternatives against the single runtime capture. It now emits the **set of concrete reachable trees** with the conditions that select each, and the runtime capture is checked for **membership** in that set. Design notes in `packages/parser/docs/exhaustive-states.md`.

### Representation (`src/harness/state-space.ts`)

```ts
interface StaticState { tree: PatternNode[]; conditions: StateCondition[] }
type StateCondition = BranchCondition | RepeatCondition | TransitionCondition
  // branch | state-update: { variable, reason, location, alternativeIndex, alternativeCount }
  // repeat:               { variable, location, count }
  // transition:           { commit, commitCount }
interface StaticStateSpace {
  states: StaticState[];
  budget: StateSpaceBudget;            // { maxStates: 256, maxRepeat: 2 } by default
  omitted: OmittedStateSpace | null;   // non-null whenever `states` is incomplete
  commits: PatternNode[][];            // distinct committed patterns, in commit order
}
type StateOmission = OmittedBranchStates | OmittedRepeatStates | OmittedState | OmittedSubtree
```

`tree` is `PatternNode[]` rather than `RuntimeSnapshot` on purpose: a concrete state can still contain `opaque` (external component) subtrees and wildcards, which a `RuntimeSnapshot` cannot express. After enumeration no branch/repeat nodes remain.

Enumeration runs once after interpretation: the materializer renders every alternative under its `$Branch`/`$Alternative` marker in a single React render (the product tree), `enumerateStateSpace` projects that tree onto each assignment of the decision variables. This is "materialize once per assignment" done as selection over one materialization rather than one React render per state.

Effect/timer/state-update driven commits: `CommitRecorder` now records an immutable snapshot on every `onCommitFiberRoot` (`recordCommits: true` in `mount.ts`), `StaticRenderResult.commits` carries them, and each distinct committed tree is enumerated as its own state with a `transition` condition (`states-effect-update`: 2 states across 2 commits).

### Correlation

A branch's variable is its **predicate identity**, not its position (`src/evaluate/predicates.ts`):

- `truthy(<id>)` — id of the uncertain value being tested; branches on the same value in different components share the variable. `!truthy(<id>)` is read back as the same variable with alternatives swapped (`static-pattern.ts#normalizeNegatedBranch`).
- `state(<cell>)` for `useState`/`useReducer` cells → `state-update` conditions.
- `path(<n>)` per interpreter fork so all bindings joined at that fork decide together (SSA-phi style); `branch#N`/`repeat#N` for markers without a predicate.
- Variables inside a repeat are scoped per iteration (`v@repeat#3[1]`).

The matcher (`compare.ts`) became assignment-aware: a `Matcher` carries `assignment: Map<variable, choice>`, reuses a decided variable and otherwise tries alternatives; fiber children are now matched inside the sibling continuation so decisions made in a child survive to later siblings. `matchPatternToRuntime` returns `{ report, decisions, failure }`; `comparePatternToRuntime` stays as the low-level wrapper.

`states-correlated-predicate`: one `useFlag()` result used as a child prop, a direct conditional and a negated conditional → 2 states, not 8. Two separate opaque hook calls remain independent (the interpreter cannot prove them equal) → `states-nested-independent` yields 4.

### Budget semantics

- Repeats enumerate `min .. min + maxRepeat`, clipped to a known `NumberRange` (array literal lengths now propagate as `count`); larger counts → `OmittedRepeatStates { countsAbove, max }`.
- At `maxStates`, the state that would have been emitted next is recorded as `OmittedState { conditions }` and every alternative no longer expanded is an `OmittedBranchStates`/`OmittedRepeatStates` carrying the conditions already chosen when it was reached. Nothing is dropped without an `omitted` entry (unit-tested in `tests/state-space.test.ts`).
- Alternatives the materializer did not render (`MAX_ALTERNATIVE_DEPTH`, element budget) become truncated `$Unknown` markers → `OmittedSubtree`.

### Status semantics

| status | before | after |
|---|---|---|
| `exact` | all static fibers matched without consuming uncertainty | runtime equals one enumerated state **and** `omitted === null` |
| `truncated` | — | runtime matched (an enumerated state, or an assignment outside `states`, `matchedState.index === null`) but the space is incomplete |
| `partial` | branches/repeats/opaque/wildcards were needed | matched only through opaque subtrees or wildcards |
| `mismatch` | a divergence | no committed pattern matches under any assignment; `closestState` = the state agreeing with the furthest attempt on the most decisions, plus its divergence |

`compareStaticToRuntime(stateSpace, runtime)` now takes a `StaticRenderStateSpace` from `enumerateStaticStates(staticResult, { anchor, transparentStaticFibers, budget })` and returns `{ report, stateSpace, matchedState, closestState, ... }`. `format-report.ts` prints state count, matched state conditions, unobserved states, and omissions. `corpus/results.json` gains `stateSpace: { states, matchedState, closestState, omitted } | null` per record (historical records migrated to `null`, legacy `branchDeviations` removed), and the whole results wrapper is now validated by a zod schema (`readCorpusResults`), not just the manifest.

### Before / after: `tests/fixtures/states-two-way`

```tsx
const isCompact = useFlag("compact");
return <main>{isCompact ? <Compact /> : <Spacious />}</main>;
```

Before (base branch):

```
status: partial
coverage: 100.0% (4 fibers + 0 text of 4 runtime nodes; 4 static)
uncertainty: branches=1 repeats=0 opaque=0 (0 skipped, 0 renamed, slots 0 matched/0 unmatched) wildcard=0
```

After:

```
status: exact
coverage: 100.0% (4 fibers + 0 text of 4 runtime nodes; 4 static)
states: 2
matched state: #1 branch(conditional on flag-kit#useFlag()) @…/src/app.tsx:8:17 = |0 of 2
unobserved states (1):
  branch(conditional on flag-kit#useFlag()) @…/src/app.tsx:8:17 = |1 of 2
```

And with `stateSpaceBudget: { maxStates: 4 }` on four independent flags (`states-budget-exhausted`):

```
status: truncated
states: 4 (incomplete)
matched state: #2 …:10:8 = |0 of 2, …:11:8 = |0 of 2, …:12:8 = |0 of 2, …:13:8 = |1 of 2
omitted (3):
  branch(…) @…:13:8 alternative |1 not expanded under …:10:8 = |0 of 2, …:11:8 = |1 of 2, …:12:8 = |0 of 2 (state budget)
  branch(…) @…:12:8 alternative |1 not expanded under …:10:8 = |0 of 2, …:11:8 = |1 of 2 (state budget)
  branch(…) @…:10:8 alternative |1 not expanded (state budget)
```

### Tests

New fixtures: `states-two-way` (2), `states-nested-independent` (4), `states-correlated-predicate` (2 not 8), `states-repeat-cardinality` (×0/×1/×2 + omission, `truncated`), `states-effect-update` (2 commits), `states-host-unknown` (`window.innerWidth`), `states-budget-exhausted` (`omitted` non-null). `tests/state-space.test.ts` unit-tests enumeration/matching; `tests/state-membership.test.ts` checks a runtime outside the enumeration is `mismatch` with `closestState`. `fixtures.test.ts` now asserts membership (`matchedState` non-null, `omitted === null` for `exact`, optional `expectedStates`/`expectOmitted`).

### Where enumeration is necessarily bounded

- Unbounded repeats: `min .. min+maxRepeat` only; the rest is an omission.
- Independent branches multiply; `maxStates` cuts the product (recorded per alternative).
- Alternatives > `MAX_ALTERNATIVE_DEPTH` off the preferred path / past the element budget are not rendered.
- Opaque externals are holes, not state sets.
- Only commits within the settle window are observed.
- Two unknowns the interpreter cannot prove equal are independent even when the program would always agree on them.

### Validation

`tsc --noEmit` clean, `pnpm -s test` 13 files / 216 tests passing, root `pnpm run check` passing (the first commit only reformats `src/libraries/react-hook-form.ts`, which failed `vp check` on the base branch). No corpus repos are checked out in this environment so no replay was run; the migrated `corpus/results.json` (33 records) validates through `readCorpusResults`.


Link to Devin session: https://app.devin.ai/sessions/49d7b6ab0b264cafa6cd785337bb342e
Open in Devin Desktop: https://app.devin.ai/desktop/session/49d7b6ab0b264cafa6cd785337bb342e?variant=devin
Requested by: @aidenybai